### PR TITLE
Feature.templatesyncstatus

### DIFF
--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -35,7 +35,10 @@ def push_sync_device(task, dry_run: bool = True):
         dev: Device = session.query(Device).filter(Device.hostname == hostname).one()
         mgmt_ip = dev.management_ip
         devtype: DeviceType = dev.device_type
-        platform: str = dev.platform
+        if isinstance(dev.platform, str):
+            platform: str = dev.platform
+        else:
+            raise ValueError("Unknown platform: {}".format(dev.platform))
 
         if not mgmt_ip:
             raise Exception("Could not find free management IP for management domain {}".format(

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -1,5 +1,7 @@
 from typing import Optional
 from ipaddress import IPv4Interface
+import os
+import yaml
 
 from nornir.plugins.tasks import networking, text
 from nornir.plugins.functions.text import print_result
@@ -13,6 +15,7 @@ from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.settings import get_settings
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
+from cnaas_nms.db.git import RepoStructureException
 from cnaas_nms.confpush.nornir_helper import NornirJobResult
 from cnaas_nms.scheduler.wrapper import job_wrapper
 
@@ -31,6 +34,8 @@ def push_sync_device(task, dry_run: bool = True):
                     neighbor_hostnames))
         dev: Device = session.query(Device).filter(Device.hostname == hostname).one()
         mgmt_ip = dev.management_ip
+        devtype: DeviceType = dev.device_type
+        platform: str = dev.platform
 
         if not mgmt_ip:
             raise Exception("Could not find free management IP for management domain {}".format(
@@ -57,10 +62,21 @@ def push_sync_device(task, dry_run: bool = True):
 
     logger.debug("Synchronize device config for host: {}".format(task.host.name))
 
+    with open('/etc/cnaas-nms/repository.yml', 'r') as db_file:
+        repo_config = yaml.safe_load(db_file)
+        local_repo_path = repo_config['templates_local']
+
+    mapfile = os.path.join(local_repo_path, platform, 'mapping.yml')
+    if not os.path.isfile(mapfile):
+        raise RepoStructureException("File {} not found in template repo".format(mapfile))
+    with open(mapfile, 'r') as f:
+        mapping = yaml.safe_load(f)
+        template = mapping[devtype.name]['entrypoint']
+
     r = task.run(task=text.template_file,
                  name="Generate device config",
-                 template="managed-full.j2",
-                 path=f"../templates/{task.host.platform}",
+                 template=template,
+                 path=f"{local_repo_path}/{task.host.platform}",
                  **template_vars)
 
     # TODO: Handle template not found, variables not defined

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -151,3 +151,10 @@ class Device(cnaas_nms.db.base.Base):
                                       re.IGNORECASE)
         return all(hostname_part_re.match(x) for x in hostname.split('.'))
 
+    @classmethod
+    def set_devtype_syncstatus(cls, session, devtype: DeviceType, syncstatus=False):
+        """Update sync status of devices of type devtype"""
+        dev: Device
+        for dev in session.query(Device).filter(Device.device_type == devtype).all():
+            dev.synchronized = syncstatus
+

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -152,9 +152,10 @@ class Device(cnaas_nms.db.base.Base):
         return all(hostname_part_re.match(x) for x in hostname.split('.'))
 
     @classmethod
-    def set_devtype_syncstatus(cls, session, devtype: DeviceType, syncstatus=False):
+    def set_devtype_syncstatus(cls, session, devtype: DeviceType, platform: str, syncstatus=False):
         """Update sync status of devices of type devtype"""
         dev: Device
-        for dev in session.query(Device).filter(Device.device_type == devtype).all():
+        for dev in session.query(Device).filter(Device.device_type == devtype).\
+                filter(Device.platform == platform).all():
             dev.synchronized = syncstatus
 

--- a/src/cnaas_nms/db/exceptions.py
+++ b/src/cnaas_nms/db/exceptions.py
@@ -1,2 +1,6 @@
 class ConfigException(Exception):
     pass
+
+
+class RepoStructureException(Exception):
+    pass

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -1,6 +1,6 @@
 import enum
 import os
-from typing import List
+from typing import Set, Tuple
 
 from git import Repo
 from git import InvalidGitRepositoryError, NoSuchPathError
@@ -118,49 +118,70 @@ def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         try:
             get_settings()
         except SettingsSyntaxError as e:
+            logger.exception("Error in settings repo configuration: {}".format(str(e)))
             raise e
 
     if repo_type == RepoType.TEMPLATES:
-        print("DEBUG20: {}".format(changed_files))
+        logger.debug("Files changed in template repository: {}".format(changed_files))
         updated_devtypes = template_syncstatus(updated_templates=changed_files)
         with sqla_session() as session:
             devtype: DeviceType
-            for devtype in updated_devtypes:
-                Device.set_devtype_syncstatus(session, devtype, syncstatus=False)
+            for devtype, platform in updated_devtypes:
+                Device.set_devtype_syncstatus(session, devtype, platform, syncstatus=False)
 
     return ret
 
 
-def template_syncstatus(updated_templates: set) -> List[DeviceType]:
+def template_syncstatus(updated_templates: set) -> Set[Tuple[DeviceType, str]]:
     """Determine what device types have become unsynchronized because
     of updated template files."""
+    unsynced_devtype = set()
     with open('/etc/cnaas-nms/repository.yml', 'r') as db_file:
         repo_config = yaml.safe_load(db_file)
         local_repo_path = repo_config['templates_local']
 
-    depfile = os.path.join(local_repo_path, 'dependencies.yml')
-    if not os.path.isfile(depfile):
-        raise RepoStructureException("File dependencies.yml not found in template repo")
-    try:
-        with open(depfile, 'r') as f:
-            dependencies = yaml.safe_load(f)
-    except Exception as e:
-        logger.exception(
-            "Could not parse dependencies.yml in template repo: {}".format(str(e)))
-        raise RepoStructureException(
-            "Could not parse dependencies.yml in template repo: {}".format(str(e)))
+    # loop through OS/platform types
+    for platform in os.listdir(local_repo_path):
+        path = os.path.join(local_repo_path, platform)
+        if not os.path.isdir(path) or platform.startswith('.'):
+            continue
 
-    unsynced_devtype = []
-    devtype: DeviceType
-    for devtype in DeviceType:
-        if devtype.name in dependencies:
-            update_required = False
-            for dependency in dependencies[devtype.name]:
-                if dependency in updated_templates:
-                    update_required = True
-            if update_required:
-                logger.info("Template for device type {} has been updated".
-                            format(devtype.name))
-                unsynced_devtype.append(devtype)
+        mapfile = os.path.join(path, 'mapping.yml')
+        if not os.path.isfile(mapfile):
+            raise RepoStructureException(
+                "File mapping.yml not found in template repo {}".format(path))
+        try:
+            with open(mapfile, 'r') as f:
+                mapping = yaml.safe_load(f)
+        except Exception as e:
+            logger.exception(
+                "Could not parse {}/mapping.yml in template repo: {}".format(path, str(e)))
+            raise RepoStructureException(
+                "Could not parse {}/mapping.yml in template repo: {}".format(path, str(e)))
+
+        devtype: DeviceType
+        for devtype in DeviceType:
+            if devtype.name in mapping:
+                update_required = False
+                try:
+                    dependencies = list([mapping[devtype.name]['entrypoint']])
+                    if 'dependencies' in mapping[devtype.name] and \
+                            isinstance(mapping[devtype.name]['dependencies'], list):
+                        dependencies.extend(mapping[devtype.name]['dependencies'])
+                except KeyError as e:
+                    logger.exception(
+                        "Could not parse mapping.yml in template repo for {}, value not found: {}".
+                        format(devtype.name, str(e)))
+                    raise RepoStructureException(
+                        "Could not parse mapping.yml in template repo for {}, value not found: {}".
+                        format(devtype.name, str(e)))
+
+                for dependency in dependencies:
+                    if os.path.join(platform, dependency) in updated_templates:
+                        update_required = True
+                if update_required:
+                    logger.info("Template for device type {} has been updated".
+                                format(devtype.name))
+                    unsynced_devtype.add((devtype, platform))
 
     return unsynced_devtype

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -79,7 +79,7 @@ def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         raise ValueError("Invalid repository")
 
     ret = ''
-    changed_files = set()
+    changed_files: Set[str] = set()
     try:
         local_repo = Repo(local_repo_path)
         prev_commit = local_repo.commit().hexsha

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -1,13 +1,17 @@
 import enum
+import os
+from typing import List
 
 from git import Repo
 from git import InvalidGitRepositoryError, NoSuchPathError
 from git.exc import NoSuchPathError
 import yaml
 
-from cnaas_nms.db.exceptions import ConfigException
+from cnaas_nms.db.exceptions import ConfigException, RepoStructureException
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.settings import get_settings, SettingsSyntaxError
+from cnaas_nms.db.device import Device, DeviceType
+from cnaas_nms.db.session import sqla_session
 
 logger = get_logger()
 
@@ -75,8 +79,10 @@ def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         raise ValueError("Invalid repository")
 
     ret = ''
+    changed_files = set()
     try:
         local_repo = Repo(local_repo_path)
+        prev_commit = local_repo.commit().hexsha
         diff = local_repo.remotes.origin.pull()
         for item in diff:
             ret += 'Commit {} by {} at {}\n'.format(
@@ -84,6 +90,11 @@ def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES) -> str:
                 item.commit.committer,
                 item.commit.committed_datetime
             )
+            diff_files = local_repo.git.diff(
+                    '{}..{}'.format(prev_commit, item.commit.hexsha),
+                    name_only=True).split()
+            changed_files.update(diff_files)
+            prev_commit = item.commit.hexsha
     except (InvalidGitRepositoryError, NoSuchPathError) as e:
         logger.info("Local repository {} not found, cloning from remote".\
                     format(local_repo_path))
@@ -109,8 +120,47 @@ def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         except SettingsSyntaxError as e:
             raise e
 
-
-    # TODO: Also return what devices were affected so we can change the to unsync?
+    if repo_type == RepoType.TEMPLATES:
+        print("DEBUG20: {}".format(changed_files))
+        updated_devtypes = template_syncstatus(updated_templates=changed_files)
+        with sqla_session() as session:
+            devtype: DeviceType
+            for devtype in updated_devtypes:
+                Device.set_devtype_syncstatus(session, devtype, syncstatus=False)
 
     return ret
 
+
+def template_syncstatus(updated_templates: set) -> List[DeviceType]:
+    """Determine what device types have become unsynchronized because
+    of updated template files."""
+    with open('/etc/cnaas-nms/repository.yml', 'r') as db_file:
+        repo_config = yaml.safe_load(db_file)
+        local_repo_path = repo_config['templates_local']
+
+    depfile = os.path.join(local_repo_path, 'dependencies.yml')
+    if not os.path.isfile(depfile):
+        raise RepoStructureException("File dependencies.yml not found in template repo")
+    try:
+        with open(depfile, 'r') as f:
+            dependencies = yaml.safe_load(f)
+    except Exception as e:
+        logger.exception(
+            "Could not parse dependencies.yml in template repo: {}".format(str(e)))
+        raise RepoStructureException(
+            "Could not parse dependencies.yml in template repo: {}".format(str(e)))
+
+    unsynced_devtype = []
+    devtype: DeviceType
+    for devtype in DeviceType:
+        if devtype.name in dependencies:
+            update_required = False
+            for dependency in dependencies[devtype.name]:
+                if dependency in updated_templates:
+                    update_required = True
+            if update_required:
+                logger.info("Template for device type {} has been updated".
+                            format(devtype.name))
+                unsynced_devtype.append(devtype)
+
+    return unsynced_devtype

--- a/src/cnaas_nms/db/tests/test_git.py
+++ b/src/cnaas_nms/db/tests/test_git.py
@@ -6,10 +6,11 @@ from cnaas_nms.db.device import DeviceType
 
 class GitTests(unittest.TestCase):
     def test_check_unsync(self):
-        devtypes = template_syncstatus({'managed-full.j2'})
+        devtypes = template_syncstatus({'eos/managed-full.j2'})
         for devtype in devtypes:
-            self.assertEqual(type(devtype), DeviceType)
-        self.assertTrue(DeviceType.ACCESS in devtypes)
+            self.assertEqual(type(devtype[0]), DeviceType)
+            self.assertEqual(type(devtype[1]), str)
+        self.assertTrue((DeviceType.ACCESS, 'eos') in devtypes)
 
 
 if __name__ == '__main__':

--- a/src/cnaas_nms/db/tests/test_git.py
+++ b/src/cnaas_nms/db/tests/test_git.py
@@ -1,0 +1,16 @@
+import unittest
+
+from cnaas_nms.db.git import template_syncstatus
+from cnaas_nms.db.device import DeviceType
+
+
+class GitTests(unittest.TestCase):
+    def test_check_unsync(self):
+        devtypes = template_syncstatus({'managed-full.j2'})
+        for devtype in devtypes:
+            self.assertEqual(type(devtype), DeviceType)
+        self.assertTrue(DeviceType.ACCESS in devtypes)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make template repo use platform dir structure and make sync_template use real settings repo instead of template from cnaas-nms src. Mark devices as unsynchronized if any jinja template files they depend on has been updated when refreshing git repo.