### PR TITLE
Feature.syncto ifclass tagged

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -124,6 +124,10 @@ networks:
 
 volumes:
   cnaas-templates:
+    external: true
   cnaas-settings:
+    external: true
   cnaas-postgres-data:
+    external: true
   cnaas-mongo-data:
+    external: true

--- a/src/cnaas_nms/api/tests/data/testdata.yml
+++ b/src/cnaas_nms/api/tests/data/testdata.yml
@@ -1,4 +1,6 @@
 ---
 interface_device: 'eosaccess'
 interface_update: 'Ethernet1'
+untagged_vlan: 'STUDENT'
+tagged_vlan_list: ['STUDENT', 'STUDENT2']
 jwt_auth_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw"

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -129,7 +129,7 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json['status'], 'success')
 
-    def test_update_interface(self):
+    def test_update_interface_configtype(self):
         ifname = self.testdata['interface_update']
         data = {
             "interfaces": {
@@ -154,7 +154,63 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json['status'], 'success')
         self.assertEqual(ifname in result.json['data']['updated'], True)
-        
+
+    def test_update_interface_data_untagged(self):
+        # Test untagged_vlan
+        ifname = self.testdata['interface_update']
+        data = {
+            "interfaces": {
+                ifname: {
+                    "data": {
+                        "untagged_vlan": self.testdata['untagged_vlan']
+                    }
+                }
+            }
+        }
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json['status'], 'success')
+        self.assertEqual(ifname in result.json['data']['updated'], True)
+        # Test invalid
+        data['interfaces'][ifname]['data']['untagged_vlan'] = "thisshouldnetexist"
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 400)
+        self.assertEqual(result.json['status'], 'error')
+
+    def test_update_interface_data_tagged(self):
+        # Test tagged
+        ifname = self.testdata['interface_update']
+        data = {
+            "interfaces": {
+                ifname: {
+                    "data": {
+                        "tagged_vlan_list": self.testdata['tagged_vlan_list']
+                    }
+                }
+            }
+        }
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json['status'], 'success')
+        self.assertEqual(ifname in result.json['data']['updated'], True)
+        # Test invalid
+        data['interfaces'][ifname]['data']['tagged_vlan_list'] = ["thisshouldnetexist"]
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 400)
+        self.assertEqual(result.json['status'], 'error')
+
     def test_add_new_device(self):
         data = {
             "hostname": "unittestdevice",

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -124,9 +124,9 @@ def get_setting_filename(repo_root: str, path: List[str]) -> str:
         if not len(path) >= 3:
             raise ValueError("Invalid directory structure for devices settings")
         if not keys_exists(DIR_STRUCTURE_HOST, path[2:]):
-            raise ValueError("File not defined in DIR_STRUCTURE")
+            raise ValueError("File {} not defined in DIR_STRUCTURE".format(path[2:]))
     elif not keys_exists(DIR_STRUCTURE, path):
-        raise ValueError("File not defined in DIR_STRUCTURE")
+        raise ValueError("File {} not defined in DIR_STRUCTURE".format(path))
     return os.path.join(repo_root, *path)
 
 
@@ -412,6 +412,8 @@ def get_settings(hostname: Optional[str] = None, device_type: Optional[DeviceTyp
             settings, settings_origin)
     # 4. Get settings repo device type settings
     if device_type:
+        if device_type == DeviceType.UNKNOWN:
+            raise ValueError("It's not possible to get settings for devices with type UNKNOWN")
         settings, settings_origin = read_settings(
             local_repo_path, [device_type.name.lower(), 'base_system.yml'], 'devicetype',
             settings, settings_origin)


### PR DESCRIPTION
1. Improve support for interface types access_untagged and access_untagged
2. Standardize interface naming for access and dist types in the jinja2 templates (this requires updating of templates-repository for access-switches to work after update)
3. Mark docker-compose volumes as "external", this is what actually makes them persistent but you need to create the volumes manually before doing docker-compose up like so:
docker volume create --name=cnaas-templates
docker volume create --name=cnaas-settings
docker volume create --name=cnaas-postgres-data
docker volume create --name=cnaas-mongo-data