### PR TITLE
Feature.ext routing variables

### DIFF
--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -108,8 +108,8 @@ class f_extroute_static(BaseModel):
 
 class f_extroute_ospfv3_vrf(BaseModel):
     name: str
-    ipv4_redist_routemap: Optional[str] = None
-    ipv6_redist_routemap: Optional[str] = None
+    ipv4_redist_routefilter: Optional[str] = None
+    ipv6_redist_routefilter: Optional[str] = None
 
 
 class f_extroute_ospfv3(BaseModel):

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -106,6 +106,16 @@ class f_extroute_static(BaseModel):
     vrfs: List[f_extroute_static_vrf]
 
 
+class f_extroute_ospfv3_vrf(BaseModel):
+    name: str
+    ipv4_redist_routemap: Optional[str] = None
+    ipv6_redist_routemap: Optional[str] = None
+
+
+class f_extroute_ospfv3(BaseModel):
+    vrfs: List[f_extroute_ospfv3_vrf]
+
+
 class f_vxlan(BaseModel):
     description: str = None
     vni: int = vxlan_vni_schema
@@ -133,6 +143,7 @@ class f_root(BaseModel):
     underlay: f_underlay = None
     evpn_spines: List[f_evpn_spine] = []
     extroute_static: Optional[f_extroute_static]
+    extroute_ospfv3: Optional[f_extroute_ospfv3]
 
 
 class f_group_item(BaseModel):


### PR DESCRIPTION
Adds support for doing routing from "customer" VRFs in the fabric to outside/external devices via static routes or OSPF.

New settings variables in root:

- extroute_static
- extroute_ospfv3

New files required required if specifying per-device settings:

- routing.yml

This has been tested with a settings config like this: devices/eosdist/routing.yml
```
extroute_static:
  vrfs:
    - name: MGMT
      ipv4:
        - destination: 0.0.0.0/0
          nexthop: 10.0.0.1
          interface: Null
          name: "my_route"
      ipv6:
        - destination: ::/0
          nexthop: fe80::2
          interface: Ethernet3
extroute_ospfv3:
  vrfs:
    - name: STUDENT
      ipv4_redist_routemap: MYMAP

```

And accompanying templates for arista eos:
```
{% if (extroute_static is defined) and extroute_static %}
 {% for vrf in extroute_static.vrfs %}
  {% for ipv4_route in vrf.ipv4 %}
   {% if (ipv4_route.interface is defined) and ipv4_route.interface %}
ip route vrf {{ vrf.name }} {{ ipv4_route.destination }} {{ipv4_route.interface }} {{ ipv4_route.nexthop }} name {{ ipv4_route.name }} {{ ipv4_route.cli_append_str }}
   {% else %}
ip route vrf {{ vrf.name }} {{ ipv4_route.destination }} {{ ipv4_route.nexthop }} name {{ ipv4_route.name }} {{ ipv4_route.cli_append_str }}
   {% endif %}
  {% endfor %}
  {% for ipv6_route in vrf.ipv6 %}
   {% if (ipv6_route.interface is defined) and ipv6_route.interface %}
ipv6 route vrf {{ vrf.name }} {{ ipv6_route.destination }} {{ ipv6_route.interface }} {{ ipv6_route.nexthop }} name {{ ipv6_route.name }} {{ ipv6_route.cli_append_str }}
   {% else %}
ipv6 route vrf {{ vrf.name }} {{ ipv6_route.destination }} {{ ipv6_route.nexthop }} name {{ ipv6_route.name }} {{ ipv6_route.cli_append_str }}
   {% endif %}
  {% endfor %}
 {% endfor %}
{% endif %}
{% if (extroute_ospfv3 is defined) and extroute_ospfv3 %}
 {% for vrf in extroute_ospfv3.vrfs %}
router ospfv3 vrf {{ vrf.name }}
 router-id {{ infra_ip }}
 passive-interface default
 address-family ipv4
  {% if (vrf.ipv4_redist_routemap is defined) and vrf.ipv4_redist_routemap %}
  redistribute bgp route-map {{ vrf.ipv4_redist_routemap }}
  {% endif %}
 address-family ipv6
  {% if (vrf.ipv6_redist_routemap is defined) and vrf.ipv6_redist_routemap %}
  redistribute bgp route-map {{ vrf.ipv6_redist_routemap }}
  {% endif %}
 {% endfor %}
{% endif %}

``` 

Results in config like this:
```
ip routing
ip routing vrf MGMT
ip routing vrf STUDENT
ipv6 unicast-routing vrf STUDENT
ip route vrf MGMT 0.0.0.0/0 10.0.0.1 name my_route 
ipv6 route vrf MGMT ::/0 Ethernet3 fe80::2 name undefined 
router ospfv3 vrf STUDENT
  router-id 10.199.0.0
  passive-interface default
  address-family ipv4
    redistribute bgp route-map MYMAP
  address-family ipv6

```