### PR TITLE
Add jobid# on each log line performed in syncto and device_init jobs

### DIFF
--- a/docker/api/cnaas-setup.sh
+++ b/docker/api/cnaas-setup.sh
@@ -45,9 +45,11 @@ python3 -m pip install -r requirements.txt
 #cd /opt/cnaas/venv/cnaas-nms/
 #git remote update
 #git fetch
-#git checkout --track origin/feature.websocket
+#git checkout --track origin/feature.log_jobid
 #python3 -m pip install -r requirements.txt
 
+chown -R www-data:www-data /opt/cnaas/settings
+chown -R www-data:www-data /opt/cnaas/templates
 #rm -rf /var/lib/apt/lists/*
 
 

--- a/docker/api/exec-pre-app.sh
+++ b/docker/api/exec-pre-app.sh
@@ -22,8 +22,6 @@ sed -e "s|^\(templates_remote: \).\+$|\1 $GITREPO_TEMPLATES|" \
 #fi
 #git clone $GITREPO_SETTINGS /opt/cnaas/settings
 #git clone $GITREPO_TEMPLATES /opt/cnaas/templates
-chown -R www-data:www-data /opt/cnaas/settings
-chown -R www-data:www-data /opt/cnaas/templates
 
 # Wait for postgres to start
 echo ">> Waiting for postgres to start"

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -104,18 +104,18 @@ class ApiTests(unittest.TestCase):
     def test_sync_devices_invalid_input(self):
         # Test invalid hostname
         data = {"hostname": "...", "dry_run": True}
-        result = self.client.post('/api/v1.0/device_sync', json=data)
+        result = self.client.post('/api/v1.0/device_syncto', json=data)
         self.assertEqual(result.status_code, 400)
 
         # Test invalid device_type
         data = {"device_type": "nonexistent", "dry_run": True}
-        result = self.client.post('/api/v1.0/device_sync', json=data)
+        result = self.client.post('/api/v1.0/device_syncto', json=data)
         self.assertEqual(result.status_code, 400)
 
     def test_sync_devices(self):
         # Test dry run sync of all devices
         data = {"all": True, "dry_run": True}
-        result = self.client.post('/api/v1.0/device_sync', json=data)
+        result = self.client.post('/api/v1.0/device_syncto', json=data)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json['status'], 'success')
         self.assertEqual(type(result.json['job_id']), str)

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -18,8 +18,6 @@ from cnaas_nms.db.linknet import Linknet
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.interface import Interface
 
-logger = get_logger()
-
 
 def get_inventory():
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
@@ -96,6 +94,7 @@ def get_neighbors(hostname: Optional[str] = None, group: Optional[str] = None)\
 
 
 def get_uplinks(session, hostname: str) -> Tuple[List, List]:
+    logger = get_logger()
     # TODO: check if uplinks are already saved in database?
     uplinks = []
     neighbor_hostnames = []
@@ -210,6 +209,7 @@ def update_inventory(hostname: str, site='default') -> dict:
 def update_linknets(hostname):
     """Update linknet data for specified device using LLDP neighbor data.
     """
+    logger = get_logger()
     result = get_neighbors(hostname=hostname)[hostname][0]
     if result.failed:
         raise Exception

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -330,7 +330,7 @@ def generate_only(hostname: str) -> (str, dict):
             return str(e), template_vars
 
 
-def sync_check_hash(task, force=False, dry_run=True):
+def sync_check_hash(task, force=False, job_id=None):
     """
     Start the task which will compare device configuration hashes.
 
@@ -338,6 +338,8 @@ def sync_check_hash(task, force=False, dry_run=True):
         task: Nornir task
         force: Ignore device hash
     """
+    set_thread_data(job_id)
+    logger = get_logger()
     if force is True:
         return
     with sqla_session() as session:
@@ -376,7 +378,7 @@ def update_config_hash(task):
 @job_wrapper
 def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = None,
                  group: Optional[str] = None, dry_run: bool = True, force: bool = False,
-                 auto_push: bool = False, job_id: Optional[str] = None,
+                 auto_push: bool = False, job_id: Optional[int] = None,
                  scheduled_by: Optional[str] = None) -> NornirJobResult:
     """Synchronize devices to their respective templates. If no arguments
     are specified then synchronize all devices that are currently out
@@ -415,7 +417,7 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
     try:
         nrresult = nr_filtered.run(task=sync_check_hash,
                                    force=force,
-                                   dry_run=dry_run)
+                                   job_id=job_id)
         print_result(nrresult)
     except Exception as e:
         logger.exception("Exception while checking config hash: {}".format(str(e)))

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -369,8 +369,8 @@ def update_config_hash(task):
 
 @job_wrapper
 def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = None,
-                 dry_run: bool = True, force: bool = False, auto_push = False,
-                 job_id: Optional[str] = None,
+                 group: Optional[str] = None, dry_run: bool = True, force: bool = False,
+                 auto_push: bool = False, job_id: Optional[str] = None,
                  scheduled_by: Optional[str] = None) -> NornirJobResult:
     """Synchronize devices to their respective templates. If no arguments
     are specified then synchronize all devices that are currently out
@@ -379,6 +379,7 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
     Args:
         hostname: Specify a single host by hostname to synchronize
         device_type: Specify a device type to synchronize
+        group: Specify a group of devices to synchronize
         dry_run: Don't commit generated config to device
         force: Commit config even if changes made outside CNaaS will get
                overwritten

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -23,12 +23,12 @@ from cnaas_nms.db.joblock import Joblock, JoblockError
 from cnaas_nms.db.git import RepoStructureException
 from cnaas_nms.confpush.nornir_helper import NornirJobResult
 from cnaas_nms.scheduler.wrapper import job_wrapper
+from cnaas_nms.scheduler.thread_data import set_thread_data
 
 from cnaas_nms.scheduler.scheduler import Scheduler
 from nornir.plugins.tasks.networking import napalm_get
 
 
-logger = get_logger()
 AUTOPUSH_MAX_SCORE = 10
 PRIVATE_ASN_START = 4200000000
 
@@ -40,6 +40,7 @@ def generate_asn(ipv4_address: IPv4Address) -> Optional[int]:
 
 
 def get_evpn_spines(session, settings: dict):
+    logger = get_logger()
     device_hostnames = []
     for entry in settings['evpn_spines']:
         if 'hostname' in entry and Device.valid_hostname(entry['hostname']):
@@ -55,6 +56,7 @@ def get_evpn_spines(session, settings: dict):
 
 
 def resolve_vlanid(vlan_name: str, vxlans: dict) -> Optional[int]:
+    logger = get_logger()
     if type(vlan_name) == int:
         return int(vlan_name)
     if not isinstance(vlan_name, str):
@@ -94,6 +96,8 @@ def push_sync_device(task, dry_run: bool = True, generate_only: bool = False,
     Returns:
 
     """
+    set_thread_data(job_id)
+    logger = get_logger()
     hostname = task.host.name
     with sqla_session() as session:
         dev: Device = session.query(Device).filter(Device.hostname == hostname).one()
@@ -299,6 +303,7 @@ def generate_only(hostname: str) -> (str, dict):
     Returns:
         (string with config, dict with available template variables)
     """
+    logger = get_logger()
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
     nr_filtered = nr.filter(name=hostname).filter(managed=True)
     template_vars = {}
@@ -350,6 +355,7 @@ def sync_check_hash(task, force=False, dry_run=True):
 
 
 def update_config_hash(task):
+    logger = get_logger()
     try:
         res = task.run(task=napalm_get, getters=["config"])
         if not isinstance(res, MultiResult) or len(res) != 1 or not isinstance(res[0].result, dict) \
@@ -390,6 +396,7 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
     Returns:
         NornirJobResult
     """
+    logger = get_logger()
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
     if hostname:
         nr_filtered = nr.filter(name=hostname).filter(managed=True)

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -7,8 +7,6 @@ from cnaas_nms.confpush.get import get_interfaces_names, get_uplinks, \
     filter_interfaces, get_interfacedb_ifs
 from cnaas_nms.tools.log import get_logger
 
-logger = get_logger()
-
 
 def update_interfacedb(hostname: str, replace: bool = False, delete: bool = False) \
         -> Optional[List[dict]]:
@@ -19,6 +17,7 @@ def update_interfacedb(hostname: str, replace: bool = False, delete: bool = Fals
     Returns:
         List of interfaces that was added to DB
     """
+    logger = get_logger()
     ret = []
     with sqla_session() as session:
         dev: Device = session.query(Device).filter(Device.hostname == hostname).one_or_none()

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -13,8 +13,6 @@ from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.tools.log import get_logger
 
-logger = get_logger()
-
 
 class VerifyPathException(Exception):
     pass
@@ -149,6 +147,7 @@ def check_settings_syntax(settings_dict: dict, settings_metadata_dict: dict):
     Raises:
         SettingsSyntaxError
     """
+    logger = get_logger()
     try:
         f_root(**settings_dict)
     except ValidationError as e:
@@ -210,6 +209,7 @@ def check_settings_collisions(unique_vlans: bool = True):
 
 def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int],
                           unique_vlans: bool = True):
+    logger = get_logger()
     # save global VLAN IDs and their unique vxlan name
     global_vlans: dict[int, str] = dict.fromkeys(mgmt_vlans, 'management')
     global_vnis: dict[int, str] = {}
@@ -290,6 +290,7 @@ def read_settings(local_repo_path: str, path: List[str], origin: str,
     Returns:
         merged_settings, merged_settings_origin
     """
+    logger = get_logger()
     filename = get_setting_filename(local_repo_path, path)
     with open(filename, 'r') as f:
         yamldata = yaml.safe_load(f)
@@ -393,6 +394,7 @@ def get_settings(hostname: Optional[str] = None, device_type: Optional[DeviceTyp
         Tuple[dict, dict]:
     """Get settings to use for device matching hostname or global
     settings if no hostname is specified."""
+    logger = get_logger()
     with open('/etc/cnaas-nms/repository.yml', 'r') as repo_file:
         repo_config = yaml.safe_load(repo_file)
 
@@ -463,6 +465,7 @@ def get_settings(hostname: Optional[str] = None, device_type: Optional[DeviceTyp
 
 
 def get_group_settings():
+    logger = get_logger()
     settings: dict = {}
     settings_origin: dict = {}
 

--- a/src/cnaas_nms/scheduler/tests/test_scheduler.py
+++ b/src/cnaas_nms/scheduler/tests/test_scheduler.py
@@ -1,17 +1,13 @@
-
-from cnaas_nms.scheduler.scheduler import Scheduler
-from cnaas_nms.scheduler.wrapper import job_wrapper
-from cnaas_nms.scheduler.jobresult import DictJobResult
-from cnaas_nms.tools.printlastjobs import print_jobs
-
-from apscheduler.job import Job
-
-import pprint
 import unittest
 import pkg_resources
 import yaml
 import os
 import time
+
+from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.scheduler.wrapper import job_wrapper
+from cnaas_nms.scheduler.jobresult import DictJobResult
+
 
 @job_wrapper
 def testfunc_success(text=''):
@@ -20,10 +16,12 @@ def testfunc_success(text=''):
         result = {'status': 'success'}
     )
 
+
 @job_wrapper
 def testfunc_exception(text=''):
     print(text)
     raise Exception("testfunc_exception raised exception")
+
 
 class InitTests(unittest.TestCase):
     def setUp(self):
@@ -38,7 +36,6 @@ class InitTests(unittest.TestCase):
         scheduler = Scheduler()
         time.sleep(3)
         scheduler.get_scheduler().print_jobs()
-        print_jobs(2)
         scheduler.shutdown()
 
     def test_add_schedule(self):

--- a/src/cnaas_nms/scheduler/thread_data.py
+++ b/src/cnaas_nms/scheduler/thread_data.py
@@ -1,0 +1,8 @@
+import threading
+
+thread_data = threading.local()
+
+
+def set_thread_data(job_id):
+    if job_id and type(job_id) == int:
+        thread_data.job_id = job_id

--- a/src/cnaas_nms/scheduler/wrapper.py
+++ b/src/cnaas_nms/scheduler/wrapper.py
@@ -8,6 +8,7 @@ from cnaas_nms.scheduler.jobresult import JobResult
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.session import redis_session
 from cnaas_nms.db.session import sqla_session
+from cnaas_nms.scheduler.thread_data import thread_data, set_thread_data
 
 
 logger = get_logger()
@@ -72,10 +73,12 @@ def job_wrapper(func):
                                                  args=(stop_event, job_id))
                 device_thread.start()
         try:
+            set_thread_data(job_id)
             # kwargs is contained in an item called kwargs because of the apscheduler.add_job call
             res = func(*args, **kwargs['kwargs'])
             if job_id:
                 res = insert_job_id(res, job_id)
+            del thread_data.job_id
         except Exception as e:
             tb = traceback.format_exc()
             logger.debug("Exception traceback in job_wrapper: {}".format(tb))


### PR DESCRIPTION
Using python threadlocalstorage to save jobid and then call get_logger() every time a function runs instead of only when the module is first loaded

Code coverage https://codecov.io/gh/SUNET/cnaas-nms/tree/5731d126d85f1318318ed07eaa5ab92e4364783d/src/cnaas_nms