### PR TITLE
Bugfix.lru cache multiprocess

### DIFF
--- a/docker/api/cnaas-setup.sh
+++ b/docker/api/cnaas-setup.sh
@@ -42,10 +42,10 @@ git checkout develop
 python3 -m pip install -r requirements.txt
 
 # Temporary for testing new branch
-#cd /opt/cnaas/venv/cnaas-nms/
-#git remote update
-#git fetch
-#git checkout --track origin/feature.log_jobid
+cd /opt/cnaas/venv/cnaas-nms/
+git remote update
+git fetch
+git checkout --track origin/bugfix.lru_cache_multiprocess
 #python3 -m pip install -r requirements.txt
 
 chown -R www-data:www-data /opt/cnaas/settings

--- a/docker/api/cnaas-setup.sh
+++ b/docker/api/cnaas-setup.sh
@@ -42,10 +42,10 @@ git checkout develop
 python3 -m pip install -r requirements.txt
 
 # Temporary for testing new branch
-cd /opt/cnaas/venv/cnaas-nms/
-git remote update
-git fetch
-git checkout --track origin/bugfix.lru_cache_multiprocess
+#cd /opt/cnaas/venv/cnaas-nms/
+#git remote update
+#git fetch
+#git checkout --track origin/bugfix.lru_cache_multiprocess
 #python3 -m pip install -r requirements.txt
 
 chown -R www-data:www-data /opt/cnaas/settings

--- a/requirements-toplevel-cmd.txt
+++ b/requirements-toplevel-cmd.txt
@@ -1,2 +1,2 @@
-python3 -m pip freeze | egrep "^(SQLAlchemy|nornir|Flask-JWT-Extended|flask-restplus|APScheduler|psycopg2|mypy|sqlalchemy-stubs|nose|GitPython|alembic|Sphinx|coverage|pluggy|redis|Flask-SocketIO|gevent|Flask-Cors)" > requirements.txt
+python3 -m pip freeze | egrep "^(SQLAlchemy|nornir|Flask-JWT-Extended|flask-restplus|APScheduler|psycopg2|mypy|sqlalchemy-stubs|nose|GitPython|alembic|Sphinx|coverage|pluggy|redis|Flask-SocketIO|gevent|Flask-Cors|redis-lru)" > requirements.txt
 # sqlalchemy-stubs is required for mypy to handle typing definitions from sqlalchemy?

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ alembic==1.0.10
 APScheduler==3.5.3
 coverage==4.5.3
 Flask-Cors==3.0.8
-Flask-RESTPlus==0.13.0
-Flask-SocketIO==4.2.1
 Flask-JWT-Extended==3.24.0
+flask-restplus==0.13.0
+Flask-SocketIO==4.2.1
 gevent==1.4.0
 GitPython==2.1.11
 mypy==0.670
@@ -15,6 +15,7 @@ pluggy==0.12.0
 psycopg2==2.7.7
 psycopg2-binary==2.7.7
 redis==3.3.8
+redis-lru==0.1.0
 Sphinx==2.0.1
 SQLAlchemy==1.3.0b2
 sqlalchemy-stubs==0.1

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -17,7 +17,10 @@ from cnaas_nms.tools.log import get_logger
 
 
 db_data = get_dbdata()
-redis_client = redis.StrictRedis(host=db_data['redis_hostname'], port=6379)
+redis_client = redis.StrictRedis(
+    host=db_data['redis_hostname'], port=6379,
+    retry_on_timeout=True, socket_keepalive=True
+)
 redis_lru_cache = RedisLRU(redis_client)
 
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -11,12 +11,13 @@ from redis_lru import RedisLRU
 from cnaas_nms.db.settings_fields import f_root, f_groups
 from cnaas_nms.tools.mergedict import MetadataDict, merge_dict_origin
 from cnaas_nms.db.device import Device, DeviceType, DeviceState
-from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.session import sqla_session, get_dbdata
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.tools.log import get_logger
 
 
-redis_client = redis.StrictRedis()
+db_data = get_dbdata()
+redis_client = redis.StrictRedis(host=db_data['redis_hostname'], port=6379)
 redis_lru_cache = RedisLRU(redis_client)
 
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -2,10 +2,11 @@ import os
 import re
 import pkg_resources
 from typing import List, Optional, Union, Tuple, Set, Dict
-from functools import lru_cache
 
 import yaml
 from pydantic.error_wrappers import ValidationError
+import redis
+from redis_lru import RedisLRU
 
 from cnaas_nms.db.settings_fields import f_root, f_groups
 from cnaas_nms.tools.mergedict import MetadataDict, merge_dict_origin
@@ -13,6 +14,10 @@ from cnaas_nms.db.device import Device, DeviceType, DeviceState
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.tools.log import get_logger
+
+
+redis_client = redis.StrictRedis()
+redis_lru_cache = RedisLRU(redis_client)
 
 
 class VerifyPathException(Exception):
@@ -305,7 +310,7 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int],
                 device_vlan_names[hostname] = {vxlan_data['vlan_name']}
 
 
-@lru_cache(1024)
+@redis_lru_cache
 def read_settings_file(filename):
     with open(filename, 'r') as f:
         return yaml.safe_load(f)
@@ -432,7 +437,7 @@ def get_downstream_dependencies(hostname: str, settings: dict) -> dict:
     return settings
 
 
-@lru_cache(1024)
+@redis_lru_cache
 def get_settings(hostname: Optional[str] = None, device_type: Optional[DeviceType] = None) -> \
         Tuple[dict, dict]:
     """Get settings to use for device matching hostname or global
@@ -518,7 +523,7 @@ def get_settings(hostname: Optional[str] = None, device_type: Optional[DeviceTyp
     return verified_settings, settings_origin
 
 
-@lru_cache(2)
+@redis_lru_cache
 def get_group_settings():
     logger = get_logger()
     settings: dict = {}
@@ -541,7 +546,7 @@ def get_group_settings():
     return f_groups(**settings).dict(), settings_origin
 
 
-@lru_cache(1024)
+@redis_lru_cache
 def get_groups(hostname=''):
     groups = []
     settings, origin = get_group_settings()


### PR DESCRIPTION
Clearing the lru cache from the API did not clear cache for the mule worker process, so let's move cache backend to redis so it's the same for all threads and processes.
Seems to be working better on initial tests at MDH, one new concern is what might happen if the TCP connection to redis is idle for a long time, will it reset the connection and cause some issue? Let's run for 24h and see what happens