### PR TITLE
Release 1.0.0rc2

### DIFF
--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -29,6 +29,7 @@ from cnaas_nms.tools.get_apidata import get_apidata
 
 from jwt.exceptions import DecodeError, InvalidSignatureError, \
     InvalidTokenError
+from flask_jwt_extended.exceptions import InvalidHeaderError
 
 
 logger = get_logger()
@@ -58,9 +59,11 @@ class CnaasApi(Api):
             data = {'status': 'error', 'data': 'JWT token missing?'}
         elif isinstance(e, NoAuthorizationError):
             data = {'status': 'error', 'data': 'JWT token missing?'}
+        elif isinstance(e, InvalidHeaderError):
+            data = {'status': 'error', 'data': 'Invalid header, JWT token missing? {}'.format(e)}
         else:
             return super(CnaasApi, self).handle_error(e)
-        return jsonify(data)
+        return jsonify(data), 401
 
 
 try:

--- a/src/cnaas_nms/version.py
+++ b/src/cnaas_nms/version.py
@@ -1,3 +1,3 @@
-__version__ = '1.0.0rc1'
+__version__ = '1.0.0rc2'
 __version_info__ = tuple([field for field in __version__.split('.')])
 __api_version__ = 'v1.0'


### PR DESCRIPTION
Handle yet another type of JWT header fail. Return HTTP response code 401 instead of 200 if auth fails.
