### PR TITLE
Make ipv4_gw optional for vxlans.yml settings [template update]

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -181,10 +181,10 @@ Contains a dictinary called "vxlans", which in turn has one dictinoary per vxlan
 name is the dictionary key and dictionaly values are:
 
   * vni: VXLAN ID, 1-16777215
-  * vrf: VRF name
+  * vrf: VRF name. Optional unless ipv4_gw is also specified.
   * vlan_id: VLAN ID, 1-4095
   * vlan_name: VLAN name, single word/no spaces, max 31 characters
-  * ipv4_gw: IPv4 address with CIDR netmask, ex: 192.168.0.1/24
+  * ipv4_gw: IPv4 address with CIDR netmask, ex: 192.168.0.1/24. Optional.
   * groups: List of group names where this VXLAN/VLAN should be provisioned. If you select an
     access switch the parent dist switch should be automatically provisioned.
 


### PR DESCRIPTION
Templates needs updating to make sure ipv4_gw and vrf is actually defined before printing them