### PR TITLE
Get/restore previous config

### DIFF
--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -183,6 +183,34 @@ This will return both the generated configuration based on the template for
 this device type, and also a list of available vaiables that could be used
 in the template.
 
+View previous config
+--------------------
+
+You can also view previous versions of the configuration for a device. All
+previous configurations are saved in the job database and can be found using
+either a specific Job ID (using job_id=), a number of steps to walk backward
+to find a previous configuration (previous=), or using a date to find the last
+configuration applied to the device before that date.
+
+::
+
+   curl "https://hostname/api/v1.0/device/<device_hostname>/previous_config?before=2020-04-07T12:03:05"
+
+   curl "https://hostname/api/v1.0/device/<device_hostname>/previous_config?previous=1"
+
+   curl "https://hostname/api/v1.0/device/<device_hostname>/previous_config?job_id=12"
+
+If you want to restore a device to a previous configuration you can send a POST:
+
+::
+
+   curl "https://hostname/api/v1.0/device/<device_hostname>/previous_config" -X POST -d '{"job_id": 12, "dry_run": true}' -H "Content-Type: application/json"
+
+When sending a POST you must specify an exact job_id to restore. The job must
+have finished with a successful status for the specified device. The device
+will change to UNMANAGED state since it's no longer in sync with current
+templates and settings.
+
 Initialize device
 -----------------
 

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -1,8 +1,8 @@
-import pprint
 import shutil
 import yaml
 import pkg_resources
 import os
+import time
 
 import unittest
 import cnaas_nms.api.app
@@ -20,11 +20,6 @@ class ApiTests(unittest.TestCase):
         self.app = cnaas_nms.api.app.app
         self.app.wsgi_app = TestAppWrapper(self.app.wsgi_app, self.jwt_auth_token)
         self.client = self.app.test_client()
-#        self.tmp_postgres = PostgresTemporaryInstance()
-
-    def tearDown(self):
-#        self.tmp_postgres.shutdown()
-        pass
 
     def test_get_single_device(self):
         hostname = "eosdist1"

--- a/src/cnaas_nms/confpush/nornir_plugins/cnaas_inventory.py
+++ b/src/cnaas_nms/confpush/nornir_plugins/cnaas_inventory.py
@@ -82,6 +82,8 @@ class CnaasInventory(Inventory):
         username, password = self._get_credentials('MANAGED')
         groups['S_MANAGED']['username'] = username
         groups['S_MANAGED']['password'] = password
+        groups['S_UNMANAGED']['username'] = username
+        groups['S_UNMANAGED']['password'] = password
 
         defaults = {'data': {'k': 'v'}}
         super().__init__(hosts=hosts, groups=groups, defaults=defaults,

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -623,7 +623,7 @@ def apply_config(hostname: str, config: str, dry_run: bool,
     Args:
         hostname: Specify a single host by hostname to synchronize
         config: Static configuration to apply
-        dry_run: Don't commit config to device
+        dry_run: Set to false to actually apply config to device
         job_id: Job ID number
         scheduled_by: Username from JWT
 

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -638,8 +638,9 @@ def apply_config(hostname: str, config: str, dry_run: bool,
             raise Exception("Device {} not found".format(hostname))
         elif not (dev.state == DeviceState.MANAGED or dev.state == DeviceState.UNMANAGED):
             raise Exception("Device {} is in invalid state: {}".format(hostname, dev.state))
-        dev.state = DeviceState.UNMANAGED
-        dev.synchronized = False
+        if not dry_run:
+            dev.state = DeviceState.UNMANAGED
+            dev.synchronized = False
 
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
     nr_filtered = nr.filter(name=hostname).filter(managed=False)

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -643,7 +643,7 @@ def apply_config(hostname: str, config: str, dry_run: bool,
             dev.synchronized = False
 
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
-    nr_filtered = nr.filter(name=hostname).filter(managed=False)
+    nr_filtered = nr.filter(name=hostname)
 
     try:
         nrresult = nr_filtered.run(task=push_static_config,

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -635,10 +635,11 @@ def apply_config(hostname: str, config: str, dry_run: bool,
     with sqla_session() as session:
         dev: Device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
         if not dev:
-            raise Exception("Device {} not found, apply_config aborting".format(hostname))
+            raise Exception("Device {} not found".format(hostname))
         elif not (dev.state == DeviceState.MANAGED or dev.state == DeviceState.UNMANAGED):
             raise Exception("Device {} is in invalid state: {}".format(hostname, dev.state))
         dev.state = DeviceState.UNMANAGED
+        dev.synchronized = False
 
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
     nr_filtered = nr.filter(name=hostname).filter(managed=False)
@@ -650,6 +651,6 @@ def apply_config(hostname: str, config: str, dry_run: bool,
                                    job_id=job_id)
     except Exception as e:
         logger.exception("Exception in apply_config: {}".format(e))
-    
+
     return NornirJobResult(nrresult=nrresult)
 

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -9,6 +9,7 @@ from nornir.plugins.tasks import networking, text
 from nornir.plugins.functions.text import print_result
 from nornir.core.filter import F
 from nornir.core.task import MultiResult
+from sqlalchemy import or_
 
 import cnaas_nms.db.helper
 import cnaas_nms.confpush.nornir_helper
@@ -584,3 +585,71 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
             )
 
     return NornirJobResult(nrresult=nrresult, next_job_id=next_job_id, change_score=total_change_score)
+
+
+def push_static_config(task, config: str, dry_run: bool = True,
+                       job_id: Optional[str] = None,
+                       scheduled_by: Optional[str] = None):
+    """
+    Nornir task to push static config to device
+
+    Args:
+        task: nornir task, sent by nornir when doing .run()
+        config: static config to apply
+        dry_run: Don't commit config to device, just do compare/diff
+        scheduled_by: username that triggered job
+
+    Returns:
+    """
+    set_thread_data(job_id)
+    logger = get_logger()
+
+    logger.debug("Push static config to device: {}".format(task.host.name))
+
+    task.run(task=networking.napalm_configure,
+             name="Push static config",
+             replace=True,
+             configuration=config,
+             dry_run=dry_run
+             )
+
+
+@job_wrapper
+def apply_config(hostname: str, config: str, dry_run: bool,
+                 job_id: Optional[int] = None,
+                 scheduled_by: Optional[str] = None) -> NornirJobResult:
+    """Apply a static configuration (from backup etc) to a device.
+
+    Args:
+        hostname: Specify a single host by hostname to synchronize
+        config: Static configuration to apply
+        dry_run: Don't commit config to device
+        job_id: Job ID number
+        scheduled_by: Username from JWT
+
+    Returns:
+        NornirJobResult
+    """
+    logger = get_logger()
+
+    with sqla_session() as session:
+        dev: Device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            raise Exception("Device {} not found, apply_config aborting".format(hostname))
+        elif not (dev.state == DeviceState.MANAGED or dev.state == DeviceState.UNMANAGED):
+            raise Exception("Device {} is in invalid state: {}".format(hostname, dev.state))
+        dev.state = DeviceState.UNMANAGED
+
+    nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
+    nr_filtered = nr.filter(name=hostname).filter(managed=False)
+
+    try:
+        nrresult = nr_filtered.run(task=push_static_config,
+                                   config=config,
+                                   dry_run=dry_run,
+                                   job_id=job_id)
+    except Exception as e:
+        logger.exception("Exception in apply_config: {}".format(e))
+    
+    return NornirJobResult(nrresult=nrresult)
+

--- a/src/cnaas_nms/db/job.py
+++ b/src/cnaas_nms/db/job.py
@@ -194,11 +194,14 @@ class Job(cnaas_nms.db.base.Base):
         result['job_id'] = job.id
         result['finish_time'] = job.finish_time.isoformat(timespec='seconds')
 
-        if 'job_tasks' not in job.result['devices'][hostname]:
+        if 'job_tasks' not in job.result['devices'][hostname] or \
+                'failed' not in job.result['devices'][hostname]:
             raise InvalidJobError("Invalid job data found in database: missing job_tasks")
 
         for task in job.result['devices'][hostname]['job_tasks']:
             if task['task_name'] == 'Generate device config':
                 result['config'] = task['result']
+
+        result['failed'] = job.result['devices'][hostname]['failed']
 
         return result

--- a/src/cnaas_nms/db/job.py
+++ b/src/cnaas_nms/db/job.py
@@ -162,18 +162,17 @@ class Job(cnaas_nms.db.base.Base):
     def get_previous_config(cls, session, hostname: str, previous: Optional[int] = None,
                             job_id: Optional[int] = None,
                             before: Optional[datetime.datetime] = None) -> Dict[str, str]:
-        """
+        """Get full configuration for a device from a previous job.
 
         Args:
-            session:
-            hostname:
-            previous:
-            job_id:
-            before:
+            session: sqla_session
+            hostname: hostname of device to get config for
+            previous: number of revisions back to get config from
+            job_id: specific job to get config from
+            before: date to get config before
 
         Returns:
             Returns a result dict with keys: config, job_id and finish_time
-
         """
         result = {}
         query_part = session.query(Job).filter(Job.function_name == 'sync_devices'). \
@@ -193,7 +192,7 @@ class Job(cnaas_nms.db.base.Base):
             raise JobNotFoundError("No matching job found")
 
         result['job_id'] = job.id
-        result['finish_time'] = job.finish_time.isoformat()
+        result['finish_time'] = job.finish_time.isoformat(timespec='seconds')
 
         if 'job_tasks' not in job.result['devices'][hostname]:
             raise InvalidJobError("Invalid job data found in database: missing job_tasks")

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -243,7 +243,9 @@ class GetTests(unittest.TestCase):
     def test_9_get_prev_config(self):
         hostname = "eosaccess"
         r = requests.get(
-            f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=1"
+            f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=1",
+            headers=AUTH_HEADER,
+            verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200)
         prev_job_id = r.json()['data']['job_id']
@@ -254,7 +256,7 @@ class GetTests(unittest.TestCase):
             "dry_run": True
         }
         r = requests.post(
-            "/api/v1.0/device/{}/previous_config".format(hostname),
+            f"{URL}/api/v1.0/device/{hostname}/previous_config",
             headers=AUTH_HEADER,
             verify=TLS_VERIFY,
             json=data

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -20,8 +20,9 @@ if not TLS_VERIFY:
 
 
 class GetTests(unittest.TestCase):
-    def setUp(self):
-        self.assertTrue(self.wait_connect(), "Connection to API failed")
+    @classmethod
+    def setUpClass(cls):
+        cls.assertTrue(cls.wait_connect(), "Connection to API failed")
 
         r = requests.put(
             f'{URL}/api/v1.0/repository/templates',
@@ -30,7 +31,7 @@ class GetTests(unittest.TestCase):
             verify=TLS_VERIFY
         )
         print("Template refresh status: {}".format(r.status_code))
-        self.assertEqual(r.status_code, 200, "Failed to refresh templates")
+        cls.assertEqual(r.status_code, 200, "Failed to refresh templates")
         r = requests.put(
             f'{URL}/api/v1.0/repository/settings',
             headers=AUTH_HEADER,
@@ -38,9 +39,9 @@ class GetTests(unittest.TestCase):
             verify=TLS_VERIFY
         )
         print("Settings refresh status: {}".format(r.status_code))
-        self.assertEqual(r.status_code, 200, "Failed to refresh settings")
+        cls.assertEqual(r.status_code, 200, "Failed to refresh settings")
 
-    def wait_connect(self):
+    def wait_connect(self) -> bool:
         for i in range(100):
             try:
                 r = requests.get(

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -240,6 +240,29 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to get CNaaS-NMS version")
 
+    def test_9_get_prev_config(self):
+        hostname = "eosaccess"
+        r = requests.get(
+            f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=1"
+        )
+        self.assertEqual(r.status_code, 200)
+        prev_job_id = r.json()['data']['job_id']
+        if r.json()['data']['failed']:
+            return
+        data = {
+            "job_id": prev_job_id,
+            "dry_run": True
+        }
+        r = requests.post(
+            "/api/v1.0/device/{}/previous_config".format(hostname),
+            headers=AUTH_HEADER,
+            verify=TLS_VERIFY,
+            json=data
+        )
+        self.assertEqual(r.status_code, 200)
+        restore_job_id = r.json()['job_id']
+        job = self.check_jobid(restore_job_id)
+        self.assertFalse(job['result']['devices'][hostname]['failed'])
 
 
 if __name__ == '__main__':

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -183,6 +183,7 @@ class GetTests(unittest.TestCase):
             verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200, "Failed to do sync_to access")
+        self.check_jobid(r.json()['job_id'])
         r = requests.post(
             f'{URL}/api/v1.0/device_syncto',
             headers=AUTH_HEADER,
@@ -190,6 +191,7 @@ class GetTests(unittest.TestCase):
             verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200, "Failed to do sync_to access")
+        self.check_jobid(r.json()['job_id'])
 
     def test_4_syncto_dist(self):
         r = requests.post(
@@ -199,6 +201,7 @@ class GetTests(unittest.TestCase):
             verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200, "Failed to do sync_to dist")
+        self.check_jobid(r.json()['job_id'])
 
     def test_5_genconfig(self):
         r = requests.get(

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -22,26 +22,6 @@ if not TLS_VERIFY:
 class GetTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.assertTrue(cls.wait_connect(), "Connection to API failed")
-
-        r = requests.put(
-            f'{URL}/api/v1.0/repository/templates',
-            headers=AUTH_HEADER,
-            json={"action": "refresh"},
-            verify=TLS_VERIFY
-        )
-        print("Template refresh status: {}".format(r.status_code))
-        cls.assertEqual(r.status_code, 200, "Failed to refresh templates")
-        r = requests.put(
-            f'{URL}/api/v1.0/repository/settings',
-            headers=AUTH_HEADER,
-            json={"action": "refresh"},
-            verify=TLS_VERIFY
-        )
-        print("Settings refresh status: {}".format(r.status_code))
-        cls.assertEqual(r.status_code, 200, "Failed to refresh settings")
-
-    def wait_connect(self) -> bool:
         for i in range(100):
             try:
                 r = requests.get(
@@ -58,7 +38,7 @@ class GetTests(unittest.TestCase):
                 else:
                     print("Bad status code {}, retrying in 1 second...".format(r.status_code))
                     time.sleep(1)
-        return False
+        assert False, "Failed to test connection to API"
 
     def wait_for_discovered_device(self):
         for i in range(100):
@@ -91,7 +71,25 @@ class GetTests(unittest.TestCase):
             else:
                 raise Exception
 
-    def test_0_init_dist(self):
+    def test_00_sync(self):
+        r = requests.put(
+            f'{URL}/api/v1.0/repository/templates',
+            headers=AUTH_HEADER,
+            json={"action": "refresh"},
+            verify=TLS_VERIFY
+        )
+        print("Template refresh status: {}".format(r.status_code))
+        self.assertEqual(r.status_code, 200, "Failed to refresh templates")
+        r = requests.put(
+            f'{URL}/api/v1.0/repository/settings',
+            headers=AUTH_HEADER,
+            json={"action": "refresh"},
+            verify=TLS_VERIFY
+        )
+        print("Settings refresh status: {}".format(r.status_code))
+        self.assertEqual(r.status_code, 200, "Failed to refresh settings")
+
+    def test_01_init_dist(self):
         new_dist_data = {
             "hostname": "eosdist1",
             "management_ip": "10.100.3.101",
@@ -129,7 +127,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to add mgmtdomain")
 
-    def test_1_ztp(self):
+    def test_02_ztp(self):
         hostname, device_id = self.wait_for_discovered_device()
         print("Discovered hostname, id: {}, {}".format(hostname, device_id))
         self.assertTrue(hostname, "No device in state discovered found for ZTP")
@@ -152,7 +150,7 @@ class GetTests(unittest.TestCase):
         self.assertFalse(result_step2['devices']['eosaccess']['failed'],
                          "Could not reach device after ZTP")
 
-    def test_2_interfaces(self):
+    def test_03_interfaces(self):
         r = requests.get(
             f'{URL}/api/v1.0/device/eosaccess/interfaces',
             headers=AUTH_HEADER,
@@ -176,7 +174,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to update interface")
 
-    def test_3_syncto_access(self):
+    def test_04_syncto_access(self):
         r = requests.post(
             f'{URL}/api/v1.0/device_syncto',
             headers=AUTH_HEADER,
@@ -194,7 +192,7 @@ class GetTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, "Failed to do sync_to access")
         self.check_jobid(r.json()['job_id'])
 
-    def test_4_syncto_dist(self):
+    def test_05_syncto_dist(self):
         r = requests.post(
             f'{URL}/api/v1.0/device_syncto',
             headers=AUTH_HEADER,
@@ -204,7 +202,7 @@ class GetTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, "Failed to do sync_to dist")
         self.check_jobid(r.json()['job_id'])
 
-    def test_5_genconfig(self):
+    def test_06_genconfig(self):
         r = requests.get(
             f'{URL}/api/v1.0/device/eosdist1/generate_config',
             headers=AUTH_HEADER,
@@ -212,7 +210,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to generate config for eosdist1")
 
-    def test_6_plugins(self):
+    def test_07_plugins(self):
         r = requests.get(
             f'{URL}/api/v1.0/plugins',
             headers=AUTH_HEADER,
@@ -228,7 +226,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to run plugin selftests")
 
-    def test_7_firmware(self):
+    def test_08_firmware(self):
         r = requests.get(
             f'{URL}/api/v1.0/firmware',
             headers=AUTH_HEADER,
@@ -237,14 +235,14 @@ class GetTests(unittest.TestCase):
         # TODO: not working
         #self.assertEqual(r.status_code, 200, "Failed to list firmware")
 
-    def test_8_sysversion(self):
+    def test_09_sysversion(self):
         r = requests.get(
             f'{URL}/api/v1.0/system/version',
             verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200, "Failed to get CNaaS-NMS version")
 
-    def test_9_get_prev_config(self):
+    def test_10_get_prev_config(self):
         hostname = "eosaccess"
         r = requests.get(
             f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=1",


### PR DESCRIPTION
Add API calls to get or restore a device to previous configurations from job history, example:
https://hostname/api/v1.0/device/<device_hostname>/previous_config?previous=1