### PR TITLE
Update device state after management config is pushed

### DIFF
--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -223,7 +223,6 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         device_variables = {**device_variables, **mlag_vars}
         # Update device state
         dev = session.query(Device).filter(Device.id == device_id).one()
-        dev.state = DeviceState.INIT
         dev.hostname = new_hostname
         session.commit()
         hostname = dev.hostname
@@ -239,6 +238,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
     with sqla_session() as session:
         dev = session.query(Device).filter(Device.id == device_id).one()
         dev.management_ip = device_variables['mgmt_ip']
+        dev.state = DeviceState.INIT
         # Remove the reserved IP since it's now saved in the device database instead
         reserved_ip = session.query(ReservedIP).filter(ReservedIP.device == dev).one_or_none()
         if reserved_ip:


### PR DESCRIPTION
Change device state to INIT after the management configuration is pushed, otherwise we will try to connect with a user which is not yet available on the switch.