### PR TITLE
Add more info to job database entries

### DIFF
--- a/docs/apiref/syncto.rst
+++ b/docs/apiref/syncto.rst
@@ -54,6 +54,10 @@ Arguments:
    re-synchronized, if you specify this option as true then all devices will be checked.
    This option does not affect syncto jobs with a specified hostname, when you select only
    a single device via hostname it's always re-synchronized. Defaults to false.
+ - comment: Optionally add a comment that is saved in the job log.
+   This should be a string with max 255 characters.
+ - ticket_ref: Optionally reference a service ticket associated with this job.
+   This should be a string with max 32 characters.
 
 If neither hostname or device_type is specified all devices that needs to be sycnhronized
 will be selected.

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -305,7 +305,13 @@ class DeviceSyncApi(Resource):
     def post(self):
         """ Start sync of device(s) """
         json_data = request.get_json()
-        kwargs: dict = {}
+        # default args
+        kwargs: dict = {
+            'dry_run': True,
+            'auto_push': False,
+            'force': False,
+            'resync': False
+        }
 
         total_count: Optional[int] = None
 
@@ -372,6 +378,10 @@ class DeviceSyncApi(Resource):
             kwargs['auto_push'] = json_data['auto_push']
         if 'resync' in json_data and isinstance(json_data['resync'], bool):
             kwargs['resync'] = json_data['resync']
+        if 'comment' in json_data and isinstance(json_data['comment'], str):
+            kwargs['job_comment'] = json_data['comment']
+        if 'ticket_ref' in json_data and isinstance(json_data['ticket_ref'], str):
+            kwargs['job_ticket_ref'] = json_data['ticket_ref']
 
         scheduler = Scheduler()
         job_id = scheduler.add_onetime_job(

--- a/src/cnaas_nms/scheduler/wrapper.py
+++ b/src/cnaas_nms/scheduler/wrapper.py
@@ -65,7 +65,21 @@ def job_wrapper(func):
             kwargs['kwargs']['job_id'] = job_id
             if scheduled_by is None:
                 scheduled_by = 'unknown'
-            job.start_job(function_name=func.__name__,
+            # Append (dry_run) to function name if set, so we can distinguish dry_run jobs
+            try:
+                if kwargs['kwargs']['dry_run']:
+                    function_name = "{} (dry_run)".format(func.__name__)
+                else:
+                    function_name = func.__name__
+            except Exception:
+                function_name = func.__name__
+            job_comment = kwargs['kwargs'].pop('job_comment', None)
+            if job_comment and isinstance(job_comment, str):
+                job.comment = job_comment[:255]
+            job_ticket_ref = kwargs['kwargs'].pop('job_ticket_ref', None)
+            if job_ticket_ref and isinstance(job_comment, str):
+                job.ticket_ref = job_ticket_ref[:32]
+            job.start_job(function_name=function_name,
                           scheduled_by=scheduled_by)
             if func.__name__ in progress_funcitons:
                 stop_event = threading.Event()

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -245,7 +245,7 @@ class GetTests(unittest.TestCase):
     def test_10_get_prev_config(self):
         hostname = "eosaccess"
         r = requests.get(
-            f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=1",
+            f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=0",
             headers=AUTH_HEADER,
             verify=TLS_VERIFY
         )


### PR DESCRIPTION
Add (dry_job) to function name in job log if argument dry_run was true. Add options to include comment and ticket_ref when starting a syncto job.