### PR TITLE
Template dry run

### DIFF
--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -211,6 +211,22 @@ have finished with a successful status for the specified device. The device
 will change to UNMANAGED state since it's no longer in sync with current
 templates and settings.
 
+Apply static config
+-------------------
+
+You can also test a static configuration specified in the API call directly
+instead of generating the configuration via templates and settings.
+This can be useful when developing new templates (see template_dry_run.py tool)
+when you don't wish to do the commit/push/refresh/sync workflow for every
+iteration. By default only dry_run are allowed, but you can configure api.yml
+to allow apply config live run as well.
+
+::
+
+   curl "https://hostname/api/v1.0/device/<device_hostname>/apply_config" -X POST -d '{"full_config": "hostname eosdist1\n...", "dry_run": True}' -H "Content-Type: application/json"
+
+This will schedule a job to send the configuration to the device.
+
 Initialize device
 -----------------
 

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -23,6 +23,7 @@ Defines parameters for the API:
 - jwtcert: Defines the path to the public JWT certificate used to verify JWT tokens
 - httpd_url: URL to the httpd container containing firmware images
 - verify_tls: Verify certificate for connections to httpd/firmware server
+- allow_apply_config_liverun: Allow liverun on apply_config API call. Defaults to False.
 
 /etc/cnaas-nms/repository.yml
 -----------------------------

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -20,6 +20,7 @@ from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.tools.log import get_logger
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from cnaas_nms.version import __api_version__
+from cnaas_nms.tools.get_apidata import get_apidata
 
 
 logger = get_logger()
@@ -606,7 +607,7 @@ class DeviceApplyConfigApi(Resource):
         """Apply exact specified configuration to device without using templates"""
         json_data = request.get_json()
         apply_kwargs = {'hostname': hostname}
-        allow_live_run = False
+        allow_live_run = get_apidata()['allow_apply_config_liverun']
         if not Device.valid_hostname(hostname):
             return empty_result(
                 status='error',

--- a/src/cnaas_nms/tools/get_apidata.py
+++ b/src/cnaas_nms/tools/get_apidata.py
@@ -1,6 +1,9 @@
 import yaml
 
 
-def get_apidata(config='/etc/cnaas-nms/api.yml'):
+def get_apidata(config='/etc/cnaas-nms/api.yml') -> dict:
+    defaults = {
+        'allow_apply_config_liverun': False
+    }
     with open(config, 'r') as api_file:
-        return yaml.safe_load(api_file)
+        return {**defaults, **yaml.safe_load(api_file)}

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -2,10 +2,17 @@
 
 import sys
 import os
-import requests
-import jinja2
-import yaml
+try:
+    import requests
+    import jinja2
+    import yaml
+except ModuleNotFoundError as e:
+    print("Please install python modules requests, jinja2 and yaml: {}".format(e))
+    sys.exit(3)
 
+if 'CNAASURL' not in os.environ or 'JWT_AUTH_TOKEN' not in os.environ:
+    print("Please export environment variables CNAASURL and JWT_AUTH_TOKEN")
+    sys.exit(4)
 
 api_url = os.environ['CNAASURL']
 headers = {"Authorization": "Bearer "+os.environ['JWT_AUTH_TOKEN']}
@@ -88,7 +95,7 @@ def main():
     print(new_config)
 
     try:
-        input("Start apply_config dry run? Ctrl-c to abort...")
+        input("Start apply_config dry run? Ctrl-c to abort or enter to continue...")
     except KeyboardInterrupt:
         print("Exiting...")
     else:

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -1,0 +1,99 @@
+#!/bin/env python3
+
+import sys
+import os
+import requests
+import jinja2
+import yaml
+
+
+api_url = os.environ['CNAASURL']
+headers = {"Authorization": "Bearer "+os.environ['JWT_AUTH_TOKEN']}
+
+
+def get_entrypoint(platform, device_type):
+    mapfile = os.path.join(platform, 'mapping.yml')
+    if not os.path.isfile(mapfile):
+        raise Exception("File {} not found".format(mapfile))
+    with open(mapfile, 'r') as f:
+        mapping = yaml.safe_load(f)
+        template_file = mapping[device_type]['entrypoint']
+    return template_file
+
+
+def get_device_details(hostname):
+    r = requests.get(
+        f"{api_url}/api/v1.0/device/{hostname}",
+        headers=headers)
+    if r.status_code != 200:
+        raise Exception("Could not query device API")
+    device_data = r.json()['data']['devices'][0]
+
+    r = requests.get(
+        f"{api_url}/api/v1.0/device/{hostname}/generate_config",
+        headers=headers)
+    if r.status_code != 200:
+        raise Exception("Could not query generate_config API")
+    config_data = r.json()['data']['config']
+
+    return device_data['device_type'], device_data['platform'], \
+        config_data['available_variables'], config_data['generated_config']
+
+
+def render_template(platform, device_type, variables):
+    jinjaenv = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(platform),
+        undefined=jinja2.StrictUndefined, trim_blocks=True
+    )
+    template_secrets = {}
+    for env in os.environ:
+        if env.startswith('TEMPLATE_SECRET_'):
+            template_secrets[env] = os.environ[env]
+    template_vars = {**variables, **template_secrets}
+    template = jinjaenv.get_template(get_entrypoint(platform, device_type))
+    return template.render(**template_vars)
+
+
+def schedule_apply_dryrun(hostname, config):
+    data = {
+        'full_config': config,
+        'dry_run': True
+    }
+    r = requests.post(
+        f"{api_url}/api/v1.0/device/{hostname}/apply_config",
+        headers=headers,
+        json=data
+    )
+    if r.status_code != 200:
+        raise Exception("Could not schedule apply_config job via API")
+    return r.json()['job_id']
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: template_dry_run.py <hostname>")
+        sys.exit(1)
+
+    hostname = sys.argv[1]
+    try:
+        device_type, platform, variables, old_config = get_device_details(hostname)
+    except Exception as e:
+        print(e)
+        sys.exit(2)
+    variables['host'] = hostname
+    new_config = render_template(platform, device_type, variables)
+    print("OLD TEMPLATE CONFIG ==============================")
+    print(old_config)
+    print("NEW TEMPLATE CONFIG ==============================")
+    print(new_config)
+
+    try:
+        input("Start apply_config dry run? Ctrl-c to abort...")
+    except KeyboardInterrupt:
+        print("Exiting...")
+    else:
+        print("Apply config dry_run job: {}".format(schedule_apply_dryrun(hostname, new_config)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Allow easier template development by allowing for dry_run of templates without commiting to git.
Two parts:
1. API call apply_config which applies specified config as-is without using templates on NMS server (only dry_run is allowed)
2. standalone script to run on administrator client which renders templates locally and sends a full config to the API for dry_run

standalone script can be run like this:
```
cd git/cnaas-templates/
~/path-to-script/template_dry_run.py eosdist1
```
New config is generated locally with local templates, and a job is scheduled to do a dry_run with the new config. Use some other tool (webui/cli/script) to read the diff from the job.