### PR TITLE
Mgmtdomain with CORE devices

### DIFF
--- a/docs/apiref/mgmtdomains.rst
+++ b/docs/apiref/mgmtdomains.rst
@@ -73,7 +73,7 @@ Example using CURL:
 
 ::
 
-   curl -s -H "Authorization: Bearer $JWT_AUTH_TOKEN" ${CNAASURL}/api/v1.0/mgmtdomain -H "Content-Type: application/json" -X POST -d '{"ipv4_gw": "10.0.6.1/24", "device_a": "dist1", "device_b": "dist2", "vlan": 600}'
+   curl -s -H "Authorization: Bearer $JWT_AUTH_TOKEN" ${CNAASURL}/api/v1.0/mgmtdomains -H "Content-Type: application/json" -X POST -d '{"ipv4_gw": "10.0.6.1/24", "device_a": "dist1", "device_b": "dist2", "vlan": 600}'
 
 
 Update management domain

--- a/docs/apiref/mgmtdomains.rst
+++ b/docs/apiref/mgmtdomains.rst
@@ -6,7 +6,7 @@ Management domain can be retreived, added, updated an removed using this API.
 Get all managment domains
 -------------------------
 
-All management domain can be listed using CURL:
+All management domains can be listed using CURL:
 
 
 ::
@@ -39,6 +39,8 @@ That will return a JSON structured response which describes all domains availabl
       }
   }
 
+Note that some of these fields does not have a use case (yet).
+
 You can also specify one specifc mgmtdomain to query by using:
 
 ::
@@ -57,7 +59,15 @@ To add a new management domain we can to call the API with a few fields set in a
    * ipv4_gw (mandatory): The IPv4 gateway to be used, should be expressed with a prefix (10.0.0.1/24)
    * device_a (mandatory): Hostname of the first device
    * device_b (mandatory): Hostname of the second device
-   * vlan (mandatory): A VLAN
+   * vlan (mandatory): A VLAN ID
+
+device_a and device_b should be a pair of DIST devices that are connected to a
+specific set of access devices that should share the same management network.
+It's also possible to specify two CORE devices if there is a need to have the
+gateway/routing for all access switch management done in the CORE layer instead.
+In the case where two CORE devices are specified there should only be one single
+mgmtdomain defined for the entire NMS, and this mgmtdomain can only contain
+exactly two CORE devices even if there are more CORE devices in the network.
 
 Example using CURL:
 

--- a/docs/apiref/mgmtdomains.rst
+++ b/docs/apiref/mgmtdomains.rst
@@ -63,7 +63,7 @@ Example using CURL:
 
 ::
 
-   curl -s -H "Authorization: Bearer $JWT_AUTH_TOKEN" ${CNAASURL}/api/v1.0/mgmtdomains -H "Content-Type: application/json" -X POST -d '{"ipv4_gw": "10.0.6.1/24", "device_a": "dist1", "device_b": "dist2", "vlan": 600}'
+   curl -s -H "Authorization: Bearer $JWT_AUTH_TOKEN" ${CNAASURL}/api/v1.0/mgmtdomain -H "Content-Type: application/json" -X POST -d '{"ipv4_gw": "10.0.6.1/24", "device_a": "dist1", "device_b": "dist2", "vlan": 600}'
 
 
 Update management domain

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -21,7 +21,7 @@ from cnaas_nms.api.linknet import api as links_api
 from cnaas_nms.api.firmware import api as firmware_api
 from cnaas_nms.api.interface import api as interfaces_api
 from cnaas_nms.api.jobs import job_api, jobs_api, joblock_api
-from cnaas_nms.api.mgmtdomain import api as mgmtdomains_api
+from cnaas_nms.api.mgmtdomain import mgmtdomain_api, mgmtdomains_api
 from cnaas_nms.api.groups import api as groups_api
 from cnaas_nms.api.repository import api as repository_api
 from cnaas_nms.api.settings import api as settings_api
@@ -106,6 +106,7 @@ api.add_namespace(interfaces_api)
 api.add_namespace(job_api)
 api.add_namespace(jobs_api)
 api.add_namespace(joblock_api)
+api.add_namespace(mgmtdomain_api)
 api.add_namespace(mgmtdomains_api)
 api.add_namespace(groups_api)
 api.add_namespace(repository_api)

--- a/src/cnaas_nms/api/mgmtdomain.py
+++ b/src/cnaas_nms/api/mgmtdomain.py
@@ -11,10 +11,12 @@ from cnaas_nms.db.session import sqla_session
 from cnaas_nms.version import __api_version__
 
 
-api = Namespace('mgmtdomains', description='API for handling managemeent domains',
-                prefix='/api/{}'.format(__api_version__))
+mgmtdomains_api = Namespace('mgmtdomains', description='API for handling management domains',
+                            prefix='/api/{}'.format(__api_version__))
+mgmtdomain_api = Namespace('mgmtdomain', description='API for handling a single management domain',
+                           prefix='/api/{}'.format(__api_version__))
 
-mgmtdomain_model = api.model('mgmtdomain', {
+mgmtdomain_model = mgmtdomain_api.model('mgmtdomain', {
     'device_a': fields.String(required=True),
     'device_b': fields.String(required=True),
     'vlan': fields.Integer(required=True),
@@ -51,7 +53,7 @@ class MgmtdomainByIdApi(Resource):
                 return empty_result('error', "Management domain not found"), 404
 
     @jwt_required
-    @api.expect(mgmtdomain_model)
+    @mgmtdomain_api.expect(mgmtdomain_model)
     def put(self, mgmtdomain_id):
         """ Modify management domain """
         json_data = request.get_json()
@@ -105,7 +107,7 @@ class MgmtdomainsApi(Resource):
         return result
 
     @jwt_required
-    @api.expect(mgmtdomain_model)
+    @mgmtdomain_api.expect(mgmtdomain_model)
     def post(self):
         """ Add management domain """
         json_data = request.get_json()
@@ -169,5 +171,5 @@ class MgmtdomainsApi(Resource):
                 return empty_result('error', errors), 400
 
 
-api.add_resource(MgmtdomainsApi, '')
-api.add_resource(MgmtdomainByIdApi, '/<int:mgmtdomain_id>')
+mgmtdomains_api.add_resource(MgmtdomainsApi, '')
+mgmtdomain_api.add_resource(MgmtdomainByIdApi, '/<int:mgmtdomain_id>')

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -210,15 +210,14 @@ def push_sync_device(task, dry_run: bool = True, generate_only: bool = False,
                             'config': intf['config'],
                             'indexnum': ifindexnum
                         })
-            if devtype == DeviceType.DIST:
-                for mgmtdom in cnaas_nms.db.helper.get_all_mgmtdomains(session, hostname):
-                    fabric_device_variables['mgmtdomains'].append({
-                        'id': mgmtdom.id,
-                        'ipv4_gw': mgmtdom.ipv4_gw,
-                        'vlan': mgmtdom.vlan,
-                        'description': mgmtdom.description,
-                        'esi_mac': mgmtdom.esi_mac
-                    })
+            for mgmtdom in cnaas_nms.db.helper.get_all_mgmtdomains(session, hostname):
+                fabric_device_variables['mgmtdomains'].append({
+                    'id': mgmtdom.id,
+                    'ipv4_gw': mgmtdom.ipv4_gw,
+                    'vlan': mgmtdom.vlan,
+                    'description': mgmtdom.description,
+                    'esi_mac': mgmtdom.esi_mac
+                })
             # find fabric neighbors
             fabric_links = []
             for neighbor_d in dev.get_neighbors(session):

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -120,7 +120,7 @@ class GetTests(unittest.TestCase):
             "vlan": 600
         }
         r = requests.post(
-            f'{URL}/api/v1.0/mgmtdomain',
+            f'{URL}/api/v1.0/mgmtdomains',
             headers=AUTH_HEADER,
             json=new_mgmtdom_data,
             verify=TLS_VERIFY

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -120,7 +120,7 @@ class GetTests(unittest.TestCase):
             "vlan": 600
         }
         r = requests.post(
-            f'{URL}/api/v1.0/mgmtdomains',
+            f'{URL}/api/v1.0/mgmtdomain',
             headers=AUTH_HEADER,
             json=new_mgmtdom_data,
             verify=TLS_VERIFY


### PR DESCRIPTION
A possible solution for when there is a requirement to have the gateway/routing for all access devices done in the core layer instead of in the dist layer.

From updated docs (creating new mgmtdomain):
device_a and device_b should be a pair of DIST devices that are connected to a
specific set of access devices that should share the same management network.
It's also possible to specify two CORE devices if there is a need to have the
gateway/routing for all access switch management done in the CORE layer instead.
In the case where two CORE devices are specified there should only be one single
mgmtdomain defined for the entire NMS, and this mgmtdomain can only contain
exactly two CORE devices even if there are more CORE devices in the network.