### PR TITLE
Render dhcpd configuration from YAML/template

### DIFF
--- a/docker/dhcpd/cnaas-setup.sh
+++ b/docker/dhcpd/cnaas-setup.sh
@@ -36,5 +36,5 @@ cd cnaas-nms/
 git checkout develop
 #python3 -m pip install -r requirements.txt
 #minimal requirements for just dhcp-hook:
-python3 -m pip install requests pyyaml netaddr
+python3 -m pip install requests pyyaml netaddr jinja2
 

--- a/docker/dhcpd/dhcpd.sh
+++ b/docker/dhcpd/dhcpd.sh
@@ -19,6 +19,14 @@ then
 	fi
 fi
 
+if [ -e "/opt/cnaas/etc/dhcpd/gen-dhcpd.py" ] && \
+       [ -e "/opt/cnaas/etc/dhcpd/dhcpd.j2" ] && \
+       [ -e "/opt/cnaas/etc/dhcpd/dhcpd.yaml" ]; then
+    source /opt/cnaas/venv/bin/activate
+    cd /opt/cnaas/etc/dhcpd/
+    python3 gen-dhcpd.py > /opt/cnaas/dhcpd.conf
+fi
+
 #cd /opt/cnaas/venv/cnaas-nms
 #git pull
 


### PR DESCRIPTION
Check if we can run the script gen-dhcpd.py which reads a YAML file and produces a dhcpd configuration. Simplifies configuration of dhcpd in some cases.