### PR TITLE
Dist ZTP [settings and template update]

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -64,7 +64,7 @@ Additional variables available for distribution switches:
   Populated from the links database table.
 
 - bgp_evpn_peers: A list of dictionaries with the keys: "peer_hostname", "peer_infra_lo", "peer_asn".
-  Contains one entry per hostname specified in settings->evpn_spines. Used to build
+  Contains one entry per hostname specified in settings->evpn_peers. Used to build
   eBGP peering for EVPN between loopbacks.
 
 - mgmtdomains: A list of dictionaries with the keys: "ipv4_gw", "vlan", "description", "esi_mac".
@@ -129,7 +129,8 @@ Can contain the following dictionaries with specified keys:
 
   * hostname: A hostname of a CORE (or DIST) device from the device database.
     The other DIST switches participating in the VXLAN/EVPN fabric will establish
-    eBGP connections to these devices.
+    eBGP connections to these devices. If an empty list is provided all CORE
+    devices will be added as evpn_peers instead.
 
 - vrfs:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -211,8 +211,16 @@ Keys for interfaces.yml or interfaces_<model>.yml:
 * interfaces: List of dicctionaries with keys:
 
   * name: Interface name, like "Ethernet1"
-  * ifclass: Interface class, one of: downlink, uplink, custom
+  * ifclass: Interface class, one of: downlink, fabric, custom
   * config: Optional. Raw CLI config used in case "custom" ifclass was selected
+
+The "downlink" ifclass is used on DIST devices to specify that this interface
+is used to connect access devices. The "fabric" ifclass is used to specify that
+this interface is used to connect DIST or CORE devices with each other to form
+the switch (vxlan) fabric. Linknet data will only be configured on interfaces
+specified as "fabric". If no linknet data is available in the database then
+the fabric interface will be configured for ZTP of DIST/CORE devices by
+providing DHCP (relay) access.
 
 etc
 ---

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -258,8 +258,6 @@ class DeviceInitApi(Resource):
                 scheduled_by=get_jwt_identity(),
                 kwargs=job_kwargs)
         elif job_kwargs['device_type'] in [DeviceType.CORE.name, DeviceType.DIST.name]:
-            job_kwargs['devtype'] = DeviceType[job_kwargs['device_type']]
-            del job_kwargs['device_type']
             scheduler = Scheduler()
             job_id = scheduler.add_onetime_job(
                 'cnaas_nms.confpush.init_device:init_fabric_device_step1',

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -257,6 +257,15 @@ class DeviceInitApi(Resource):
                 when=1,
                 scheduled_by=get_jwt_identity(),
                 kwargs=job_kwargs)
+        elif job_kwargs['device_type'] in [DeviceType.CORE.name, DeviceType.DIST.name]:
+            job_kwargs['devtype'] = DeviceType[job_kwargs['device_type']]
+            del job_kwargs['device_type']
+            scheduler = Scheduler()
+            job_id = scheduler.add_onetime_job(
+                'cnaas_nms.confpush.init_device:init_fabric_device_step1',
+                when=1,
+                scheduled_by=get_jwt_identity(),
+                kwargs=job_kwargs)
         else:
             return empty_result(status='error', data="Unsupported 'device_type' provided"), 400
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -257,7 +257,7 @@ class DeviceInitApi(Resource):
                 scheduler = Scheduler()
                 job_id = scheduler.add_onetime_job(
                     'cnaas_nms.confpush.init_device:init_device_step2',
-                    when=60,
+                    when=1,
                     scheduled_by=get_jwt_identity(),
                     kwargs={'device_id': device_id, 'iteration': 1})
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -444,7 +444,7 @@ class DeviceSyncApi(Resource):
                     status='error',
                     data=f"Hostname '{hostname}' not found or is not a managed device"
                 ), 400
-            kwargs['hostname'] = hostname
+            kwargs['hostnames'] = [hostname]
             what = hostname
         elif 'device_type' in json_data:
             devtype_str = str(json_data['device_type']).upper()

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -353,8 +353,9 @@ class DeviceInitCheckApi(Resource):
             try:
                 ret['linknets'] = cnaas_nms.confpush.get.update_linknets(
                     session,
-                    hostname=target_hostname,
+                    hostname=dev.hostname,
                     devtype=target_devtype,
+                    ztp_hostname=target_hostname,
                     dry_run=True
                 )
                 ret['linknets_compatible'] = True

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -356,7 +356,7 @@ class DeviceInitCheckApi(Resource):
 
             try:
                 if 'linknets' in ret:
-                    cnaas_nms.confpush.init_device.pre_init_check_neighbors(
+                    ret['neighbors'] = cnaas_nms.confpush.init_device.pre_init_check_neighbors(
                         session, dev, target_devtype,
                         ret['linknets'], parsed_args['neighbors'])
                     ret['neighbors_compatible'] = True

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -338,6 +338,7 @@ class DeviceInitCheckApi(Resource):
         try:
             parsed_args = DeviceInitApi.arg_check(device_id, json_data)
             target_devtype = DeviceType[parsed_args['device_type']]
+            target_hostname = parsed_args['new_hostname']
         except ValueError as e:
             return empty_result(status='error', data=str(e)), 400
 
@@ -352,7 +353,7 @@ class DeviceInitCheckApi(Resource):
             try:
                 ret['linknets'] = cnaas_nms.confpush.get.update_linknets(
                     session,
-                    hostname=dev.hostname,
+                    hostname=target_hostname,
                     devtype=target_devtype,
                     dry_run=True
                 )

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -25,6 +25,7 @@ class SettingsApi(Resource):
         args = request.args
         hostname = None
         device_type = None
+        model = None
         if 'hostname' in args:
             if Device.valid_hostname(args['hostname']):
                 hostname = args['hostname']
@@ -35,6 +36,7 @@ class SettingsApi(Resource):
                     filter(Device.hostname == hostname).one_or_none()
                 if dev:
                     device_type = dev.device_type
+                    model = dev.model
                 else:
                     return empty_result('error', "Hostname not found in database"), 400
         if 'device_type' in args:
@@ -44,7 +46,7 @@ class SettingsApi(Resource):
                 return empty_result('error', "Invalid device type specified"), 400
 
         try:
-            settings, settings_origin = get_settings(hostname, device_type)
+            settings, settings_origin = get_settings(hostname, device_type, model)
         except Exception as e:
             return empty_result('error', "Error getting settings: {}".format(str(e))), 400
 
@@ -55,7 +57,6 @@ class SettingsModelApi(Resource):
     def get(self):
         response = make_response(settings_root_model.schema_json())
         response.headers['Content-Type'] = "application/json"
-        response.headers['Content-Type'] = 'application/json'
         return response
 
     def post(self):

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -24,6 +24,9 @@ class DeviceTests(unittest.TestCase):
         self.tmp_postgres = PostgresTemporaryInstance()
 
     def tearDown(self):
+        device_id = self.testdata['initcheck_device_id']
+        self.client.put(f'/api/v1.0/device/{device_id}',
+                        json={'state': 'MANAGED'})
         self.tmp_postgres.shutdown()
 
     def test_0_add_invalid_device(self):

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -382,7 +382,8 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
             interface_a=local_if,
             hostname_b=remote_device_inst.hostname,
             interface_b=data[0]['port'],
-            ipv4_network=ipv4_network
+            ipv4_network=ipv4_network,
+            strict_check=not dry_run  # Don't do strict check if this is a dry_run
         )
         if not dry_run:
             local_device_inst.synchronized = False

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -316,10 +316,16 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
         if not remote_device_inst:
             logger.debug(f"Unknown neighbor device, ignoring: {data[0]['hostname']}")
             continue
-        if remote_device_inst.state not in [DeviceState.MANAGED, DeviceState.UNMANAGED]:
-            logger.debug("Neighbor device is not MANAGED/UNMANAGED, ignoring: {}".format(
+        if remote_device_inst.state in [DeviceState.DISCOVERED, DeviceState.INIT]:
+            # In case of MLAG init the peer does not have the correct devtype set yet,
+            # use same devtype as local device instead
+            remote_devtype = devtype
+        elif remote_device_inst.state not in [DeviceState.MANAGED, DeviceState.UNMANAGED]:
+            logger.debug("Neighbor device has invalid state, ignoring: {}".format(
                 data[0]['hostname']))
             continue
+        else:
+            remote_devtype = remote_device_inst.device_type
 
         logger.debug(f"Remote device found, device id: {remote_device_inst.id}")
 
@@ -328,7 +334,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
                                                 local_device_inst.model
                                                 )
         remote_device_settings, _ = get_settings(remote_device_inst.hostname,
-                                                 remote_device_inst.device_type,
+                                                 remote_devtype,
                                                  remote_device_inst.model
                                                  )
 

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -289,7 +289,8 @@ def verify_peer_iftype(local_hostname: str, local_devtype: DeviceType,
                                                             intf['ifclass']))
 
 
-def update_linknets(session, hostname: str, devtype: DeviceType, dry_run: bool = False):
+def update_linknets(session, hostname: str, devtype: DeviceType,
+                    ztp_hostname: Optional[str] = None, dry_run: bool = False):
     """Update linknet data for specified device using LLDP neighbor data.
     """
     logger = get_logger()
@@ -297,6 +298,10 @@ def update_linknets(session, hostname: str, devtype: DeviceType, dry_run: bool =
     if result.failed:
         raise Exception
     neighbors = result.result['lldp_neighbors']
+    if ztp_hostname:
+        settings_hostname = ztp_hostname
+    else:
+        settings_hostname = hostname
 
     ret = []
 
@@ -313,7 +318,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType, dry_run: bool =
             continue
         logger.debug(f"Remote device found, device id: {remote_device_inst.id}")
 
-        local_device_settings, _ = get_settings(hostname,
+        local_device_settings, _ = get_settings(settings_hostname,
                                                 devtype,
                                                 local_device_inst.model
                                                 )

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -380,6 +380,8 @@ def update_linknets(session, hostname: str, devtype: DeviceType, dry_run: bool =
             ipv4_network=ipv4_network
         )
         if not dry_run:
+            local_device_inst.synchronized = False
+            remote_device_inst.synchronized = False
             session.add(new_link)
             session.commit()
         else:

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -40,7 +40,7 @@ class InitError(Exception):
     pass
 
 
-def push_base_management_access(task, device_variables, job_id):
+def push_base_management(task, device_variables: dict, devtype: DeviceType, job_id):
     set_thread_data(job_id)
     logger = get_logger()
     logger.debug("Push basetemplate for host: {}".format(task.host.name))
@@ -54,7 +54,7 @@ def push_base_management_access(task, device_variables, job_id):
         raise RepoStructureException("File {} not found in template repo".format(mapfile))
     with open(mapfile, 'r') as f:
         mapping = yaml.safe_load(f)
-        template = mapping['ACCESS']['entrypoint']
+        template = mapping[devtype.name]['entrypoint']
 
     r = task.run(task=text.template_file,
                  name="Generate initial device config",
@@ -274,8 +274,9 @@ def init_access_device_step1(device_id: int, new_hostname: str,
     nr_filtered = nr.filter(name=hostname)
 
     # step2. push management config
-    nrresult = nr_filtered.run(task=push_base_management_access,
+    nrresult = nr_filtered.run(task=push_base_management,
                                device_variables=device_variables,
+                               devtype=DeviceType.ACCESS,
                                job_id=job_id)
 
     with sqla_session() as session:

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -418,7 +418,7 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
             'infra_ip': str(infra_ip),
         }
 
-        device_variables = populate_device_vars(session, dev, new_hostname, DeviceType.ACCESS)
+        device_variables = populate_device_vars(session, dev, new_hostname, devtype)
         device_variables = {
             **device_variables,
             **mgmt_variables
@@ -439,7 +439,7 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
 
     with sqla_session() as session:
         dev = session.query(Device).filter(Device.id == device_id).one()
-        dev.management_ip = device_variables['mgmt_ip']
+        dev.management_ip = mgmt_ip
         dev.state = DeviceState.INIT
         dev.device_type = devtype
         # Remove the reserved IP since it's now saved in the device database instead

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -304,10 +304,14 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         logger.exception("Error while running plugin hooks for allocated_ipv4: ".format(str(e)))
 
     # step3. register apscheduler job that continues steps
+    if mlag_peer_id and mlag_peer_new_hostname:
+        step2_delay = 30+60+30  # account for delayed start of peer device plus mgmt timeout
+    else:
+        step2_delay = 30
     scheduler = Scheduler()
     next_job_id = scheduler.add_onetime_job(
         'cnaas_nms.confpush.init_device:init_device_step2',
-        when=30,
+        when=step2_delay,
         scheduled_by=scheduled_by,
         kwargs={'device_id': device_id, 'iteration': 1})
 

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -302,7 +302,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
     # step3. register apscheduler job that continues steps
     scheduler = Scheduler()
     next_job_id = scheduler.add_onetime_job(
-        'cnaas_nms.confpush.init_device:init_access_device_step2',
+        'cnaas_nms.confpush.init_device:init_device_step2',
         when=30,
         scheduled_by=scheduled_by,
         kwargs={'device_id': device_id, 'iteration': 1})

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -56,24 +56,11 @@ def push_base_management_access(task, device_variables, job_id):
         mapping = yaml.safe_load(f)
         template = mapping['ACCESS']['entrypoint']
 
-    settings, settings_origin = get_settings(task.host.name, DeviceType.ACCESS)
-
-    # Add all environment variables starting with TEMPLATE_SECRET_ to
-    # the list of configuration variables. The idea is to store secret
-    # configuration outside of the templates repository.
-    template_secrets = {}
-    for env in os.environ:
-        if env.startswith('TEMPLATE_SECRET_'):
-            template_secrets[env] = os.environ[env]
-
-    # Merge dicts, this will overwrite interface list from settings
-    template_vars = {**settings, **device_variables, **template_secrets}
-
     r = task.run(task=text.template_file,
                  name="Generate initial device config",
                  template=template,
                  path=f"{local_repo_path}/{task.host.platform}",
-                 **template_vars)
+                 **device_variables)
 
     #TODO: Handle template not found, variables not defined
 

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -396,6 +396,9 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, device_type: str
         except Exception as e:
             raise e
         else:
+            dev.state = DeviceState.INIT
+            dev.device_type = devtype
+            session.commit()
             # If neighbor check works, commit new linknets
             # This will also mark neighbors as unsynced
             linknets = cnaas_nms.confpush.get.update_linknets(
@@ -445,8 +448,6 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, device_type: str
     with sqla_session() as session:
         dev = session.query(Device).filter(Device.id == device_id).one()
         dev.management_ip = mgmt_ip
-        dev.state = DeviceState.INIT
-        dev.device_type = devtype
         # Remove the reserved IP since it's now saved in the device database instead
         reserved_ip = session.query(ReservedIP).filter(ReservedIP.device == dev).one_or_none()
         if reserved_ip:

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -349,7 +349,7 @@ def check_neighbor_sync(session, hostnames: List[str]):
 
 
 @job_wrapper
-def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceType,
+def init_fabric_device_step1(device_id: int, new_hostname: str, device_type: str,
                              neighbors: Optional[List[str]] = [],
                              job_id: Optional[str] = None,
                              scheduled_by: Optional[str] = None) -> NornirJobResult:
@@ -358,6 +358,7 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
     Args:
         device_id: Device to select for initialization
         new_hostname: Hostname to configure on this device
+        device_type: String representing DeviceType
         neighbors: Optional list of hostnames of peer devices
         job_id: job_id provided by scheduler when adding job
         scheduled_by: Username from JWT.
@@ -370,6 +371,10 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
         ValueError
     """
     logger = get_logger()
+    if DeviceType.has_name(device_type):
+        devtype = DeviceType[device_type]
+    else:
+        raise ValueError("Invalid 'device_type' provided")
 
     if devtype not in [DeviceType.CORE, DeviceType.DIST]:
         raise ValueError("Init fabric device requires device type DIST or CORE")

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -379,7 +379,7 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
 
         # Test update of linknets using LLDP data
         linknets = cnaas_nms.confpush.get.update_linknets(
-            session, dev.hostname, devtype, dry_run=True)
+            session, dev.hostname, devtype, ztp_hostname=new_hostname, dry_run=True)
 
         try:
             verified_neighbors = pre_init_check_neighbors(
@@ -394,7 +394,7 @@ def init_fabric_device_step1(device_id: int, new_hostname: str, devtype: DeviceT
             # If neighbor check works, commit new linknets
             # This will also mark neighbors as unsynced
             linknets = cnaas_nms.confpush.get.update_linknets(
-                session, dev.hostname, devtype, dry_run=False)
+                session, dev.hostname, devtype, ztp_hostname=new_hostname, dry_run=False)
             logger.debug("New linknets for INIT of {} created: {}".format(
                 new_hostname, linknets
             ))

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -151,6 +151,7 @@ def populate_device_vars(session, dev: Device,
                 'mgmt_gw': str(mgmt_gw_ipif.ip),
                 'mgmt_ipif': str(IPv4Interface('{}/{}'.format(mgmt_ip,
                                                               mgmt_gw_ipif.network.prefixlen))),
+                'mgmt_ip': str(mgmt_ip),
                 'mgmt_prefixlen': int(mgmt_gw_ipif.network.prefixlen),
                 'interfaces': []
             }

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -464,7 +464,7 @@ def update_config_hash(task):
 
 
 @job_wrapper
-def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = None,
+def sync_devices(hostnames: Optional[List[str]] = None, device_type: Optional[str] = None,
                  group: Optional[str] = None, dry_run: bool = True, force: bool = False,
                  auto_push: bool = False, job_id: Optional[int] = None,
                  scheduled_by: Optional[str] = None, resync: bool = False) -> NornirJobResult:
@@ -492,9 +492,9 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
     nr = cnaas_init()
     dev_count = 0
     skipped_hostnames = []
-    if hostname:
+    if hostnames:
         nr_filtered, dev_count, skipped_hostnames = \
-            inventory_selector(nr, hostname=hostname)
+            inventory_selector(nr, hostname=hostnames)
     else:
         if device_type:
             nr_filtered, dev_count, skipped_hostnames = \
@@ -626,7 +626,7 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
             format(total_change_score, dry_run, len(device_list), len(changed_hosts)))
 
     next_job_id = None
-    if auto_push and len(device_list) == 1 and hostname and dry_run:
+    if auto_push and len(device_list) == 1 and hostnames and dry_run:
         if not changed_hosts:
             logger.info("None of the selected host has any changes (diff), skipping auto-push")
         elif total_change_score < AUTOPUSH_MAX_SCORE:
@@ -635,11 +635,11 @@ def sync_devices(hostname: Optional[str] = None, device_type: Optional[str] = No
                 'cnaas_nms.confpush.sync_devices:sync_devices',
                 when=0,
                 scheduled_by=scheduled_by,
-                kwargs={'hostname': hostname, 'dry_run': False, 'force': force})
+                kwargs={'hostnames': hostnames, 'dry_run': False, 'force': force})
             logger.info(f"Auto-push scheduled live-run of commit as job id {next_job_id}")
         else:
             logger.info(
-                f"Auto-push of config to device {hostname} failed because change score of "
+                f"Auto-push of config to device {hostnames} failed because change score of "
                 f"{total_change_score} is higher than auto-push limit {AUTOPUSH_MAX_SCORE}"
             )
 

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -463,6 +463,22 @@ def update_config_hash(task):
             logger.debug("Config hash for {} updated to {}".format(task.host.name, new_config_hash))
 
 
+def confcheck_devices(hostnames: List[str], job_id=None):
+    nr = cnaas_init()
+    nr_filtered, dev_count, skipped_hostnames = \
+        inventory_selector(nr, hostname=hostnames)
+
+    try:
+        nrresult = nr_filtered.run(task=sync_check_hash,
+                                   job_id=job_id)
+    except Exception as e:
+        raise e
+    else:
+        if nrresult.failed:
+            raise Exception('Configuration hash check failed for {}'.format(
+                ' '.join(nrresult.failed_hosts.keys())))
+
+
 @job_wrapper
 def sync_devices(hostnames: Optional[List[str]] = None, device_type: Optional[str] = None,
                  group: Optional[str] = None, dry_run: bool = True, force: bool = False,

--- a/src/cnaas_nms/confpush/tests/test_get.py
+++ b/src/cnaas_nms/confpush/tests/test_get.py
@@ -7,6 +7,8 @@ import yaml
 import os
 
 from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.device import DeviceType
+
 
 class GetTests(unittest.TestCase):
     def setUp(self):
@@ -36,7 +38,8 @@ class GetTests(unittest.TestCase):
 
     def test_update_links(self):
         with sqla_session() as session:
-            new_links = cnaas_nms.confpush.get.update_linknets(session, self.testdata['update_hostname'])
+            new_links = cnaas_nms.confpush.get.update_linknets(
+                session, self.testdata['update_hostname'], DeviceType.ACCESS)
         pprint.pprint(new_links)
 
 

--- a/src/cnaas_nms/confpush/underlay.py
+++ b/src/cnaas_nms/confpush/underlay.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import load_only
 from cnaas_nms.db.device import Device, DeviceType
 from cnaas_nms.db.linknet import Linknet
 from cnaas_nms.db.settings import get_settings
+from cnaas_nms.db.reservedip import ReservedIP
 
 
 def find_free_infra_ip(session) -> Optional[IPv4Address]:
@@ -29,16 +30,22 @@ def find_free_infra_ip(session) -> Optional[IPv4Address]:
 def find_free_mgmt_lo_ip(session) -> Optional[IPv4Address]:
     """Returns first free IPv4 infra IP."""
     used_ips = []
+    reserved_ips = []
     device_query = session.query(Device). \
         filter(Device.management_ip != None).options(load_only("management_ip"))
     for device in device_query:
         used_ips.append(device.management_ip)
+    reserved_ip_query = session.query(ReservedIP).options(load_only("ip"))
+    for reserved_ip in reserved_ip_query:
+        reserved_ips.append(reserved_ip.ip)
 
     settings, settings_origin = get_settings(device_type=DeviceType.CORE)
     mgmt_lo_net = IPv4Network(settings['underlay']['mgmt_lo_net'])
     for num, net in enumerate(mgmt_lo_net.subnets(new_prefix=32)):
         ipaddr = IPv4Address(net.network_address)
         if ipaddr in used_ips:
+            continue
+        if ipaddr in reserved_ips:
             continue
         else:
             return ipaddr

--- a/src/cnaas_nms/db/data/default_settings.yml
+++ b/src/cnaas_nms/db/data/default_settings.yml
@@ -2,6 +2,5 @@
 ntp_servers: []
 radius_servers: []
 snmp_servers: []
-evpn_spines: []
 vrfs: []
 vxlans: {}

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -241,7 +241,11 @@ class Device(cnaas_nms.db.base.Base):
                 [x.hostname for x in peers]
             ))
         elif len(peers) == 1:
-            if self.device_type != next(iter(peers)).device_type:
+            peer_devtype = next(iter(peers)).device_type
+            if self.device_type == DeviceType.UNKNOWN or peer_devtype == DeviceType.UNKNOWN:
+                # Ignore check during INIT, one device might be UNKNOWN
+                pass
+            elif self.device_type != peer_devtype:
                 raise DeviceException("MLAG peers are not the same device type")
             return next(iter(peers))
         else:

--- a/src/cnaas_nms/db/linknet.py
+++ b/src/cnaas_nms/db/linknet.py
@@ -54,14 +54,15 @@ class Linknet(cnaas_nms.db.base.Base):
 
     @classmethod
     def create_linknet(cls, session, hostname_a: str, interface_a: str, hostname_b: str,
-                       interface_b: str, ipv4_network: Optional[ipaddress.IPv4Network] = None):
+                       interface_b: str, ipv4_network: Optional[ipaddress.IPv4Network] = None,
+                       strict_check: bool = True):
         """Add a linknet between two devices. If ipv4_network is specified both
         devices must be of type CORE or DIST."""
         dev_a: cnaas_nms.db.device.Device = session.query(cnaas_nms.db.device.Device).\
             filter(cnaas_nms.db.device.Device.hostname == hostname_a).one_or_none()
         if not dev_a:
             raise ValueError(f"Hostname {hostname_a} not found in database")
-        if ipv4_network and dev_a.device_type not in \
+        if strict_check and ipv4_network and dev_a.device_type not in \
                 [cnaas_nms.db.device.DeviceType.DIST, cnaas_nms.db.device.DeviceType.CORE]:
             raise ValueError(
                 "Linknets can only be added between two core/dist devices " +
@@ -72,7 +73,7 @@ class Linknet(cnaas_nms.db.base.Base):
             filter(cnaas_nms.db.device.Device.hostname == hostname_b).one_or_none()
         if not dev_b:
             raise ValueError(f"Hostname {hostname_b} not found in database")
-        if ipv4_network and dev_b.device_type not in \
+        if strict_check and ipv4_network and dev_b.device_type not in \
                 [cnaas_nms.db.device.DeviceType.DIST, cnaas_nms.db.device.DeviceType.CORE]:
             raise ValueError(
                 "Linknets can only be added between two core/dist devices " +


### PR DESCRIPTION
Add support for doing device_init with device_type DIST and CORE

:warning: Behavior of linknets has changed, CORE and DIST devices have to specifically set ifclass to "fabric" in settings before linknet data will be populated on the interface. If a "fabric" ifclass interface does not have a corresponding linknet in the database, it should be configured for ZTP of DIST/CORE devices by providing DHCP relay in the template.

Example template:
```
{% elif intf.ifclass == 'fabric' %}
 {% if intf.ipv4if is defined and intf.ipv4if %}
  description {{ intf.peer_hostname }}
  no switchport
  ip address {{ intf.ipv4if }}
 {% else %}
  description ZTP
  switchport access vlan 1
 {% endif %}
{% elif ...
```

Caveat:
```
service routing protocols model multi-agent
```
Must be added to dhcp-init.j2 since this requires a reboot to apply. Otherwise evpn will not come up after ZTP, and the newly initialized device will not be reachable.