### PR TITLE
Release 1.2

### DIFF
--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+Version 1.2.0
+-------------
+
+New features:
+
+- ZTP support for core and diste devices (#137)
+- Init check API call to test if device is compatible for ZTP without commit (#136, #156)
+- Option to have model-specific default interface settings (#135)
+- Post-flight check for firmware upgrade (#139)
+- Abort scheduled jobs, best-effort abort of running jobs (#142)
+- API call to update existing interfaces on device after ZTP (#155)
+- More settings for external BGP routing, DNS servers, internal VLANs (#143, #146, #152)
+- Install NMS issued certificate on new devices during ZTP (#149)
+- Switch to Nornir 3.0, improved whitespace rendering in templates (#148)
+
+Bug fixes:
+
+- Fix blocking websockets (#138)
+- Fix access downlink port detection (#141)
+- Post upgrade confighash mismatch (#145)
+- Discover device duplicate jobs improvements (#151)
+- Trim facts fields before saving in database (#153)
+
 Version 1.1.0
 -------------
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -182,6 +182,12 @@ Can contain the following dictionaries with specified keys:
       * name: Name/description of route (optional, defaults to "undefined")
       * cli_append_str: Custom configuration to append to this route (optional)
 
+    * ipv6:
+
+      * destination: IPv6 prefix
+      * nexthop: IPv6 nexthop address
+      * other options are the same as ipv4
+
 * extroute_ospfv3:
 
   * vrfs:
@@ -252,6 +258,7 @@ name is the dictionary key and dictionaly values are:
   * vlan_id: VLAN ID, 1-4095
   * vlan_name: VLAN name, single word/no spaces, max 31 characters
   * ipv4_gw: IPv4 address with CIDR netmask, ex: 192.168.0.1/24. Optional.
+  * ipv6_gw: IPv6 address, ex: fe80::1. Optional.
   * groups: List of group names where this VXLAN/VLAN should be provisioned. If you select an
     access switch the parent dist switch should be automatically provisioned.
 

--- a/src/cnaas_nms/confpush/firmware.py
+++ b/src/cnaas_nms/confpush/firmware.py
@@ -42,7 +42,7 @@ def arista_pre_flight_check(task, job_id: Optional[str] = None) -> str:
 
     # Get amount of free disk space
     res = task.run(napalm_cli, commands=[flash_diskspace])
-    if not isinstance(res, MultiResult) or len(res.result.keys()) is not 1:
+    if not isinstance(res, MultiResult) or len(res.result.keys()) != 1:
         raise Exception('Could not check free space')
 
     # Remove old firmware images if needed

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -34,7 +34,7 @@ ipv4_if_schema = Field(None, regex=f"^{IPV4_IF_REGEX}$",
 ipv6_schema = Field(..., regex=f"^{IPV6_REGEX}$",
                     description="IPv6 address")
 IPV6_IF_REGEX = f"{IPV6_REGEX}" + r"\/[0-9]{1,3}"
-ipv6_if_schema = Field(..., regex=f"^{IPV6_IF_REGEX}$",
+ipv6_if_schema = Field(None, regex=f"^{IPV6_IF_REGEX}$",
                        description="IPv6 address in CIDR/prefix notation (::/0)")
 
 # VLAN name is alphanumeric max 32 chars on Cisco
@@ -215,6 +215,7 @@ class f_vxlan(BaseModel):
     vlan_id: int = vlan_id_schema
     vlan_name: str = vlan_name_schema
     ipv4_gw: Optional[str] = ipv4_if_schema
+    ipv6_gw: Optional[str] = ipv6_if_schema
     dhcp_relays: Optional[List[f_dhcp_relay]]
     mtu: Optional[int] = mtu_schema
     vxlan_host_route: bool = True
@@ -226,6 +227,13 @@ class f_vxlan(BaseModel):
         if v:
             if 'vrf' not in values or not values['vrf']:
                 raise ValueError('VRF is required when specifying ipv4_gw')
+        return v
+
+    @validator('ipv6_gw')
+    def vrf_required_if_ipv6_gw_set(cls, v, values, **kwargs):
+        if v:
+            if 'vrf' not in values or not values['vrf']:
+                raise ValueError('VRF is required when specifying ipv6_gw')
         return v
 
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -20,7 +20,7 @@ IPV6_REGEX = (
     r':((:[0-9a-fA-F]{1,4}){1,7}|:))'
 )
 FQDN_REGEX = r'([a-z0-9-]{1,63}\.)([a-z-][a-z0-9-]{1,62}\.?)+'
-HOST_REGEX = f"^({IPV4_REGEX}|{FQDN_REGEX})$"
+HOST_REGEX = f"^({IPV4_REGEX}|{IPV4_REGEX}|{FQDN_REGEX})$"
 HOSTNAME_REGEX = r"^([a-z0-9-]{1,63})(\.[a-z0-9-]{1,63})*$"
 host_schema = Field(..., regex=HOST_REGEX, max_length=253,
                     description="Hostname, FQDN or IP address")

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -20,7 +20,7 @@ IPV6_REGEX = (
     r':((:[0-9a-fA-F]{1,4}){1,7}|:))'
 )
 FQDN_REGEX = r'([a-z0-9-]{1,63}\.)([a-z-][a-z0-9-]{1,62}\.?)+'
-HOST_REGEX = f"^({IPV4_REGEX}|{IPV4_REGEX}|{FQDN_REGEX})$"
+HOST_REGEX = f"^({IPV4_REGEX}|{IPV6_REGEX}|{FQDN_REGEX})$"
 HOSTNAME_REGEX = r"^([a-z0-9-]{1,63})(\.[a-z0-9-]{1,63})*$"
 host_schema = Field(..., regex=HOST_REGEX, max_length=253,
                     description="Hostname, FQDN or IP address")

--- a/src/cnaas_nms/version.py
+++ b/src/cnaas_nms/version.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0dev3'
+__version__ = '1.2.0rc1'
 __version_info__ = tuple([field for field in __version__.split('.')])
 __api_version__ = 'v1.0'

--- a/src/cnaas_nms/version.py
+++ b/src/cnaas_nms/version.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0rc1'
+__version__ = '1.2.0'
 __version_info__ = tuple([field for field in __version__.split('.')])
 __api_version__ = 'v1.0'


### PR DESCRIPTION
Version 1.2.0
-------------

New features:

- ZTP support for core and diste devices (#137)
- Init check API call to test if device is compatible for ZTP without commit (#136, #156)
- Option to have model-specific default interface settings (#135)
- Post-flight check for firmware upgrade (#139)
- Abort scheduled jobs, best-effort abort of running jobs (#142)
- API call to update existing interfaces on device after ZTP (#155)
- More settings for external BGP routing, DNS servers, internal VLANs (#143, #146, #152)
- Install NMS issued certificate on new devices during ZTP (#149)
- Switch to Nornir 3.0, improved whitespace rendering in templates (#148)

Bug fixes:

- Fix blocking websockets (#138)
- Fix access downlink port detection (#141)
- Post upgrade confighash mismatch (#145)
- Discover device duplicate jobs improvements (#151)
- Trim facts fields before saving in database (#153)
