### PR TITLE
Bugfix: Jinja cached include

### DIFF
--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -23,8 +23,7 @@ cnaas_jinja_env = JinjaEnvironment(
     trim_blocks=True,
     lstrip_blocks=True,
     keep_trailing_newline=True,
-    cache_size=0,
-    enable_async=True
+    cache_size=0
 )
 
 

--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -22,7 +22,10 @@ class NornirJobResult(JobResult):
 cnaas_jinja_env = JinjaEnvironment(
     trim_blocks=True,
     lstrip_blocks=True,
-    keep_trailing_newline=True)
+    keep_trailing_newline=True,
+    cache_size=0,
+    enable_async=True
+)
 
 
 def cnaas_init() -> Nornir:

--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -19,11 +19,16 @@ class NornirJobResult(JobResult):
     change_score: Optional[float] = None
 
 
-cnaas_jinja_env = JinjaEnvironment(
+class RelativeJinjaEnvironment(JinjaEnvironment):
+    """Enable relative template paths"""
+    def join_path(self, template, parent):
+        return os.path.join(os.path.dirname(parent), template)
+
+
+cnaas_jinja_env = RelativeJinjaEnvironment(
     trim_blocks=True,
     lstrip_blocks=True,
-    keep_trailing_newline=True,
-    cache_size=0
+    keep_trailing_newline=True
 )
 
 


### PR DESCRIPTION
Make template includes relative to parent template, this solves issues where eos/dist.j2 would sometimes include junos/dist-interfaces.j2 and vice versa