### PR TITLE
Return different jinja env per filesystemloader path

### DIFF
--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -18,7 +18,7 @@ from cnaas_nms.db.interface import Interface, InterfaceConfigType
 
 def get_inventory():
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
-    return nr.dict()
+    return nr.dict()['inventory']
 
 
 def get_running_config(hostname):

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -17,7 +17,7 @@ from cnaas_nms.db.device import Device, DeviceState, DeviceType, DeviceStateExce
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.scheduler.wrapper import job_wrapper
-from cnaas_nms.confpush.nornir_helper import NornirJobResult, cnaas_jinja_env
+from cnaas_nms.confpush.nornir_helper import NornirJobResult, get_jinja_env
 from cnaas_nms.confpush.update import update_interfacedb_worker, update_linknets, set_facts
 from cnaas_nms.confpush.sync_devices import populate_device_vars, confcheck_devices, \
     sync_devices
@@ -88,7 +88,7 @@ def push_base_management(task, device_variables: dict, devtype: DeviceType, job_
     r = task.run(task=template_file,
                  name="Generate initial device config",
                  template=template,
-                 jinja_env=cnaas_jinja_env,
+                 jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
                  path=f"{local_repo_path}/{task.host.platform}",
                  **device_variables)
 
@@ -705,7 +705,7 @@ def set_hostname_task(task, new_hostname: str):
         task=template_file,
         name="Generate hostname config",
         template="hostname.j2",
-        jinja_env=cnaas_jinja_env,
+        jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
         path=f"{local_repo_path}/{task.host.platform}",
         **template_vars
     )

--- a/src/cnaas_nms/confpush/interface_state.py
+++ b/src/cnaas_nms/confpush/interface_state.py
@@ -4,7 +4,7 @@ import yaml
 from nornir_napalm.plugins.tasks import napalm_configure, napalm_get
 from nornir_jinja2.plugins.tasks import template_file
 
-from cnaas_nms.confpush.nornir_helper import cnaas_init, cnaas_jinja_env
+from cnaas_nms.confpush.nornir_helper import cnaas_init, get_jinja_env
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.db.session import sqla_session
@@ -67,7 +67,7 @@ def bounce_task(task, interfaces: List[str]):
         task=template_file,
         name="Generate port bounce down config",
         template="bounce-down.j2",
-        jinja_env=cnaas_jinja_env,
+        jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
         path=f"{local_repo_path}/{task.host.platform}",
         **template_vars
     )
@@ -82,7 +82,7 @@ def bounce_task(task, interfaces: List[str]):
         task=template_file,
         name="Generate port bounce up config",
         template="bounce-up.j2",
-        jinja_env=cnaas_jinja_env,
+        jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
         path=f"{local_repo_path}/{task.host.platform}",
         **template_vars
     )

--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -27,7 +27,7 @@ class RelativeJinjaEnvironment(JinjaEnvironment):
         return os.path.join(os.path.dirname(parent), template)
 
 
-@lru_cache
+@lru_cache(maxsize=8)
 def get_jinja_env(path):
     jinja_env = RelativeJinjaEnvironment(
         trim_blocks=True,

--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple, List, Union
+from functools import lru_cache
 import os
 
 from nornir import InitNornir
@@ -7,7 +8,7 @@ from nornir.core import Nornir
 from nornir.core.task import AggregatedResult, MultiResult
 from nornir.core.filter import F
 from nornir.core.plugins.inventory import InventoryPluginRegister
-from jinja2 import Environment as JinjaEnvironment
+from jinja2 import Environment as JinjaEnvironment, FileSystemLoader
 
 from cnaas_nms.confpush.nornir_plugins.cnaas_inventory import CnaasInventory
 from cnaas_nms.scheduler.jobresult import JobResult
@@ -26,15 +27,18 @@ class RelativeJinjaEnvironment(JinjaEnvironment):
         return os.path.join(os.path.dirname(parent), template)
 
 
-cnaas_jinja_env = RelativeJinjaEnvironment(
-    trim_blocks=True,
-    lstrip_blocks=True,
-    keep_trailing_newline=True
-)
-
-cnaas_jinja_env.filters['increment_ip'] = jinja_filters.increment_ip
-cnaas_jinja_env.filters['isofy_ipv4'] = jinja_filters.isofy_ipv4
-cnaas_jinja_env.filters['ipv4_to_ipv6'] = jinja_filters.ipv4_to_ipv6
+@lru_cache
+def get_jinja_env(path):
+    jinja_env = RelativeJinjaEnvironment(
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        loader=FileSystemLoader(path),
+    )
+    jinja_env.filters['increment_ip'] = jinja_filters.increment_ip
+    jinja_env.filters['isofy_ipv4'] = jinja_filters.isofy_ipv4
+    jinja_env.filters['ipv4_to_ipv6'] = jinja_filters.ipv4_to_ipv6
+    return jinja_env
 
 
 def cnaas_init() -> Nornir:

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -10,7 +10,7 @@ from nornir_jinja2.plugins.tasks import template_file
 from nornir_utils.plugins.functions import print_result
 
 import cnaas_nms.db.helper
-from cnaas_nms.confpush.nornir_helper import cnaas_init, inventory_selector, cnaas_jinja_env
+from cnaas_nms.confpush.nornir_helper import cnaas_init, inventory_selector, get_jinja_env
 from cnaas_nms.db.session import sqla_session, redis_session
 from cnaas_nms.confpush.get import calc_config_hash
 from cnaas_nms.confpush.changescore import calculate_score
@@ -356,7 +356,7 @@ def push_sync_device(task, dry_run: bool = True, generate_only: bool = False,
     r = task.run(task=template_file,
                  name="Generate device config",
                  template=template,
-                 jinja_env=cnaas_jinja_env,
+                 jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
                  path=f"{local_repo_path}/{task.host.platform}",
                  **template_vars)
 


### PR DESCRIPTION
To fix issues where different threads try to access/modify the same jinjaenv with different paths, and also to accommodate for possible future change in nornir_jinja2 where you need to specify filesystem path for your own environments