### PR TITLE
api docker: Fix unhandled exception error in git_version

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -46,10 +46,12 @@ RUN chown -R www-data:www-data /tmp/devicecerts && \
 # Give permission for unittests
 RUN chown root:www-data /opt/cnaas/*.sh && \
     chmod g+rx /opt/cnaas/*.sh
-RUN chown -R www-data:www-data /opt/cnaas/venv/cnaas-nms/src/
+RUN chown -R www-data:www-data /opt/cnaas/venv/
 
 # Branch specific, don't cache
 ADD "https://api.github.com/repos/SUNET/cnaas-nms/git/refs/heads/" latest_commit
+
+USER www-data
 RUN /opt/cnaas/cnaas-setup-branch.sh $BUILDBRANCH
 
 

--- a/docker/api/cnaas-setup-branch.sh
+++ b/docker/api/cnaas-setup-branch.sh
@@ -8,5 +8,6 @@ if [ "$1" != "develop" ] ; then
 	cd /opt/cnaas/venv/cnaas-nms/
 	git fetch --all
 	git checkout --track origin/$1
+	source /opt/cnaas/venv/bin/activate
 	python3 -m pip install -r requirements.txt
 fi


### PR DESCRIPTION
#181 describes that the git version cannot be determined because of file system permissions on the `.git/` directory (when using the default docker-compose setup).

To remedy this,

- www-data is granted ownership of all of /opt/cnaas/venv/ (this includes the .git directory, and allows package installs via pip as www-data)
- the cnaas-setup-branch script is run as www-data, not root (to avoid messing up permissions)
- the venv is activated when installing requirements via cnaas-setup-branch script (to avoid installing the requirements into the user's homedir)