### PR TITLE
Cleanup the dhcpd container's docker config

### DIFF
--- a/docker/dhcpd/Dockerfile
+++ b/docker/dhcpd/Dockerfile
@@ -1,15 +1,15 @@
 FROM debian:buster
-ARG BUILDBRANCH
-ARG GITREPO_BASE
 
 RUN mkdir -p /opt/cnaas \
     && mkdir /etc/cnaas-nms
 
-COPY cnaas-setup.sh dhcp-hook.sh dhcpd.sh dhcpd.conf /opt/cnaas/
-RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
-
 COPY apiclient.yml /etc/cnaas-nms/apiclient.yml
 COPY config/supervisord_app.conf /etc/supervisor/supervisord.conf
+COPY cnaas-setup.sh dhcp-hook.sh dhcpd.sh dhcpd.conf /opt/cnaas/
+
+ARG BUILDBRANCH
+ARG GITREPO_BASE
+RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 
 EXPOSE 67/udp
 

--- a/docker/dhcpd/Dockerfile
+++ b/docker/dhcpd/Dockerfile
@@ -2,17 +2,14 @@ FROM debian:buster
 ARG BUILDBRANCH
 ARG GITREPO_BASE
 
-RUN mkdir -p /opt/cnaas
-RUN mkdir /etc/cnaas-nms
+RUN mkdir -p /opt/cnaas \
+    && mkdir /etc/cnaas-nms
 
-COPY cnaas-setup.sh /opt/cnaas/cnaas-setup.sh
+COPY cnaas-setup.sh dhcp-hook.sh dhcpd.sh dhcpd.conf /opt/cnaas/
 RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 
-COPY dhcp-hook.sh /opt/cnaas/dhcp-hook.sh
 COPY apiclient.yml /etc/cnaas-nms/apiclient.yml
 COPY config/supervisord_app.conf /etc/supervisor/supervisord.conf
-COPY dhcpd.sh /opt/cnaas/dhcpd.sh
-COPY dhcpd.conf /opt/cnaas/dhcpd.conf
 
 EXPOSE 67/udp
 

--- a/docker/dhcpd/Dockerfile
+++ b/docker/dhcpd/Dockerfile
@@ -9,7 +9,6 @@ COPY cnaas-setup.sh /opt/cnaas/cnaas-setup.sh
 RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 
 COPY dhcp-hook.sh /opt/cnaas/dhcp-hook.sh
-COPY db_config.yml /etc/cnaas-nms/db_config.yml
 COPY apiclient.yml /etc/cnaas-nms/apiclient.yml
 COPY config/supervisord_app.conf /etc/supervisor/supervisord.conf
 COPY dhcpd.sh /opt/cnaas/dhcpd.sh

--- a/docker/dhcpd/db_config.yml
+++ b/docker/dhcpd/db_config.yml
@@ -1,7 +1,0 @@
-type: postgresql
-hostname: cnaas_postgres
-port: 5432
-username: cnaas
-password: cnaas
-database: cnaas
-redis_hostname: cnaas_redis

--- a/docker/dhcpd/dhcpd.sh
+++ b/docker/dhcpd/dhcpd.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-sed -e "s/^\(password: \).\+$/\1 $DB_PASSWORD/" \
-    -e "s/^\(hostname: \).\+$/\1 $DB_HOSTNAME/" \
-    -e "s/^\(mongo_hostname: \).\+$/\1 $MONGODB_HOSTNAME/" \
-  < /etc/cnaas-nms/db_config.yml > db_config.yml.new \
-  && mv -f db_config.yml.new /etc/cnaas-nms/db_config.yml
-
 if [ ! -z "$GITREPO_ETC" ]
 then
 	cd /opt/cnaas


### PR DESCRIPTION
This PR will

1. Remove lingering database config that is outdated as per 500124b
2. Reduce the number of layers on the Dockerfile 
      by consolidating RUN and COPY commands where possible.

      This is following common [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) and should slightly improve build times for dev+prod containers.
3. Improve build cache use
    by ordering the layers in a meaningful way: 
     - 'static' steps with little change potential first
     - moving the ARG directives down in the file, as they will invalidate subsequent RUN commands if ARG values change.

    This is motivated by the fact that in our dev environment, we rebuild containers a lot -- and smart caching can save a lot of time.

Mind that 2) and 3) do not make any changes to the executed commands -- differences are only in the ordering and combination.