### PR TITLE
postgres docker: Consolidate COPY command

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,5 @@
 FROM postgres:11
 
-COPY nms.sql /docker-entrypoint-initdb.d/
-RUN chown postgres:postgres /docker-entrypoint-initdb.d/*.sql
+COPY --chown=postgres:postgres nms.sql /docker-entrypoint-initdb.d/
 
 EXPOSE 5432


### PR DESCRIPTION
Rather diminutive change, mostly to keep the Dockerfiles consistent after #185 

`nms.sql` is the only file `COPY`ed here, so it can be chown'ed while `COPY`ing.
(Also, checked to make sure that there are no further *.sql files in that directory that we might skip.)