### PR TITLE
Add section on env vars to config doc

### DIFF
--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -1,21 +1,21 @@
 Configuration
 =============
 
+CNaaS NMS relies on configuration files and environment variables for configuration.
+
 Config files
 ------------
 
 Config files are placed in /etc/cnaas-nms
 
-If you run the docker container version some of these configuration options will
-be set by environment variables at startup.
 
 /etc/cnaas-nms/db_config.yml
-----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Defines how to connect to the SQL and redis databases.
 
 /etc/cnaas-nms/api.yml
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 Defines parameters for the API:
 
@@ -31,6 +31,51 @@ Defines parameters for the API:
 - allow_apply_config_liverun: Allow liverun on apply_config API call. Defaults to False.
 
 /etc/cnaas-nms/repository.yml
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Defines paths to git repositories.
+
+Environment variables
+---------------------
+
+Besides config files, cnaas-nms uses environment variables for configuration.
+The environment variables are typically set using docker-compose.
+
+Docker-compose will spin up a multi container environment including the
+CNaaS NMS API, httpd and dhcp server, postgresql, redis and the JWT auth server.
+
+There are various ways to set environment variables in docker-compose.
+The most common one is the ``docker-compose.yml`` file.
+
+A list of the environment variables used by each Docker container:
+
+cnaas_api
+
+- ``GITREPO_TEMPLATES`` -- templates git repository
+- ``GITREPO_SETTINGS`` -- settings git repository
+- ``COVERAGE`` -- calculate test coverage. 1 or 0 (yes or no)
+- ``USERNAME_DHCP_BOOT`` -- user name to log into devices during DHCP boot process
+- ``PASSWORD_DHCP_BOOT``
+- ``USERNAME_DISCOVERED`` -- user name for discovered devices
+- ``PASSWORD_DISCOVERED``
+- ``USERNAME_INIT`` -- user name for initialised devices
+- ``PASSWORD_INIT``
+- ``USERNAME_MANAGED`` -- user name for managed devices
+- ``PASSWORD_MANAGED``
+
+cnaas_httpd
+
+- ``GITREPO_TEMPLATES`` -- templates git repository
+
+cnaas_dhcpd
+
+- ``GITREPO_ETC`` -- git repository containing dhcpd config
+- ``DB_PASSWORD`` -- database password
+- ``DB_HOSTNAME`` -- database host
+- ``JWT_AUTH_TOKEN`` --  token to authenticate against the cnaas-nms REST API
+
+cnaas_postgres
+
+- ``POSTGRES_USER`` -- database username
+- ``POSTGRES_PASSWORD`` -- database password
+- ``POSTGRES_DB`` -- name of the cnaas-nms database


### PR DESCRIPTION
I added documentation for using environment variables to configure CNaaS NMS.
Also, slight reformatting of existing documentation was necessary (headlines).