### PR TITLE
Increase QueuePool max_overflow

### DIFF
--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -33,7 +33,7 @@ def get_sqlalchemy_conn_str(**kwargs) -> str:
 
 
 conn_str = get_sqlalchemy_conn_str()
-engine = create_engine(conn_str, pool_size=50, max_overflow=0)
+engine = create_engine(conn_str, pool_size=50, max_overflow=50)
 connection = engine.connect()
 Session = sessionmaker(bind=engine)
 


### PR DESCRIPTION
Try increasing max_overflow from 0 to 50 to avoid sqlalchemy.exc.TimeOutError when syncing many devices