### PR TITLE
Settings for route leaking [template update optional]

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -73,6 +73,7 @@ RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 # Freeze source
 USER root
 RUN chown -R root:www-data /opt/cnaas/venv/cnaas-nms/ && chmod -R u=rwX,g=rX,o= /opt/cnaas/venv/cnaas-nms/
+USER www-data
 
 # Prepare for uwsgi
 COPY --chown=root:www-data config/uwsgi.ini /opt/cnaas/venv/cnaas-nms/

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -71,7 +71,8 @@ ADD "https://api.github.com/repos/SUNET/cnaas-nms/git/refs/heads/" latest_commit
 # Cnaas setup script
 RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 # Freeze source
-RUN -R chown root:www-data /opt/cnaas/venv/cnaas-nms/ && chmod -R u=rwX,g=rX,o= /opt/cnaas/venv/cnaas-nms/
+USER root
+RUN chown -R root:www-data /opt/cnaas/venv/cnaas-nms/ && chmod -R u=rwX,g=rX,o= /opt/cnaas/venv/cnaas-nms/
 
 # Prepare for uwsgi
 COPY --chown=root:www-data config/uwsgi.ini /opt/cnaas/venv/cnaas-nms/

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -168,6 +168,14 @@ Can contain the following dictionaries with specified keys:
   * vrf_id: An integer between 1-65535. This ID can be used to generate unique VNI, RD and RT
     values for this VRF.
   * groups: A list of groups this VRF should be provisioned on.
+  * import_route_targets: A list of strings containing extra route targets to import
+    for route leaking (optional)
+  * export_route_targets: A list of strings containing extra route targets to export
+    for route leaking (optional)
+  * import_policy: A string containing route policy/route map to define import
+    behavior, useful in route leaking scenarios (optional)
+  * export_policy: A string containing route policy/route map to define export
+    behavior, useful in route leaking scenarios (optional)
 
 * extroute_static:
 
@@ -203,6 +211,7 @@ Can contain the following dictionaries with specified keys:
 
     * name: Name of the VRF
     * local_as: AS number that CNaaS NMS devices will present themselves as
+    * cli_append_str: Custom configuration to append to BGP VRF config (optional)
     * neighbor_v4:
 
       * peer_as: AS number the remote peer

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -116,6 +116,10 @@ class f_interface(BaseModel):
 class f_vrf(BaseModel):
     name: str = None
     vrf_id: int = vrf_id_schema
+    import_route_targets: List[str] = []
+    export_route_targets: List[str] = []
+    import_policy: Optional[str] = None
+    export_policy: Optional[str] = None
     groups: List[str] = []
 
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -199,6 +199,7 @@ class f_extroute_bgp_vrf(BaseModel):
     local_as: int = as_num_schema
     neighbor_v4: List[f_extroute_bgp_neighbor_v4] = []
     neighbor_v6: List[f_extroute_bgp_neighbor_v6] = []
+    cli_append_str: str = ""
 
 
 class f_extroute_bgp(BaseModel):

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -224,8 +224,20 @@ class GetTests(unittest.TestCase):
         self.assertEqual(type(auto_job1['next_job_id']), int, "No auto-push commit job found")
         self.check_jobid(auto_job1['next_job_id'])
 
+    def test_05_update_facts_dist(self):
+        hostname = "eosdist1"
+        r = requests.post(
+            f'{URL}/api/v1.0/device_update_facts',
+            headers=AUTH_HEADER,
+            json={"hostname": hostname},
+            verify=TLS_VERIFY
+        )
+        self.assertEqual(r.status_code, 200, "Failed to do update facts for dist")
+        update_facts_job_id = r.json()['job_id']
+        job = self.check_jobid(update_facts_job_id)
+        self.assertIn("diff", job['result'])
 
-    def test_05_syncto_dist(self):
+    def test_06_syncto_dist(self):
         r = requests.post(
             f'{URL}/api/v1.0/device_syncto',
             headers=AUTH_HEADER,
@@ -235,7 +247,7 @@ class GetTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, "Failed to do sync_to dist")
         self.check_jobid(r.json()['job_id'])
 
-    def test_06_genconfig(self):
+    def test_07_genconfig(self):
         r = requests.get(
             f'{URL}/api/v1.0/device/eosdist1/generate_config',
             headers=AUTH_HEADER,
@@ -243,7 +255,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to generate config for eosdist1")
 
-    def test_07_plugins(self):
+    def test_08_plugins(self):
         r = requests.get(
             f'{URL}/api/v1.0/plugins',
             headers=AUTH_HEADER,
@@ -259,7 +271,7 @@ class GetTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, "Failed to run plugin selftests")
 
-    def test_08_firmware(self):
+    def test_09_firmware(self):
         r = requests.get(
             f'{URL}/api/v1.0/firmware',
             headers=AUTH_HEADER,
@@ -268,14 +280,14 @@ class GetTests(unittest.TestCase):
         # TODO: not working
         self.assertEqual(r.status_code, 200, "Failed to list firmware")
 
-    def test_09_sysversion(self):
+    def test_10_sysversion(self):
         r = requests.get(
             f'{URL}/api/v1.0/system/version',
             verify=TLS_VERIFY
         )
         self.assertEqual(r.status_code, 200, "Failed to get CNaaS-NMS version")
 
-    def test_10_get_prev_config(self):
+    def test_11_get_prev_config(self):
         hostname = "eosaccess"
         r = requests.get(
             f"{URL}/api/v1.0/device/{hostname}/previous_config?previous=0",
@@ -300,19 +312,6 @@ class GetTests(unittest.TestCase):
         restore_job_id = r.json()['job_id']
         job = self.check_jobid(restore_job_id)
         self.assertFalse(job['result']['devices'][hostname]['failed'])
-
-    def test_11_update_facts_dist(self):
-        hostname = "eosdist1"
-        r = requests.post(
-            f'{URL}/api/v1.0/device_update_facts',
-            headers=AUTH_HEADER,
-            json={"hostname": hostname},
-            verify=TLS_VERIFY
-        )
-        self.assertEqual(r.status_code, 200, "Failed to do update facts for dist")
-        update_facts_job_id = r.json()['job_id']
-        job = self.check_jobid(update_facts_job_id)
-        self.assertIn("diff", job['result'])
 
     def test_12_abort_running_job(self):
         data = {


### PR DESCRIPTION
Example template:
```
diff --git a/eos/dist-bgp.j2 b/eos/dist-bgp.j2
index 8864cd2..8d8d5a0 100644
--- a/eos/dist-bgp.j2
+++ b/eos/dist-bgp.j2
@@ -48,6 +48,18 @@ router bgp {{ asn }}
   rd {{ infra_ip }}:{{ vrf.vrf_id }}
   route-target export evpn 2:{{ vrf.vrf_id }}
   route-target import evpn 2:{{ vrf.vrf_id }}
+  {% for export_route_target in vrf.export_route_targets %}
+  route-target export evpn {{ export_route_target }}
+  {% endfor %}
+  {% for import_route_target in vrf.import_route_targets %}
+  route-target import evpn {{ import_route_target }}
+  {% endfor %}
+  {% if (vrf.export_policy is defined) and vrf.export_policy %}
+  route-target export evpn route-map {{ vrf.export_policy }}
+  {% endif %}
+  {% if (vrf.import_policy is defined) and vrf.import_policy %}
+  route-target import evpn route-map {{ vrf.import_policy }}
+  {% endif %}
   redistribute connected
   redistribute static
```