### PR TITLE
Filter job results via API

### DIFF
--- a/docs/apiref/jobs.rst
+++ b/docs/apiref/jobs.rst
@@ -86,9 +86,27 @@ The result will look like this:
     }
   }
 
+It is possible to filter out specific jobs by using query parameters in the
+same way as the devices API. In addition to filtering out entries you can also
+filter out parts of the job result for "syncto" type jobs, if you are only
+interested in the diffs and don't want to see the full generated config for
+example:
+
+::
+
+   curl "http://hostname/api/v1.0/jobs?filter\[function.name\]\[contains\]=sync&filter_jobresult=config"
+
 The finished_devices attribute will be populated as devices are finishing.
 This value will only be updated for every other second to not keep
 the database too busy.
+
+It's also possible to query a single job by job ID:
+
+::
+
+   curl http://hostname/api/v1.0/job/5
+
+
 
 Locks
 -----

--- a/src/cnaas_nms/api/jobs.py
+++ b/src/cnaas_nms/api/jobs.py
@@ -38,7 +38,9 @@ def filter_job_dict(job_dict: dict, args: dict) -> dict:
         }
     }
     filter_items = []
-    if "result" not in job_dict or "devices" not in job_dict["result"]:
+    if not isinstance(job_dict, dict) or "result" not in job_dict or \
+            not isinstance(job_dict["result"], dict) or "devices" not in job_dict["result"] or \
+            "function_name" not in job_dict or not isinstance(job_dict["function_name"], str):
         return job_dict
 
     if job_dict["function_name"].startswith("sync_devices"):

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -47,6 +47,23 @@ class ApiTests(unittest.TestCase):
         # Exactly one result
         self.assertEqual(len(result.json['data']['jobs']), 1)
 
+    def test_filter_job(self):
+        result = self.client.get('/api/v1.0/jobs?filter[function.name][contains]=sync&filter_jobresult=config')
+
+        # 200 OK
+        self.assertEqual(result.status_code, 200)
+        # Succes in json
+        self.assertEqual(result.json['status'], 'success')
+        # At least one result
+        self.assertGreaterEqual(len(result.json['data']['jobs']), 1, "No jobs found")
+        # Exactly 2 task results
+        first_device_result = next(iter(result.json['data']['jobs'][0]['result']['devices'].values()))
+        self.assertEqual(len(first_device_result['job_tasks']), 2,
+                         "Job result output should only contain 2 tasks")
+        self.assertEqual(len(list(filter(lambda x: x["task_name"] != "Generate device config",
+                                         first_device_result['job_tasks']))),
+                         2, "Job result included 'Generate device config' task")
+
     def test_get_managementdomain(self):
         result = self.client.get('/api/v1.0/mgmtdomains?per_page=1')
         # 200 OK


### PR DESCRIPTION
...you can also filter out parts of the job result for "syncto" type jobs, if you are only
interested in the diffs and don't want to see the full generated config for
example:
```curl "http://hostname/api/v1.0/jobs?filter\[function.name\]\[contains\]=sync&filter_jobresult=config"```