### PR TITLE
[WIP/fragment] Uninett: compose override for tests

### DIFF
--- a/docker/api/nosetests.sh
+++ b/docker/api/nosetests.sh
@@ -5,15 +5,6 @@ source venv/bin/activate
 
 cd venv/cnaas-nms/src
 
-export USERNAME_DHCP_BOOT="admin"
-export PASSWORD_DHCP_BOOT="abc123abc123"
-export USERNAME_DISCOVERED="admin"
-export PASSWORD_DISCOVERED="abc123abc123"
-export USERNAME_INIT="admin"
-export PASSWORD_INIT="abc123abc123"
-export USERNAME_MANAGED="admin"
-export PASSWORD_MANAGED="abc123abc123"
-
 nosetests --collect-only --with-id -v
 nosetests --with-coverage --cover-package=cnaas_nms -v
 cp .coverage /coverage/.coverage-nosetests

--- a/docker/docker-compose.tests.yaml
+++ b/docker/docker-compose.tests.yaml
@@ -42,3 +42,24 @@ services:
       - DB_PASSWORD=cnaas
       - DB_HOSTNAME=docker_cnaas_postgres_1
       - JWT_AUTH_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw
+
+
+  #
+  # Databases
+  #
+
+  cnaas_postgres:
+    volumes:
+      - cnaas-postgres-test-data:/var/lib/postgresql/data
+
+volumes:
+  cnaas-templates:
+    external: false
+  cnaas-settings:
+    external: false
+  cnaas-postgres-test-data:
+    external: false
+  cnaas-jwtcert:
+    external: false
+  cnaas-cacert:
+    external: false

--- a/docker/docker-compose.tests.yaml
+++ b/docker/docker-compose.tests.yaml
@@ -1,0 +1,44 @@
+version: '3.7'
+services:
+
+  #
+  # CNaaS services -- test setup
+  #
+
+  cnaas_api:
+    environment:
+      - GITREPO_TEMPLATES=git://gitops.sunet.se/cnaas-lab-templates
+      - GITREPO_SETTINGS=git://gitops.sunet.se/cnaas-lab-settings
+      - COVERAGE=1
+      - USERNAME_DHCP_BOOT=admin
+      - PASSWORD_DHCP_BOOT=abc123abc123
+      - USERNAME_DISCOVERED=admin
+      - PASSWORD_DISCOVERED=abc123abc123
+      - USERNAME_INIT=admin
+      - PASSWORD_INIT=abc123abc123
+      - USERNAME_MANAGED=admin
+      - PASSWORD_MANAGED=abc123abc123
+    volumes:
+      - type: bind
+        source: ./coverage
+        target: /coverage
+
+  cnaas_httpd:
+    environment:
+      - GITREPO_TEMPLATES=git://gitops.sunet.se/cnaas-lab-templates
+
+  cnaas_dhcpd:
+    build:
+      context: ./dhcpd/
+      args:
+        - BUILDBRANCH=develop
+        - GITREPO_BASE=https://github.com/SUNET/cnaas-nms.git
+    ports:
+      - 67:67/udp
+    networks:
+      - cnaas
+    environment:
+      - GITREPO_ETC=https://github.com/indy-independence/cnaas-nms-lab-etc.git
+      - DB_PASSWORD=cnaas
+      - DB_HOSTNAME=docker_cnaas_postgres_1
+      - JWT_AUTH_TOKEN=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -21,12 +21,6 @@ then
 	fi
 fi
 
-docker volume create cnaas-templates
-docker volume create cnaas-settings
-docker volume create cnaas-postgres-data
-docker volume create cnaas-jwtcert
-docker volume create cnaas-cacert
-
 docker-compose -f docker-compose.yaml -f docker-compose.tests.yaml up -d
 
 docker cp ./jwt-cert/public.pem docker_cnaas_api_1:/opt/cnaas/jwtcert/public.pem

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -5,20 +5,6 @@ cd ../docker/
 # if running selinux on host this is required: chcon -Rt svirt_sandbox_file_t coverage/
 mkdir -p coverage/
 
-export GITREPO_TEMPLATES="git://gitops.sunet.se/cnaas-lab-templates"
-export GITREPO_SETTINGS="git://gitops.sunet.se/cnaas-lab-settings"
-export GITREPO_ETC="https://github.com/indy-independence/cnaas-nms-lab-etc.git"
-export USERNAME_DHCP_BOOT="admin"
-export PASSWORD_DHCP_BOOT="abc123abc123"
-export USERNAME_DISCOVERED="admin"
-export PASSWORD_DISCOVERED="abc123abc123"
-export USERNAME_INIT="admin"
-export PASSWORD_INIT="abc123abc123"
-export USERNAME_MANAGED="admin"
-export PASSWORD_MANAGED="abc123abc123"
-export COVERAGE=1
-export JWT_AUTH_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw"
-
 docker-compose down
 
 if docker volume ls | egrep -q "cnaas-postgres-data$"
@@ -41,7 +27,7 @@ docker volume create cnaas-postgres-data
 docker volume create cnaas-jwtcert
 docker volume create cnaas-cacert
 
-docker-compose up -d
+docker-compose -f docker-compose.yaml -f docker-compose.tests.yaml up -d
 
 docker cp ./jwt-cert/public.pem docker_cnaas_api_1:/opt/cnaas/jwtcert/public.pem
 docker-compose exec -u root -T cnaas_api /bin/chown -R www-data:www-data /opt/cnaas/jwtcert/


### PR DESCRIPTION
Basic idea:

Using a compose override file to set the environment variables for integration testing, instead of setting them in a shell script.
This keeps test logic and environment separate.

Plus: Creating the volumes as non-external will create them automatically (if they do not exist) and prevent them from interfering with other docker-instances on the same machine. The scope of a non-external volume is the compose-file it is defined in.