### PR TITLE
Add killall to API container again

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
       python3-venv \
       python3-wheel \
       python3-yaml \
+      psmisc \
       supervisor \
       uwsgi-plugin-python3 \
     && pip3 install --no-cache-dir uwsgi


### PR DESCRIPTION
The `killall` command is not available on the API container any longer as a side effect of 224a3a2d32f1f9298a59ff31ad6de2b740d97966

However, `killall` is good to have, and it's useful in many cases. (E.g., if you add a new public key or manually switch to a new git branch on the API container.)

So we add it again. It's part of the psmisc debian package.

Also see this comment https://github.com/SUNET/cnaas-front/pull/70#discussion_r719267726
in SUNET/cnaas-front#70
The instructions for setting up the dev environment for the frontend rely on the command.