### PR TITLE
Make TEMPLATE_SECRET_* variables also available as a dict

### DIFF
--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -15,6 +15,7 @@ from cnaas_nms.confpush.nornir_helper import cnaas_init, inventory_selector, get
 from cnaas_nms.db.session import sqla_session, redis_session
 from cnaas_nms.confpush.get import calc_config_hash
 from cnaas_nms.confpush.changescore import calculate_score
+from cnaas_nms.tools.jinja_helpers import get_environment_secrets
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.settings import get_settings
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
@@ -316,10 +317,7 @@ def populate_device_vars(session, dev: Device,
     # Add all environment variables starting with TEMPLATE_SECRET_ to
     # the list of configuration variables. The idea is to store secret
     # configuration outside of the templates repository.
-    template_secrets = {}
-    for env in os.environ:
-        if env.startswith('TEMPLATE_SECRET_'):
-            template_secrets[env] = os.environ[env]
+    template_secrets = get_environment_secrets()
     # Merge all dicts with variables into one, later row overrides
     # Device variables override any names from settings, for example the
     # interfaces list from settings are replaced with an interface list from

--- a/src/cnaas_nms/tools/jinja_helpers.py
+++ b/src/cnaas_nms/tools/jinja_helpers.py
@@ -5,5 +5,9 @@ import os
 def get_environment_secrets(prefix="TEMPLATE_SECRET_"):
     """Returns a dictionary of secrets stored in environment variables"""
     template_secrets = {env: value for env, value in os.environ.items() if env.startswith(prefix)}
+    # Also make secrets available as a dict, so keys can be constructed dynamically in templates
+    template_secrets["TEMPLATE_SECRET"] = {
+        env.replace(prefix, ""): value for env, value in template_secrets.items()
+    }
 
     return template_secrets

--- a/src/cnaas_nms/tools/jinja_helpers.py
+++ b/src/cnaas_nms/tools/jinja_helpers.py
@@ -1,0 +1,9 @@
+"""Functions that aid in the building of Jinja template contexts"""
+import os
+
+
+def get_environment_secrets(prefix="TEMPLATE_SECRET_"):
+    """Returns a dictionary of secrets stored in environment variables"""
+    template_secrets = {env: value for env, value in os.environ.items() if env.startswith(prefix)}
+
+    return template_secrets

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -3,6 +3,9 @@
 import sys
 import os
 import argparse
+
+from jinja_helpers import get_environment_secrets
+
 try:
     import requests
     import jinja2
@@ -74,11 +77,7 @@ def render_template(platform, device_type, variables):
     for f in jfilters:
         jinjaenv.filters[f] = jfilters[f]
     print("Jinja filters added: {}".format([*jfilters]))
-    template_secrets = {}
-    for env in os.environ:
-        if env.startswith('TEMPLATE_SECRET_'):
-            template_secrets[env] = os.environ[env]
-    template_vars = {**variables, **template_secrets}
+    template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))
     return template.render(**template_vars)
 

--- a/src/cnaas_nms/tools/tests/test_jinja_helpers.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_helpers.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+
+from cnaas_nms.tools.jinja_helpers import get_environment_secrets
+
+
+class EnvironmentSecretsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ['TEMPLATE_SECRET_FOO'] = 'bar'
+        os.environ['TEMPLATE_SECRET_TEST_TYPE'] = 'cromulent'
+        os.environ['NOT_A_SECRET'] = 'foobar'
+
+    def tearDown(self) -> None:
+        del os.environ['TEMPLATE_SECRET_FOO']
+        del os.environ['TEMPLATE_SECRET_TEST_TYPE']
+        del os.environ['NOT_A_SECRET']
+
+    def test_that_individual_secrets_are_present(self):
+        secrets = get_environment_secrets()
+        self.assertEquals(secrets['TEMPLATE_SECRET_FOO'], 'bar')
+        self.assertEquals(secrets['TEMPLATE_SECRET_TEST_TYPE'], 'cromulent')
+
+    def test_that_secret_dict_is_set_properly(self):
+        secrets = get_environment_secrets()
+        self.assertIn('TEMPLATE_SECRET', secrets)
+
+        secret_dict = secrets.get('TEMPLATE_SECRET')
+        self.assertEquals(secret_dict['FOO'], 'bar')
+        self.assertEquals(secret_dict['TEST_TYPE'], 'cromulent')
+
+    def test_that_non_secret_variables_arent_included(self):
+        secrets = get_environment_secrets()
+        self.assertNotIn('NOT_A_SECRET', secrets)


### PR DESCRIPTION
An identified use case of ours is to be able to configure one or more TACACS+ servers in a host list. Each TACACS+ server may have a unique secret key. Since these are considered secrets, they should not be in the settings files, but exported to the CNaaS-NMS environment.

Environment variables are generally a flat structure, so the best way to map such a secret env var to a host is to include the host's IP address or name as part of the environment variable. However, the template will not be able to know the name of the variable until runtime, so the name needs to be constructed dynamically. Jinja does not allow this.

However, if the secrets are also made available as a dictionary variable in the context, the dict keys *can* be constructed manually.

This PR sets out to make TEMPLATE_SECRET variables accessible in the Jinja contexts as a dict, in addition to being top-level variables (which is kept in to retain backwards compatibility).

Secondarily, to achieve this, the code that builds the context was extracted into a re-usable function. Redundant code paths are updated to use the new function.


In effect, a secret exported to the environment as `TEMPLATE_SECRET_FOO` should be available to a template as both `{{ TEMPLATE_SECRET_FOO }}` *and* `{{ TEMPLATE_SECRET['FOO'] }}` (or even `{{ TEMPLATE_SECRET.FOO }}`)