### PR TITLE
Allow having two uplinks to stack

### DIFF
--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -103,18 +103,13 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
                 filter(Interface.configtype == InterfaceConfigType.ACCESS_DOWNLINK).all()
             if not intfs:
                 continue
-            try:
-                local_if = dev.get_neighbor_local_ifname(session, neighbor_d)
-                remote_if = neighbor_d.get_neighbor_local_ifname(session, dev)
-            except ValueError as e:
-                logger.debug("Ignoring possible uplinks to neighbor {}: {}".format(
-                    neighbor_d.hostname, e))
-                continue
-
-            intf: Interface
-            for intf in intfs:
-                if intf.name == remote_if:
-                    uplinks[local_if] = neighbor_d.hostname
+            for linknet in dev.get_links_to(session, neighbor_d):
+                local_if = linknet.get_port(dev.id)
+                remote_if = linknet.get_port(neighbor_d.id)
+                intf: Interface
+                for intf in intfs:
+                    if intf.name == remote_if:
+                        uplinks[local_if] = neighbor_d.hostname
 
     logger.debug("Uplinks for device {} detected: {}".
                  format(hostname, ', '.join(["{}: {}".format(ifname, hostname)

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -93,13 +93,13 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
 
     for neighbor_d in neighbors:
         if neighbor_d.device_type == DeviceType.DIST:
-            local_if = dev.get_neighbor_local_ifname(session, neighbor_d)
-            # Neighbor interface ifclass is already verified in
-            # update_linknets -> verify_peer_iftype
-            if local_if:
+            for linknet in dev.get_links_to(session, neighbor_d):
+                local_if = linknet.get_port(dev.id)
+                # Neighbor interface ifclass is already verified in
+                # update_linknets -> verify_peer_iftype
                 uplinks[local_if] = neighbor_d.hostname
         elif neighbor_d.device_type == DeviceType.ACCESS:
-            intfs: Interface = session.query(Interface).filter(Interface.device == neighbor_d).\
+            intfs: List[Interface] = session.query(Interface).filter(Interface.device == neighbor_d).\
                 filter(Interface.configtype == InterfaceConfigType.ACCESS_DOWNLINK).all()
             if not intfs:
                 continue

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -235,26 +235,26 @@ def populate_device_vars(session, dev: Device,
         fabric_interfaces = {}
         for neighbor_d in dev.get_neighbors(session):
             if neighbor_d.device_type == DeviceType.DIST or neighbor_d.device_type == DeviceType.CORE:
-                # TODO: support multiple links to the same neighbor?
-                local_if = dev.get_neighbor_local_ifname(session, neighbor_d)
-                local_ipif = dev.get_neighbor_local_ipif(session, neighbor_d)
-                neighbor_ip = dev.get_neighbor_ip(session, neighbor_d)
-                if local_if:
-                    fabric_interfaces[local_if] = {
-                        'name': local_if,
-                        'ifclass': 'fabric',
-                        'ipv4if': local_ipif,
-                        'peer_hostname': neighbor_d.hostname,
-                        'peer_infra_lo': str(neighbor_d.infra_ip),
-                        'peer_ip': str(neighbor_ip),
-                        'peer_asn': generate_asn(neighbor_d.infra_ip)
-                    }
-                    fabric_device_variables['bgp_ipv4_peers'].append({
-                        'peer_hostname': neighbor_d.hostname,
-                        'peer_infra_lo': str(neighbor_d.infra_ip),
-                        'peer_ip': str(neighbor_ip),
-                        'peer_asn': generate_asn(neighbor_d.infra_ip)
-                    })
+                for linknet in dev.get_links_to(session, neighbor_d):
+                    local_if = linknet.get_port(dev.id)
+                    local_ipif = linknet.get_ipif(dev.id)
+                    neighbor_ip = linknet.get_ip(neighbor_d.id)
+                    if local_if:
+                        fabric_interfaces[local_if] = {
+                            'name': local_if,
+                            'ifclass': 'fabric',
+                            'ipv4if': local_ipif,
+                            'peer_hostname': neighbor_d.hostname,
+                            'peer_infra_lo': str(neighbor_d.infra_ip),
+                            'peer_ip': str(neighbor_ip),
+                            'peer_asn': generate_asn(neighbor_d.infra_ip)
+                        }
+                        fabric_device_variables['bgp_ipv4_peers'].append({
+                            'peer_hostname': neighbor_d.hostname,
+                            'peer_infra_lo': str(neighbor_d.infra_ip),
+                            'peer_ip': str(neighbor_ip),
+                            'peer_asn': generate_asn(neighbor_d.infra_ip)
+                        })
         ifname_peer_map = dev.get_linknet_localif_mapping(session)
         if 'interfaces' in settings and settings['interfaces']:
             for intf in settings['interfaces']:

--- a/src/cnaas_nms/db/linknet.py
+++ b/src/cnaas_nms/db/linknet.py
@@ -52,6 +52,27 @@ class Linknet(cnaas_nms.db.base.Base):
             d[col.name] = value
         return d
 
+    def get_port(self, device_id):
+        if device_id == self.device_a_id:
+            return self.device_a_port
+        if device_id == self.device_b_id:
+            return self.device_b_port
+        raise ValueError(f"The device_id {device_id} is not part of this linknet")
+
+    def get_ip(self, device_id):
+        if device_id == self.device_a_id:
+            return self.device_a_ip
+        if device_id == self.device_b_id:
+            return self.device_b_ip
+        raise ValueError(f"The device_id {device_id} is not part of this linknet")
+
+    def get_ipif(self, device_id):
+        if device_id == self.device_a_id:
+            return f"{self.device_a_ip}/{ipaddress.IPv4Network(self.ipv4_network).prefixlen}"
+        if device_id == self.device_b_id:
+            return f"{self.device_b_ip}/{ipaddress.IPv4Network(self.ipv4_network).prefixlen}"
+        raise ValueError(f"The device_id {device_id} is not part of this linknet")
+
     @staticmethod
     def deduplicate_linknet_dicts(linknets: List[dict]) -> List[dict]:
         """Take a list of dicts as returned from Device.get_linknets_as_dict


### PR DESCRIPTION
As a stack is still a single device, multiple links between devices must be supported to be able to have two uplinks to a stack.
Draft changes trying to figure out what needs to be changed/what restrictions should there be to make this work properly.

current changes mostly change some code that assume one interface per neighbor into allowing multiple interfaces and removing any related restrictions.