### PR TITLE
Add support for branch refspecs in Git repo urls

### DIFF
--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -83,3 +83,20 @@ cnaas_postgres
 - ``POSTGRES_USER`` -- database username
 - ``POSTGRES_PASSWORD`` -- database password
 - ``POSTGRES_DB`` -- name of the cnaas-nms database
+
+Git repository URLs
+-------------------
+
+All the options that point to various GIT repositories (``GITREPO_*``) support typical Git-compatible URLs, including,
+but not limited to:
+
+- ``ssh://user@host.xz:port/path/to/repo.git/``
+- ``https://host.xz/path/to/repo.git/``
+- ``git://host.xz/path/to/repo.git/``
+
+Additionally, specific commits or branches can be specified by adding a URL anchor containing a Git reference such as
+a branch name, tag or commit ID. Examples:
+
+- ``ssh://user@host.xz:port/path/to/repo.git/#stable``
+- ``https://host.xz/path/to/repo.git/#v1.2.3``
+- ``git://host.xz/path/to/repo.git/#2a8c7f6c6544dd438808ab1bec560115783a2f2a``


### PR DESCRIPTION
This will parse any fragment present in a Git repo url as a branch refspec, and make sure to clone that branch when the repo is first cloned.

I would have liked to add some unit tests for the new function, but I am unable to run said unit tests in isolation, because the existing code base carries the sad code smell of simple module imports causing **side-effects**: Just attempting to run the tests present in `cnaas_nms.db.tests.test_git` ultimately causes the `cnaas_nms.db.session` module to be imported, and this module tries to connect to a running database at import time. This problem should be fixed separately.

Fixes #222 