### PR TITLE
Make a re-usable Jinja filter registry

### DIFF
--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -36,9 +36,7 @@ def get_jinja_env(path):
         loader=FileSystemLoader(path),
         cache_size=0,
     )
-    jinja_env.filters['increment_ip'] = jinja_filters.increment_ip
-    jinja_env.filters['isofy_ipv4'] = jinja_filters.isofy_ipv4
-    jinja_env.filters['ipv4_to_ipv6'] = jinja_filters.ipv4_to_ipv6
+    jinja_env.filters.update(jinja_filters.FILTERS)
     return jinja_env
 
 

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -1,8 +1,30 @@
+"""Jinja filter functions for use in configuration templates"""
+
 import ipaddress
 import re
-from typing import Union
+from typing import Union, Optional, Callable
+
+# This global dict can be used to update the Jinja environment filters dict to include all
+# registered template filter function
+FILTERS = {}
 
 
+def template_filter(name: Optional[str] = None) -> Callable:
+    """Registers a template filter function in the FILTERS dict.
+
+    Args:
+        name: Optional alternative name to register the function as
+    """
+
+    def decorator(func):
+        name_ = name if name else func.__name__
+        FILTERS[name_] = func
+        return func
+
+    return decorator
+
+
+@template_filter()
 def increment_ip(ip_string, increment=1):
     """Increment an IP address by a given value. Default increment value is 1.
     Args:
@@ -31,6 +53,7 @@ def increment_ip(ip_string, increment=1):
         return format(ip + increment)
 
 
+@template_filter()
 def isofy_ipv4(ip_string, prefix=''):
     """Transform IPv4 address so it can be used as an ISO/NET address.
     All four blocks of the IP address are padded with zeros and split up into double octets.
@@ -61,6 +84,7 @@ def isofy_ipv4(ip_string, prefix=''):
     return iso_address
 
 
+@template_filter()
 def ipv4_to_ipv6(
     v6_network: Union[str, ipaddress.IPv6Network], v4_address: Union[str, ipaddress.IPv4Interface]
 ):

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -56,9 +56,7 @@ def get_device_details(hostname):
 def load_jinja_filters():
     try:
         import jinja_filters
-        jf = jinja_filters.__dict__
-        functions = {f: jf[f] for f in jf if callable(jf[f])}
-        return functions
+        return jinja_filters.FILTERS
     except ModuleNotFoundError:
         print('No jinja_filters.py file in PYTHONPATH, proceeding without filters')
         return {}
@@ -74,8 +72,7 @@ def render_template(platform, device_type, variables):
         keep_trailing_newline=True
     )
     jfilters = load_jinja_filters()
-    for f in jfilters:
-        jinjaenv.filters[f] = jfilters[f]
+    jinjaenv.filters.update(jfilters)
     print("Jinja filters added: {}".format([*jfilters]))
     template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))


### PR DESCRIPTION
Explicitly register all functions that should be made available as Jinja template filters during config runs. Use this registry explicitly in both production and in the template_dry_run.py script.

Flask already has a decorator to register template filter functions with the app, but since the Flask app framework is not being used to render configuration templates for devices, that was a no-go. 

This implements a bespoke decorator for this purpose. Any function that is decorated with `@template_filter()` will be added to the registry, and the Jinja environment will be populated with everything in the registry. 