### PR TITLE
Add Jinja filter to extract IP interface address from a network prefix

### DIFF
--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -36,9 +36,7 @@ def get_jinja_env(path):
         loader=FileSystemLoader(path),
         cache_size=0,
     )
-    jinja_env.filters['increment_ip'] = jinja_filters.increment_ip
-    jinja_env.filters['isofy_ipv4'] = jinja_filters.isofy_ipv4
-    jinja_env.filters['ipv4_to_ipv6'] = jinja_filters.ipv4_to_ipv6
+    jinja_env.filters.update(jinja_filters.FILTERS)
     return jinja_env
 
 

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -1,8 +1,30 @@
+"""Jinja filter functions for use in configuration templates"""
+
 import ipaddress
 import re
-from typing import Union
+from typing import Union, Optional, Callable
+
+# This global dict can be used to update the Jinja environment filters dict to include all
+# registered template filter function
+FILTERS = {}
 
 
+def template_filter(name: Optional[str] = None) -> Callable:
+    """Registers a template filter function in the FILTERS dict.
+
+    Args:
+        name: Optional alternative name to register the function as
+    """
+
+    def decorator(func):
+        name_ = name if name else func.__name__
+        FILTERS[name_] = func
+        return func
+
+    return decorator
+
+
+@template_filter()
 def increment_ip(ip_string, increment=1):
     """Increment an IP address by a given value. Default increment value is 1.
     Args:
@@ -31,6 +53,7 @@ def increment_ip(ip_string, increment=1):
         return format(ip + increment)
 
 
+@template_filter()
 def isofy_ipv4(ip_string, prefix=''):
     """Transform IPv4 address so it can be used as an ISO/NET address.
     All four blocks of the IP address are padded with zeros and split up into double octets.
@@ -61,6 +84,7 @@ def isofy_ipv4(ip_string, prefix=''):
     return iso_address
 
 
+@template_filter()
 def ipv4_to_ipv6(
     v6_network: Union[str, ipaddress.IPv6Network], v4_address: Union[str, ipaddress.IPv4Interface]
 ):

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -112,3 +112,24 @@ def ipv4_to_ipv6(
 
     v6_address = v6_network[int(v4_address)]
     return ipaddress.IPv6Interface(f"{v6_address}/{v6_network.prefixlen}")
+
+
+@template_filter()
+def get_interface(
+    network: Union[ipaddress.IPv6Interface, ipaddress.IPv4Interface, str], index: int
+) -> Union[ipaddress.IPv6Interface, ipaddress.IPv4Interface]:
+    """Returns a host address with a prefix length from its index in a network.
+
+    Example:
+    >>> get_interface("10.0.1.0/24", 2)
+    ipaddress.IPv4Interface("10.0.1.2/24")
+
+    Args:
+        network: Network in CIDR notation
+        index: The host address' index in the network prefix
+    """
+    if isinstance(network, str):
+        network = ipaddress.ip_network(network)
+
+    host = network[index]
+    return ipaddress.ip_interface(f"{host}/{network.prefixlen}")

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -56,9 +56,7 @@ def get_device_details(hostname):
 def load_jinja_filters():
     try:
         import jinja_filters
-        jf = jinja_filters.__dict__
-        functions = {f: jf[f] for f in jf if callable(jf[f])}
-        return functions
+        return jinja_filters.FILTERS
     except ModuleNotFoundError:
         print('No jinja_filters.py file in PYTHONPATH, proceeding without filters')
         return {}
@@ -74,8 +72,7 @@ def render_template(platform, device_type, variables):
         keep_trailing_newline=True
     )
     jfilters = load_jinja_filters()
-    for f in jfilters:
-        jinjaenv.filters[f] = jfilters[f]
+    jinjaenv.filters.update(jfilters)
     print("Jinja filters added: {}".format([*jfilters]))
     template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -1,7 +1,7 @@
 import ipaddress
 import unittest
 
-from cnaas_nms.tools.jinja_filters import increment_ip, isofy_ipv4, ipv4_to_ipv6
+from cnaas_nms.tools.jinja_filters import increment_ip, isofy_ipv4, ipv4_to_ipv6, get_interface
 
 
 class JinjaFilterTests(unittest.TestCase):
@@ -86,6 +86,24 @@ class IPv6ToIPv4Tests(unittest.TestCase):
     def test_should_return_an_ipv6interface(self):
         result = ipv4_to_ipv6('2001:700::/64', '10.0.0.1')
         self.assertIsInstance(result, ipaddress.IPv6Interface)
+
+
+class GetInterfaceTests(unittest.TestCase):
+    """Tests for the get_interface filter function"""
+
+    def test_should_return_correct_ipv4_interface(self):
+        self.assertEqual(get_interface('10.0.1.0/24', 2), ipaddress.IPv4Interface('10.0.1.2/24'))
+
+    def test_should_return_correct_ipv6_interface(self):
+        self.assertEqual(
+            get_interface('2001:700:dead:c0de::/64', 2),
+            ipaddress.IPv6Interface('2001:700:dead:c0de::2/64'),
+        )
+
+    def test_should_raise_on_invalid_network(self):
+        with self.assertRaises(ValueError):
+            invalid_network = '2001:700:0:::/64'
+            get_interface(invalid_network, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This  `get_interface` filter can be used to extract an indexed host address complete with a CIDR netmask from a network address variable.

This depends on #225, so keeping it as a draft until that can be merged