### PR TITLE
Add filter to calculate SHA256 checksum of a downloaded file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ nose==1.3.7
 pluggy==0.13.1
 psycopg2==2.8.6
 psycopg2-binary==2.8.6
+requests==2.26.0
 redis==3.5.3
 redis-lru==0.1.0
 Sphinx==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ flask-restx==0.2.0
 Flask-SocketIO==5.0.0
 gevent==20.9.0
 GitPython==3.1.11
+mock==4.0.3
 mypy==0.790
 mypy-extensions==0.4.3
 nornir==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.4.3
 APScheduler==3.6.3
+cachetools==4.2.4
 coverage==5.3
 Flask-Cors==3.0.9
 Flask-JWT-Extended==3.25.0

--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -36,9 +36,7 @@ def get_jinja_env(path):
         loader=FileSystemLoader(path),
         cache_size=0,
     )
-    jinja_env.filters['increment_ip'] = jinja_filters.increment_ip
-    jinja_env.filters['isofy_ipv4'] = jinja_filters.isofy_ipv4
-    jinja_env.filters['ipv4_to_ipv6'] = jinja_filters.ipv4_to_ipv6
+    jinja_env.filters.update(jinja_filters.FILTERS)
     return jinja_env
 
 

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -5,6 +5,7 @@ import ipaddress
 import re
 from typing import Union, Optional, Callable
 
+from cachetools import cached, TTLCache
 import requests
 
 # This global dict can be used to update the Jinja environment filters dict to include all
@@ -118,6 +119,7 @@ def ipv4_to_ipv6(
 
 
 @template_filter()
+@cached(cache=TTLCache(maxsize=128, ttl=300))
 def file_sha256sum(file_url: str) -> str:
     """Downloads a file from the internet and returns its sha256 checksum"""
     response = requests.get(file_url)

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -1,8 +1,30 @@
+"""Jinja filter functions for use in configuration templates"""
+
 import ipaddress
 import re
-from typing import Union
+from typing import Union, Optional, Callable
+
+# This global dict can be used to update the Jinja environment filters dict to include all
+# registered template filter function
+FILTERS = {}
 
 
+def template_filter(name: Optional[str] = None) -> Callable:
+    """Registers a template filter function in the FILTERS dict.
+
+    Args:
+        name: Optional alternative name to register the function as
+    """
+
+    def decorator(func):
+        name_ = name if name else func.__name__
+        FILTERS[name_] = func
+        return func
+
+    return decorator
+
+
+@template_filter()
 def increment_ip(ip_string, increment=1):
     """Increment an IP address by a given value. Default increment value is 1.
     Args:
@@ -31,6 +53,7 @@ def increment_ip(ip_string, increment=1):
         return format(ip + increment)
 
 
+@template_filter()
 def isofy_ipv4(ip_string, prefix=''):
     """Transform IPv4 address so it can be used as an ISO/NET address.
     All four blocks of the IP address are padded with zeros and split up into double octets.
@@ -61,6 +84,7 @@ def isofy_ipv4(ip_string, prefix=''):
     return iso_address
 
 
+@template_filter()
 def ipv4_to_ipv6(
     v6_network: Union[str, ipaddress.IPv6Network], v4_address: Union[str, ipaddress.IPv4Interface]
 ):

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -1,8 +1,11 @@
 """Jinja filter functions for use in configuration templates"""
 
+import hashlib
 import ipaddress
 import re
 from typing import Union, Optional, Callable
+
+import requests
 
 # This global dict can be used to update the Jinja environment filters dict to include all
 # registered template filter function
@@ -112,3 +115,11 @@ def ipv4_to_ipv6(
 
     v6_address = v6_network[int(v4_address)]
     return ipaddress.IPv6Interface(f"{v6_address}/{v6_network.prefixlen}")
+
+
+@template_filter()
+def file_sha256sum(file_url: str) -> str:
+    """Downloads a file from the internet and returns its sha256 checksum"""
+    response = requests.get(file_url)
+    checksum = hashlib.sha256(response.content)
+    return checksum.hexdigest()

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -56,9 +56,7 @@ def get_device_details(hostname):
 def load_jinja_filters():
     try:
         import jinja_filters
-        jf = jinja_filters.__dict__
-        functions = {f: jf[f] for f in jf if callable(jf[f])}
-        return functions
+        return jinja_filters.FILTERS
     except ModuleNotFoundError:
         print('No jinja_filters.py file in PYTHONPATH, proceeding without filters')
         return {}
@@ -74,8 +72,7 @@ def render_template(platform, device_type, variables):
         keep_trailing_newline=True
     )
     jfilters = load_jinja_filters()
-    for f in jfilters:
-        jinjaenv.filters[f] = jfilters[f]
+    jinjaenv.filters.update(jfilters)
     print("Jinja filters added: {}".format([*jfilters]))
     template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -1,7 +1,9 @@
 import ipaddress
 import unittest
 
-from cnaas_nms.tools.jinja_filters import increment_ip, isofy_ipv4, ipv4_to_ipv6
+from mock import Mock, patch
+
+from cnaas_nms.tools.jinja_filters import increment_ip, isofy_ipv4, ipv4_to_ipv6, file_sha256sum
 
 
 class JinjaFilterTests(unittest.TestCase):
@@ -86,6 +88,24 @@ class IPv6ToIPv4Tests(unittest.TestCase):
     def test_should_return_an_ipv6interface(self):
         result = ipv4_to_ipv6('2001:700::/64', '10.0.0.1')
         self.assertIsInstance(result, ipaddress.IPv6Interface)
+
+
+class FileSha256SumTests(unittest.TestCase):
+    """Tests for the file_sha256sum filter function"""
+
+    def setUp(self) -> None:
+        self.request_patch = patch('requests.get')
+        self.get = self.request_patch.start()
+
+    def test_should_return_correct_checksum(self):
+        self.get.return_value = Mock(content=b'fake-content')
+        expected_checksum = '9c87681ea7ba17d350f3cb62894935d8f77c0aacc678966d51638d584a6eaee0'
+
+        checksum = file_sha256sum('fake_url')
+        self.assertEqual(checksum, expected_checksum)
+
+    def tearDown(self) -> None:
+        self.request_patch.stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Our Juniper switches are configured to download a specific Python program, and for security measures, the config needs to contains SHA256 checksum to validate the downloaded file against.

The new `file_sha256sum` filter function will take the URL to said file as its input and calculate said SHA256 sum from this file. The function is cached to avoid unnecessary amounts of requests against the server serving said file.

This depends on #225, so keeping it as a draft until that can be merged