### PR TITLE
Add an ipwrap template filter to ensure IPv6 addresses used in URLs are wrapped in brackets

### DIFF
--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -2,7 +2,7 @@
 
 import ipaddress
 import re
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, Any
 
 # This global dict can be used to update the Jinja environment filters dict to include all
 # registered template filter function
@@ -22,6 +22,25 @@ def template_filter(name: Optional[str] = None) -> Callable:
         return func
 
     return decorator
+
+
+@template_filter()
+def ipwrap(address: Any) -> str:
+    """Wraps the input argument in brackets if it looks like an IPv6 address. Otherwise, returns
+    the input unchanged. This is useful in templates that need to build valid URLs from host name
+    variables that can be either FQDNs or any IPv4 or IPv6 address.
+
+    Args:
+        address: Any string or object that can be cast to a string
+    """
+    try:
+        if not isinstance(address, int):
+            ipaddress.IPv6Address(address)
+            return f"[{address}]"
+    except ValueError:
+        pass
+
+    return str(address)
 
 
 @template_filter()

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -1,7 +1,13 @@
 import ipaddress
 import unittest
 
-from cnaas_nms.tools.jinja_filters import increment_ip, isofy_ipv4, ipv4_to_ipv6, get_interface
+from cnaas_nms.tools.jinja_filters import (
+    increment_ip,
+    isofy_ipv4,
+    ipv4_to_ipv6,
+    get_interface,
+    ipwrap,
+)
 
 
 class JinjaFilterTests(unittest.TestCase):
@@ -61,6 +67,30 @@ class JinjaFilterTests(unittest.TestCase):
         for prefix in invalid_prefixes:
             with self.assertRaises(ValueError):
                 isofy_ipv4('10.0.0.1', prefix=prefix)
+
+
+class IPWrapTests(unittest.TestCase):
+    """Tests for the ipwrap filter function"""
+
+    def test_should_wrap_ipv6_string_in_brackets(self):
+        address = "fe80:c0ff:eeba:be::"
+        self.assertEqual(ipwrap(address), f"[{address}]")
+
+    def test_should_wrap_ipv6_address_object_in_brackets(self):
+        address = ipaddress.IPv6Address("fe80:c0ff:eeba:be::")
+        self.assertEqual(ipwrap(address), f"[{address}]")
+
+    def test_should_not_wrap_ipv4_address(self):
+        address = "10.0.1.42"
+        self.assertEqual(ipwrap(address), address)
+
+    def test_should_not_wrap_fqdn(self):
+        address = "wwww.example.org"
+        self.assertEqual(ipwrap(address), address)
+
+    def test_should_not_wrap_ints(self):
+        address = 338288761799928348595999619069446717440
+        self.assertEqual(ipwrap(address), str(address))
 
 
 class IPv6ToIPv4Tests(unittest.TestCase):


### PR DESCRIPTION
The ipwrap filter is functionally equivalent to that provided by Ansible (see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters_ipaddr.html#wrapping-ipv6-addresses-in-brackets).

A template may look like

```
url https://{{ file_server }}/somefile.py
```

However, if the `file_server` variable is not a FQDN or an IPv4 address, but an IPv6 address, it needs to be enclosed in brackets to make a valid URL. The value itself may come from the NMS settings and is used for other things than just URLs, so the brackets cannot be part of the set value.


This depends on #225, so keeping it as draft until that can be merged.