### PR TITLE
Improve error message for template dry run jinja_filters import error

### DIFF
--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -57,8 +57,11 @@ def load_jinja_filters():
     try:
         import jinja_filters
         return jinja_filters.FILTERS
-    except ModuleNotFoundError:
-        print('No jinja_filters.py file in PYTHONPATH, proceeding without filters')
+    except ModuleNotFoundError as error:
+        print(
+            f'jinja_filters.py could not be loaded from PYTHONPATH, proceeding without filters: '
+            '{error}'
+        )
         return {}
 
 


### PR DESCRIPTION
If jinja_filters is actually found, but its sub-dependencies cannot be imported, the actual culprit would be masked. This adds the exception string to the output.

Our users were told jinja_filters was not found, when the actual problem was that they had not installed the cachetools module, which our current filter set depends on.