### PR TITLE
Add API for Stackmembers

### DIFF
--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -364,3 +364,59 @@ NMS CA (specified in api.yml).
 
 Either one of "hostname" or "group" arguments must be specified. The "action"
 argument must be specified and the only valid action for now is "RENEW".
+
+
+Show stackmembers
+--------------
+Stackmembers for a device can be listed with the following API call:
+
+::
+
+   curl https://hostname/api/v1.0/device/1/stackmember
+
+This will return all stackmember entries from the database that are tied to the specified device.
+Example output:
+
+::
+
+  {
+      "status": "success",
+      "data": {
+          "stackmembers": [
+              {
+                 "member_no": 1,
+                 "hardware_id": "4AE008A",
+                 "priority": 55,
+              },
+              {
+                 "member_no": 2,
+                 "hardware_id": "B77C34F",
+                 "priority": 125,
+              },
+          ]
+      }
+  }  
+
+Set stackmembers
+--------------
+
+Stackmembers for a device can be set using a PUT operation.
+This replaces any existing stackmembers.
+
+The JSON structure for the API call is a list of data
+defining the stackmembers under the key "stackmembers". Each stackmember
+has three fields available:
+
+   * member_no (optional)
+   * hardware_id (mandatory)
+   * priority (optional)
+
+member_no and hardware_id must be unique for each stackmember in the same device.
+
+Example for defining two stackmembers for device with device_id 1:
+
+::
+
+   curl -H "Content-Type: application/json" -X PUT -d
+   '{"stackmembers": [{"member_no": 1,"hardware_id": "4AE008A","priority": 55}, {"member_no": 2, "hardware_id": "B77C34F", "priority": 125}]}'
+   https://hostname/api/v1.0/device/1/stackmember

--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -372,7 +372,7 @@ Stackmembers for a device can be listed with the following API call:
 
 ::
 
-   curl https://hostname/api/v1.0/device/1/stackmember
+   curl https://hostname/api/v1.0/device/<device_hostname>/stackmember
 
 This will return all stackmember entries from the database that are tied to the specified device.
 Example output:
@@ -413,10 +413,10 @@ has three fields available:
 
 member_no and hardware_id must be unique for each stackmember in the same device.
 
-Example for defining two stackmembers for device with device_id 1:
+Example for defining two stackmembers:
 
 ::
 
    curl -H "Content-Type: application/json" -X PUT -d
    '{"stackmembers": [{"member_no": 1,"hardware_id": "4AE008A","priority": 55}, {"member_no": 2, "hardware_id": "B77C34F", "priority": 125}]}'
-   https://hostname/api/v1.0/device/1/stackmember
+   https://hostname/api/v1.0/device/<device_hostname>/stackmember

--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -367,7 +367,7 @@ argument must be specified and the only valid action for now is "RENEW".
 
 
 Show stackmembers
---------------
+-----------------
 Stackmembers for a device can be listed with the following API call:
 
 ::
@@ -395,10 +395,10 @@ Example output:
               },
           ]
       }
-  }  
+  }
 
 Set stackmembers
---------------
+----------------
 
 Stackmembers for a device can be set using a PUT operation.
 This replaces any existing stackmembers.

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -1012,8 +1012,6 @@ class DeviceStackmembersApi(Resource):
             device_instance = session.query(Device).filter(Device.id == device_id).one_or_none()
             if not device_instance:
                 return empty_result('error', "Device not found"), 404
-            if not device_instance.is_stack(session):
-                return empty_result('error', "This device is not a stack"), 400
             try:
                 for stackmember in device_instance.get_stackmembers(session):
                     session.delete(stackmember)

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -7,7 +7,7 @@ from flask_restx import Resource, Namespace, fields
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 
-from pydantic import ValidationError, parse_obj_as
+from pydantic import ValidationError
 
 import cnaas_nms.confpush.init_device
 import cnaas_nms.confpush.sync_devices
@@ -1002,7 +1002,7 @@ class DeviceStackmembersApi(Resource):
     @jwt_required
     def put(self, device_id):
         try:
-            validated_json_data = parse_obj_as(StackmembersModel, request.get_json()).dict()
+            validated_json_data = StackmembersModel(**request.get_json()).dict()
             data = validated_json_data['stackmembers']
         except ValidationError as e:
             errors = [error['msg'] for error in e.errors()]

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -1005,7 +1005,7 @@ class DeviceStackmembersApi(Resource):
             validated_json_data = StackmembersModel(**request.get_json()).dict()
             data = validated_json_data['stackmembers']
         except ValidationError as e:
-            errors = [error['msg'] for error in e.errors()]
+            errors = DeviceStackmembersApi.format_errors(e.errors())
             return empty_result('error', errors), 400
         result = empty_result(data={'stackmembers': []})
         with sqla_session() as session:
@@ -1025,6 +1025,17 @@ class DeviceStackmembersApi(Resource):
                 session.rollback()
                 return empty_result('error', str(e)), 400
         return result
+
+    @classmethod
+    def format_errors(cls, errors):
+        return_errors = []
+        for error in errors:
+            error_msg = error['msg']
+            if error['type'] != 'value_error':
+                error_msg = f"{error['loc'][2]}: {error_msg}"
+            return_errors.append(error_msg)
+        return return_errors
+
 
 # Devices
 device_api.add_resource(DeviceByIdApi, '/<int:device_id>')

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -137,6 +137,7 @@ stackmembers_model = device_api.model('stackmembers', {
     'stackmembers': fields.List(fields.Nested(stackmember_model)),
 })
 
+
 class DeviceByIdApi(Resource):
     @jwt_required
     def get(self, device_id):
@@ -993,8 +994,8 @@ class DeviceCertApi(Resource):
                 data=f"Unknown action specified: {action}"
             ), 400
 
-class DeviceStackmembersApi(Resource):
 
+class DeviceStackmembersApi(Resource):
     @jwt_required
     def get(self, hostname):
         """ Get stackmembers for device """

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -1,7 +1,6 @@
 import json
 import datetime
 from typing import Optional
-from typing_extensions import Required
 
 from flask import request, make_response
 from flask_restx import Resource, Namespace, fields

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -1,6 +1,7 @@
 import json
 import datetime
 from typing import Optional
+from typing_extensions import Required
 
 from flask import request, make_response
 from flask_restx import Resource, Namespace, fields
@@ -127,6 +128,15 @@ device_cert_model = device_syncto_api.model('device_cert', {
                             example="RENEW")
 })
 
+stackmember_model = device_api.model('stackmember', {
+    'member_no': fields.Integer(required=False),
+    'hardware_id': fields.String(required=True),
+    'prioity_id': fields.Integer(required=False)
+})
+
+stackmembers_model = device_api.model('stackmembers', {
+    'stackmembers': fields.List(fields.Nested(stackmember_model)),
+})
 
 class DeviceByIdApi(Resource):
     @jwt_required
@@ -1000,6 +1010,7 @@ class DeviceStackmembersApi(Resource):
         return result
 
     @jwt_required
+    @device_api.expect(stackmembers_model)
     def put(self, device_id):
         try:
             validated_json_data = StackmembersModel(**request.get_json()).dict()

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -273,7 +273,7 @@ class DevicesApi(Resource):
         resp.headers['X-Total-Count'] = total_count
         resp.headers['Content-Type'] = 'application/json'
         return resp
-    
+
 
 class DeviceInitApi(Resource):
     @jwt_required

--- a/src/cnaas_nms/api/models/stackmembers_model.py
+++ b/src/cnaas_nms/api/models/stackmembers_model.py
@@ -2,7 +2,7 @@ from typing import Optional, List
 from pydantic import BaseModel, validator, conint
 
 class StackmemberModel(BaseModel):
-    member_no: conint(gt=-1)
+    member_no: Optional[conint(gt=-1)] = None
     hardware_id: str
     priority: Optional[conint(gt=-1)] = None
 

--- a/src/cnaas_nms/api/models/stackmembers_model.py
+++ b/src/cnaas_nms/api/models/stackmembers_model.py
@@ -1,0 +1,33 @@
+from typing import Optional, List
+from pydantic import BaseModel, validator, conint
+
+class StackmemberModel(BaseModel):
+    member_no: conint(gt=-1)
+    hardware_id: str
+    priority: Optional[conint(gt=-1)] = None
+
+    @validator('hardware_id')
+    def validate_non_empty_hardware_id(cls, hardware_id):
+        """Validates that hardware_id is not an empty string"""
+        if not hardware_id:
+            raise ValueError("hardware_id cannot be an empty string")
+        return hardware_id
+
+class StackmembersModel(BaseModel):
+    stackmembers: List[StackmemberModel]
+
+    @validator('stackmembers')
+    def validate_unique_member_no(cls, stackmembers):
+        """Validates that all StackmemberModel in stackmembers have unique member_no compared to each other"""
+        member_no_count = len(set([stackmember.member_no for stackmember in stackmembers]))
+        if member_no_count != len(stackmembers):
+            raise ValueError("member_no must be unique for stackmembers belonging to the same device")
+        return stackmembers
+
+    @validator('stackmembers')
+    def validate_unique_hardware_id(cls, stackmembers):
+        """Validates that all StackmemberModel in stackmembers have unique hardware_id compared to each other"""
+        hardware_id_count = len(set([stackmember.hardware_id for stackmember in stackmembers]))
+        if hardware_id_count != len(stackmembers):
+            raise ValueError("hardware_id must be unique for stackmembers belonging to the same device")
+        return stackmembers

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -218,8 +218,6 @@ class DeviceTests(unittest.TestCase):
         new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
             session.add(new_device)
-            stackmember = Stackmember(device_id=1, hardware_id="AB1234", member_no=1, priority=3)
-            session.add(stackmember)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "DC1231", "member_no": 1},
             {"hardware_id": "CD5555", "member_no": 1}
@@ -232,8 +230,6 @@ class DeviceTests(unittest.TestCase):
         new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
             session.add(new_device)
-            stackmember = Stackmember(device_id=1, hardware_id="AB1234", member_no=1, priority=3)
-            session.add(stackmember)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AA1111", "member_no": 1},
             {"hardware_id": "AA1111", "member_no": 2}

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -148,8 +148,6 @@ class DeviceTests(unittest.TestCase):
         new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
             session.add(new_device)
-            stackmember = Stackmember(device_id=1, hardware_id="AB1234", member_no=1, priority=3,)
-            session.add(stackmember)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AB1234", "member_no": 0, "priority": None},
             {"hardware_id": "CD5555", "member_no": 2, "priority": 99},

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -163,13 +163,24 @@ class DeviceTests(unittest.TestCase):
             q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
             self.assertEqual(len(q_stackmembers), 3, msg=json_data)
     
-    def test_put_stackmembers_invalid(self):
+    def test_put_stackmembers_invalid_member_no(self):
         new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
             session.add(new_device)
         stackmember_data = {'stackmembers': [
-            {"hardware_id": "AB1234", "member_no": "adwa", "priority": 99},
-        ]}
+            {"hardware_id": "AB1234", "member_no": "string"}]}
+        result = self.client.put(f'/api/v1.0/device/{1}/stackmember', json=stackmember_data)
+        json_data = json.loads(result.data.decode())
+        self.assertEqual(result.status_code, 400, msg=json_data)
+        with sqla_session() as session:
+            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
+            self.assertEqual(q_stackmembers, [])
+
+    def test_put_stackmembers_invalid_hardware_id(self):
+        new_device = self.create_test_device(device_id=1)
+        with sqla_session() as session:
+            session.add(new_device)
+        stackmember_data = {'stackmembers': [{"hardware_id": "", "member_no": 0}]}
         result = self.client.put(f'/api/v1.0/device/{1}/stackmember', json=stackmember_data)
         json_data = json.loads(result.data.decode())
         self.assertEqual(result.status_code, 400, msg=json_data)

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -6,7 +6,6 @@ import json
 import unittest
 
 from cnaas_nms.api import app
-from cnaas_nms.tools.testsetup import PostgresTemporaryInstance
 from cnaas_nms.db.session import clear_db
 from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
 
@@ -22,13 +21,8 @@ class DeviceTests(unittest.TestCase):
         self.app = app.app
         self.app.wsgi_app = TestAppWrapper(self.app.wsgi_app, self.jwt_auth_token)
         self.client = self.app.test_client()
-        self.tmp_postgres = PostgresTemporaryInstance()
 
     def tearDown(self):
-        device_id = self.testdata['initcheck_device_id']
-        self.client.put(f'/api/v1.0/device/{device_id}',
-                        json={'state': 'MANAGED'})
-        self.tmp_postgres.shutdown()
         clear_db()
 
     def test_0_add_invalid_device(self):
@@ -150,9 +144,6 @@ class DeviceTests(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         json_data = json.loads(result.data.decode())
         self.assertEqual(json_data['data']['compatible'], False)
-
-        self.client.put(f'/api/v1.0/device/{device_id}',
-                        json={'state': 'MANAGED'})
 
 
 if __name__ == '__main__':

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -7,6 +7,7 @@ import unittest
 
 from cnaas_nms.api import app
 from cnaas_nms.tools.testsetup import PostgresTemporaryInstance
+from cnaas_nms.db.session import clear_db
 from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
 
 
@@ -28,6 +29,7 @@ class DeviceTests(unittest.TestCase):
         self.client.put(f'/api/v1.0/device/{device_id}',
                         json={'state': 'MANAGED'})
         self.tmp_postgres.shutdown()
+        clear_db()
 
     def test_0_add_invalid_device(self):
         device_data = {

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -161,6 +161,19 @@ class DeviceTests(unittest.TestCase):
             q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
             self.assertEqual(len(q_stackmembers), 3, msg=json_data)
 
+    def test_put_stackmembers_invalid_priority(self):
+        new_device = self.create_test_device()
+        with sqla_session() as session:
+            session.add(new_device)
+        stackmember_data = {'stackmembers': [
+            {"hardware_id": "AB1234", "member_no": 1, "priority": "string"}]}
+        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
+        json_data = json.loads(result.data.decode())
+        self.assertEqual(result.status_code, 400, msg=json_data)
+        with sqla_session() as session:
+            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
+            self.assertEqual(q_stackmembers, [])
+
     def test_put_stackmembers_invalid_member_no(self):
         new_device = self.create_test_device()
         with sqla_session() as session:

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -18,6 +18,14 @@ class DeviceTests(unittest.TestCase):
             self.testdata = yaml.safe_load(f_testdata)
             if 'jwt_auth_token' in self.testdata:
                 self.jwt_auth_token = self.testdata['jwt_auth_token']
+        os.environ["USERNAME_DHCP_BOOT"] = "cnaas"
+        os.environ["PASSWORD_DHCP_BOOT"] = "cnaas"
+        os.environ["USERNAME_DISCOVERED"] = "cnaas"
+        os.environ["PASSWORD_DISCOVERED"] = "cnaas"
+        os.environ["USERNAME_INIT"] = "cnaas"
+        os.environ["PASSWORD_INIT"] = "cnaas"
+        os.environ["USERNAME_MANAGED"] = "cnaas"
+        os.environ["PASSWORD_MANAGED"] = "cnaas"
         self.app = app.app
         self.app.wsgi_app = TestAppWrapper(self.app.wsgi_app, self.jwt_auth_token)
         self.client = self.app.test_client()

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -6,7 +6,7 @@ import unittest
 from ipaddress import IPv4Address
 
 from cnaas_nms.api import app
-from cnaas_nms.db.session import clear_db, sqla_session
+from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.stackmember import Stackmember
 from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
@@ -20,35 +20,36 @@ class DeviceTests(unittest.TestCase):
             self.testdata = yaml.safe_load(f_testdata)
             if 'jwt_auth_token' in self.testdata:
                 self.jwt_auth_token = self.testdata['jwt_auth_token']
-        os.environ["USERNAME_DHCP_BOOT"] = "cnaas"
-        os.environ["PASSWORD_DHCP_BOOT"] = "cnaas"
-        os.environ["USERNAME_DISCOVERED"] = "cnaas"
-        os.environ["PASSWORD_DISCOVERED"] = "cnaas"
-        os.environ["USERNAME_INIT"] = "cnaas"
-        os.environ["PASSWORD_INIT"] = "cnaas"
-        os.environ["USERNAME_MANAGED"] = "cnaas"
-        os.environ["PASSWORD_MANAGED"] = "cnaas"
         self.app = app.app
         self.app.wsgi_app = TestAppWrapper(self.app.wsgi_app, self.jwt_auth_token)
         self.client = self.app.test_client()
+        device_id, hostname = self.add_device()
+        self.device_id = device_id
+        self.hostname = hostname
 
     def tearDown(self):
-        clear_db()
+        with sqla_session() as session:
+            for hostname in ["testdevice", "testdevice2"]:
+                device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+                if device:
+                    session.delete(device)
 
-    def create_test_device(self, device_id=1):
-        return Device(
-            id=device_id,
-            ztp_mac="08002708a8be",
-            hostname="test_device",
-            platform="eos",
-            management_ip=IPv4Address("10.0.1.22"),
-            state=DeviceState.MANAGED,
-            device_type=DeviceType.DIST,
-        )
+    def add_device(self):
+        with sqla_session() as session:
+            device = Device (
+                hostname="testdevice",
+                platform="eos",
+                management_ip=IPv4Address("10.0.1.22"),
+                state=DeviceState.MANAGED,
+                device_type=DeviceType.DIST,
+            )
+            session.add(device)
+            q_device = session.query(Device).filter(Device.hostname == device.hostname).one_or_none()
+            return q_device.id, q_device.hostname
 
     def test_add_invalid_device(self):
         device_data = {
-            "hostname": "unittestdevice",
+            "hostname": "testdevice2",
             "management_ip": "10.1.2.3",
             "dhcp_ip": "11.1.2.3",
             "ztp_mac": "0800275C091F",
@@ -61,7 +62,7 @@ class DeviceTests(unittest.TestCase):
 
     def test_add_new_device(self):
         device_data = {
-            "hostname": "unittestdevice",
+            "hostname": "testdevice2",
             "management_ip": "10.1.2.3",
             "dhcp_ip": "11.1.2.3",
             "ztp_mac": "0800275C091F",
@@ -73,40 +74,33 @@ class DeviceTests(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
 
     def test_get_device(self):
-        new_device = self.create_test_device(1)
-        with sqla_session() as session:
-            session.add(new_device)
+        result = self.client.get(f'/api/v1.0/device/{self.hostname}')
+        self.assertEqual(result.status_code, 200)
+        json_data = json.loads(result.data.decode())
+        self.assertEqual([self.hostname], [device['hostname'] for device in json_data['data']['devices']])
+
+    def test_get_devices(self):
         result = self.client.get('/api/v1.0/devices')
         self.assertEqual(result.status_code, 200)
         json_data = json.loads(result.data.decode())
-        self.assertEqual([1], [device['id'] for device in json_data['data']['devices']])
-        result = self.client.get(f'/api/v1.0/device/{1}')
-        self.assertEqual(result.status_code, 200)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual([1], [device['id'] for device in json_data['data']['devices']])
+        self.assertTrue(self.hostname in [device['hostname'] for device in json_data['data']['devices']])
 
     def test_modify_device(self):
-        device_data = {"hostname": "unittestdevicechanged"}
-        new_device = self.create_test_device(device_id=1)
-        with sqla_session() as session:
-            session.add(new_device)
-        result = self.client.put(f'/api/v1.0/device/{1}', json=device_data)
+        modify_data = {"description": "changed_description"}
+        result = self.client.put(f'/api/v1.0/device/{self.device_id}', json=modify_data)
         self.assertEqual(result.status_code, 200)
         json_data = json.loads(result.data.decode())
         updated_device = json_data['data']['updated_device']
-        self.assertEqual(device_data['hostname'], updated_device['hostname'])
+        self.assertEqual(modify_data['description'], updated_device['description'])
         with sqla_session() as session:
-            q_device = session.query(Device).filter(Device.id == 1).one_or_none()
-            self.assertEqual(device_data['hostname'], q_device.hostname)
+            q_device = session.query(Device).filter(Device.hostname == self.hostname).one_or_none()
+            self.assertEqual(modify_data['description'], q_device.description)
 
     def test_delete_device(self):
-        new_device = self.create_test_device(device_id=1)
-        with sqla_session() as session:
-            session.add(new_device)
-        result = self.client.delete(f'/api/v1.0/device/{1}')
+        result = self.client.delete(f'/api/v1.0/device/{self.device_id}')
         self.assertEqual(result.status_code, 200)
         with sqla_session() as session:
-            q_device = session.query(Device).filter(Device.id == 1).one_or_none()
+            q_device = session.query(Device).filter(Device.hostname == self.hostname).one_or_none()
             self.assertIsNone(q_device)
 
     def test_initcheck_distdevice(self):
@@ -119,124 +113,85 @@ class DeviceTests(unittest.TestCase):
         self.assertEqual(json_data['data']['compatible'], False)
 
     def test_get_stackmembers_invalid_device(self):
-        result = self.client.get(f'/api/v1.0/device/{"test_device"}/stackmember')
+        result = self.client.get(f'/api/v1.0/device/{"nonexisting"}/stackmember')
         json_data = json.loads(result.data.decode())
         self.assertEqual(result.status_code, 404, msg=json_data)
 
     def test_get_stackmembers_no_stackmembers(self):
-        new_device = self.create_test_device()
-        with sqla_session() as session:
-            session.add(new_device)
-        result = self.client.get(f'/api/v1.0/device/{"test_device"}/stackmember')
+        result = self.client.get(f'/api/v1.0/device/{self.hostname}/stackmember')
         json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 200, msg=json_data)
-        self.assertEqual(json_data['data']['stackmembers'], [], msg=json_data)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(json_data['data']['stackmembers'], [])
 
     def test_get_stackmembers(self):
-        new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
-            session.add(new_device)
-            stackmember = Stackmember(device_id=1, hardware_id="AB1234", member_no=1, priority=3)
+            stackmember = Stackmember(device_id=self.device_id, hardware_id="AB1234", member_no=1, priority=3)
             session.add(stackmember)
-        result = self.client.get(f'/api/v1.0/device/{"test_device"}/stackmember')
+        result = self.client.get(f'/api/v1.0/device/{self.hostname}/stackmember')
         json_data = json.loads(result.data.decode())
         self.assertEqual(result.status_code, 200, msg=json_data)
         self.assertEqual(len(json_data['data']['stackmembers']), 1, msg=json_data)
         self.assertEqual(json_data['data']['stackmembers'][0]["hardware_id"], "AB1234", msg=json_data)
 
     def test_put_stackmembers_valid(self):
-        new_device = self.create_test_device()
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AB1234", "member_no": 0, "priority": None},
             {"hardware_id": "CD5555", "member_no": 2, "priority": 99},
             {"hardware_id": "GF43534", "member_no": 5},
         ]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
         json_data = json.loads(result.data.decode())
         self.assertEqual(result.status_code, 200, msg=json_data)
         self.assertEqual(len(json_data['data']['stackmembers']), 3, msg=json_data)
         with sqla_session() as session:
-            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
+            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == self.device_id).all()
             self.assertEqual(len(q_stackmembers), 3, msg=json_data)
 
     def test_put_stackmembers_invalid_priority(self):
-        new_device = self.create_test_device()
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AB1234", "member_no": 1, "priority": "string"}]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 400, msg=json_data)
-        with sqla_session() as session:
-            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
-            self.assertEqual(q_stackmembers, [])
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
+        self.assertEqual(result.status_code, 400)
 
     def test_put_stackmembers_invalid_member_no(self):
-        new_device = self.create_test_device()
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AB1234", "member_no": "string"}]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 400, msg=json_data)
-        with sqla_session() as session:
-            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
-            self.assertEqual(q_stackmembers, [])
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
+        self.assertEqual(result.status_code, 400)
 
     def test_put_stackmembers_invalid_hardware_id(self):
-        new_device = self.create_test_device()
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [{"hardware_id": "", "member_no": 0}]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 400, msg=json_data)
-        with sqla_session() as session:
-            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
-            self.assertEqual(q_stackmembers, [])
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
+        self.assertEqual(result.status_code, 400)
 
     def test_put_stackmembers_clear(self):
-        new_device = self.create_test_device(device_id=1)
         with sqla_session() as session:
-            session.add(new_device)
-            stackmember = Stackmember(device_id=1, hardware_id="AB1234", member_no=1, priority=3,)
+            stackmember = Stackmember(device_id=self.device_id, hardware_id="AB1234", member_no=1, priority=3,)
             session.add(stackmember)
         stackmember_data = {'stackmembers': []}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
         json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 200, msg=json_data)
-        self.assertEqual(len(json_data['data']['stackmembers']), 0, msg=json_data)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(len(json_data['data']['stackmembers']), 0)
         with sqla_session() as session:
-            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == 1).all()
-            self.assertEqual(len(q_stackmembers), 0, msg=json_data)
+            q_stackmembers = session.query(Stackmember).filter(Stackmember.device_id == self.device_id).all()
+            self.assertEqual(len(q_stackmembers), 0)
 
     def test_put_stackmembers_dupe_member_no(self):
-        new_device = self.create_test_device(device_id=1)
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "DC1231", "member_no": 1},
             {"hardware_id": "CD5555", "member_no": 1}
         ]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 400, msg=json_data)
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
+        self.assertEqual(result.status_code, 400)
 
     def test_put_stackmembers_dupe_hardware_id(self):
-        new_device = self.create_test_device(device_id=1)
-        with sqla_session() as session:
-            session.add(new_device)
         stackmember_data = {'stackmembers': [
             {"hardware_id": "AA1111", "member_no": 1},
             {"hardware_id": "AA1111", "member_no": 2}
         ]}
-        result = self.client.put(f'/api/v1.0/device/{"test_device"}/stackmember', json=stackmember_data)
-        json_data = json.loads(result.data.decode())
-        self.assertEqual(result.status_code, 400, msg=json_data)
+        result = self.client.put(f'/api/v1.0/device/{self.hostname}/stackmember', json=stackmember_data)
+        self.assertEqual(result.status_code, 400)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -35,19 +35,6 @@ conn_str = get_sqlalchemy_conn_str()
 engine = create_engine(conn_str, pool_size=50, max_overflow=50)
 connection = engine.connect()
 Session = sessionmaker(bind=engine)
-    
-def clear_db():
-    """For clearing postgresql database"""
-    conn_str = get_sqlalchemy_conn_str()
-    engine = create_engine(conn_str, pool_size=50, max_overflow=50)
-    con = engine.connect()
-    trans = con.begin()
-    meta = MetaData(bind=engine, reflect=True)
-    for table in meta.sorted_tables:
-        con.execute(f'ALTER TABLE "{table.name}" DISABLE TRIGGER ALL;')
-        con.execute(table.delete())
-        con.execute(f'ALTER TABLE "{table.name}" ENABLE TRIGGER ALL;')
-    trans.commit()
 
 @contextmanager
 def sqla_session(**kwargs):

--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -5,8 +5,8 @@ from contextlib import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
+from sqlalchemy.sql.schema import MetaData
 from redis import StrictRedis
-
 
 def get_dbdata(config='/etc/cnaas-nms/db_config.yml'):
     with open(config, 'r') as db_file:
@@ -31,12 +31,23 @@ def get_sqlalchemy_conn_str(**kwargs) -> str:
         f"{db_data['hostname']}:{db_data['port']}/{db_data['database']}"
     )
 
-
 conn_str = get_sqlalchemy_conn_str()
 engine = create_engine(conn_str, pool_size=50, max_overflow=50)
 connection = engine.connect()
 Session = sessionmaker(bind=engine)
-
+    
+def clear_db():
+    """For clearing postgresql database"""
+    conn_str = get_sqlalchemy_conn_str()
+    engine = create_engine(conn_str, pool_size=50, max_overflow=50)
+    con = engine.connect()
+    trans = con.begin()
+    meta = MetaData(bind=engine, reflect=True)
+    for table in meta.sorted_tables:
+        con.execute(f'ALTER TABLE "{table.name}" DISABLE TRIGGER ALL;')
+        con.execute(table.delete())
+        con.execute(f'ALTER TABLE "{table.name}" ENABLE TRIGGER ALL;')
+    trans.commit()
 
 @contextmanager
 def sqla_session(**kwargs):

--- a/src/cnaas_nms/db/stackmember.py
+++ b/src/cnaas_nms/db/stackmember.py
@@ -1,9 +1,7 @@
-from sqlalchemy import Column, Integer, UniqueConstraint, String
-from sqlalchemy import ForeignKey
+from sqlalchemy import Column, Integer, UniqueConstraint, String, ForeignKey
 from sqlalchemy.orm import relationship, backref
 
 import cnaas_nms.db.base
-
 
 class Stackmember(cnaas_nms.db.base.Base):
     __tablename__ = 'stackmember'
@@ -18,3 +16,12 @@ class Stackmember(cnaas_nms.db.base.Base):
     hardware_id = Column(String(64), nullable=False)
     member_no = Column(Integer)
     priority = Column(Integer)
+
+    def as_dict(self) -> dict:
+        """Return JSON serializable dict."""
+        d = {
+            "member_no": self.member_no,
+            "hardware_id": self.hardware_id,
+            "priority": self.priority,
+        }
+        return d

--- a/src/cnaas_nms/db/tests/test_device.py
+++ b/src/cnaas_nms/db/tests/test_device.py
@@ -81,7 +81,7 @@ class DeviceTests(unittest.TestCase):
             self.assertEqual(new_stack.get_stackmembers(session), [])
             stackmember1 = Stackmember(
                 device_id = new_stack.id,
-                hardware_id = "FO64534",
+                hardware_id = "FO64535",
                 member_no = "0",
             )
             session.add(stackmember1)


### PR DESCRIPTION
Adds PUT and GET API for Stackmembers. Uses pydantic for input validation. 

It does not have a Flask model, as I made a pydantic model instead. But a Flask model may be required for the automated API documentation, I think?

Device API tests are rewritten to not rely on data pre-existing in the database. 

Function added to session for wiping the database between tests. This is needed, as the API uses different sessions from the tests, so if i want to see if stuff was actually added to the database I have to fully commit stuff to the db and then check. This kinda overlaps with the test_sqla_session, so device db tests can be rewritten to use clear_db instead of test_sqla_session to remove this redundancy.

Currently hardware_id accepts numbers as well as str. This was not initally intentional, as it turned out that using `str` in pydantic also allows numbers (ints and floats i tested with), ad automatically converts them to strings. Probably holds true for other data types as well. This can be fixed by using StrictStr or something akin to that. I havent changed it yet as maybe there is a reason to allow stuff that can be converted to a string.

Probably more stuff to discuss that i havent considered