### PR TITLE
Improve hostname and device_id variables for templates

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -28,6 +28,10 @@ will depend on things defined in a file called "managed-full.j2".
 The template files themselves are written using the Jinja2 templating language. Variables
 that are exposed from CNaaS includes:
 
+- hostname: Short hostname of device
+
+- host: Short hostname of device (implicitly added by nornir-jinja2)
+
 - mgmt_ip: IPv4 management address (ex 192.168.0.10)
 
 - mgmt_ipif: IPv4 management address including prefix length (ex 192.168.0.10/24)
@@ -49,6 +53,8 @@ that are exposed from CNaaS includes:
 
 - device_os_version: Device OS version string, same as "os_version" in the
   device API. Can be used if you need OS version specific configuration lines.
+
+- device_id: CNaaS-NMS internal ID number of the device
 
 Additional variables available for distribution switches:
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -744,6 +744,7 @@ class DeviceConfigApi(Resource):
 
         try:
             config, template_vars = cnaas_nms.confpush.sync_devices.generate_only(hostname)
+            template_vars['host'] = hostname
             result['data']['config'] = {
                 'hostname': hostname,
                 'generated_config': config,

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -404,6 +404,18 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(result.status_code, 400)
         self.assertTrue("action" in result.json['message'], msg="Unexpected error message")
 
+    def test_generate_only_vars(self):
+        result = self.client.get("/api/v1.0/device/{}/generate_config".format(
+            self.testdata['interface_device']
+        ))
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json['status'], 'success')
+        self.assertEqual(
+            result.json['data']['config']['available_variables']['hostname'],
+            self.testdata['interface_device'],
+            "hostname variable not found in generate_only variables"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -110,7 +110,10 @@ def populate_device_vars(session, dev: Device,
     logger = get_logger()
     device_variables = {
         'device_model': dev.model,
-        'device_os_version': dev.os_version
+        'device_os_version': dev.os_version,
+        'device_id': dev.id,
+        'hostname': dev.hostname
+        # 'host' variable is also implicitly added by nornir-jinja2
     }
 
     if ztp_hostname:


### PR DESCRIPTION
Add 'hostname' and 'device_id' variables to template generation. Document nornir-jinja2 hidden/implicit variable 'host', and make sure it shows up in 'available_variables' on generate_only API call.