### PR TITLE
Added the device IPv4 address in the response for management domains on the distribution layer.

### DIFF
--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -303,7 +303,8 @@ def populate_device_vars(session, dev: Device,
                     'ipv4_gw': mgmtdom.ipv4_gw,
                     'vlan': mgmtdom.vlan,
                     'description': mgmtdom.description,
-                    'esi_mac': mgmtdom.esi_mac
+                    'esi_mac': mgmtdom.esi_mac,
+                    'ipv4_ip': str(mgmtdom.device_a_ip) if hostname == mgmtdom.device_a.hostname else str(mgmtdom.device_b_ip)
                 })
         # populate evpn peers data
         for neighbor_d in get_evpn_peers(session, settings):


### PR DESCRIPTION
When configuring a management domain on a Junos device we need to configure an irb interface. As the IP address may be inserted into the database, it would be nice to also return it as a variable. With this change we can support the following template to create a managment domain on the core / dist:

```{% for mgmtdom in mgmtdomains %}
interfaces {
    irb { 
        unit {{ mgmtdom.vlan }} {
            virtual-gateway-accept-data;
            virtual-gateway-v4-mac 00:00:5e:00:00:04;
            family inet {
                address {{ mgmtdom.ipv4_ip/{{ mgmtdom.ipv4_gw.split("/")[1] }} {.  <<<<<<< This line
                    preferred;
                    virtual-gateway-address {{ mgmtdom.ipv4_gw.split("/")[0] }};
                }
            }
        }
    }
}
vlans {
    MGMT-DOMAIN-{{ mgmtdom.id }} {
        vlan-id {{ mgmtdom.vlan }};
        l3-interface irb.{{ mgmtdom.vlan }};
        vxlan {
            vni {{ mgmtdom.vlan }};
        }
    }
}

routing-instances {
    MGMT {
        interface irb.{{ mgmtdom.vlan }};
    }
}
{% endfor %}
```