### PR TITLE
Add Link header to point to next page of paginated data if it exists

### DIFF
--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -81,7 +81,7 @@ app = Flask(__name__)
 # TODO: make origins configurable
 cors = CORS(app,
             resources={r"/api/*": {"origins": "*"}},
-            expose_headers=["Content-Type", "Authorization", "X-Total-Count"])
+            expose_headers=["Content-Type", "Authorization", "X-Total-Count", "Link"])
 socketio = SocketIO(app, cors_allowed_origins='*')
 app.config['SECRET_KEY'] = os.urandom(128)
 app.config['JWT_PUBLIC_KEY'] = jwt_pubkey

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -13,7 +13,7 @@ import cnaas_nms.confpush.underlay
 import cnaas_nms.confpush.get
 import cnaas_nms.confpush.update
 from cnaas_nms.confpush.nornir_helper import cnaas_init, inventory_selector
-from cnaas_nms.api.generic import build_filter, empty_result
+from cnaas_nms.api.generic import build_filter, empty_result, pagination_headers
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.job import Job, JobNotFoundError, InvalidJobError
 from cnaas_nms.db.session import sqla_session
@@ -257,8 +257,8 @@ class DevicesApi(Resource):
                 total_count = instance.total
 
         resp = make_response(json.dumps(empty_result(status='success', data=data)), 200)
-        resp.headers['X-Total-Count'] = total_count
         resp.headers['Content-Type'] = 'application/json'
+        resp.headers = {**resp.headers, **pagination_headers(total_count)}
         return resp
 
 

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -75,9 +75,9 @@ def pagination_headers(total_count) -> dict:
         except (AssertionError, ValueError):
             pass
 
-    last_page = int(math.ceil(total_count / per_page))
+    last_page = math.ceil(total_count / per_page)
     if last_page == 1:
-        return {}
+        return headers
 
     if 'page' in args:
         try:
@@ -85,16 +85,14 @@ def pagination_headers(total_count) -> dict:
         except ValueError:
             pass
 
-    query_without_page = {k: request.args[k] for k in request.args if k not in ["page"]}
+    query = request.args
 
-    if page_arg * per_page < total_count:
+    if page_arg < last_page:
         links.append('<{}>; rel="next"'.format(
-            request.base_url + "?" + urllib.parse.urlencode({**query_without_page, "page": page_arg + 1})
+            request.base_url + "?" + urllib.parse.urlencode({**query, "page": page_arg + 1})
         ))
-
-    if page_arg != last_page:
         links.append('<{}>; rel="last"'.format(
-            request.base_url + "?" + urllib.parse.urlencode({**query_without_page, "page": last_page})
+            request.base_url + "?" + urllib.parse.urlencode({**query, "page": last_page})
         ))
 
     if links:

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -1,4 +1,6 @@
 import re
+import urllib
+import math
 from typing import List
 
 from flask import request
@@ -54,6 +56,51 @@ def offset_results() -> int:
             pass
 
     return offset
+
+
+def pagination_headers(total_count) -> dict:
+    per_page = DEFAULT_PER_PAGE
+    page_arg = 1
+    links = []
+    headers = {
+        "X-Total-Count": total_count,
+    }
+
+    args = request.args
+    if 'per_page' in args:
+        try:
+            per_page_arg = int(args['per_page'])
+            assert 1 <= per_page_arg <= MAX_PER_PAGE
+            per_page = per_page_arg
+        except (AssertionError, ValueError):
+            pass
+
+    last_page = int(math.ceil(total_count / per_page))
+    if last_page == 1:
+        return {}
+
+    if 'page' in args:
+        try:
+            page_arg = max(1, int(args['page']))
+        except ValueError:
+            pass
+
+    query_without_page = {k: request.args[k] for k in request.args if k not in ["page"]}
+
+    if page_arg * per_page < total_count:
+        links.append('<{}>; rel="next"'.format(
+            request.base_url + "?" + urllib.parse.urlencode({**query_without_page, "page": page_arg + 1})
+        ))
+
+    if page_arg != last_page:
+        links.append('<{}>; rel="last"'.format(
+            request.base_url + "?" + urllib.parse.urlencode({**query_without_page, "page": last_page})
+        ))
+
+    if links:
+        headers["Link"] = ",".join(links)
+
+    return headers
 
 
 def build_filter(f_class, query: sqlalchemy.orm.query.Query):

--- a/src/cnaas_nms/api/jobs.py
+++ b/src/cnaas_nms/api/jobs.py
@@ -6,7 +6,7 @@ from flask_restx import Resource, Namespace, fields
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from sqlalchemy import func
 
-from cnaas_nms.api.generic import empty_result, build_filter
+from cnaas_nms.api.generic import empty_result, build_filter, pagination_headers
 from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.joblock import Joblock
 from cnaas_nms.db.session import sqla_session
@@ -82,8 +82,8 @@ class JobsApi(Resource):
                 total_count = instance.total
 
         resp = make_response(json.dumps(empty_result(status='success', data=data)), 200)
-        resp.headers['X-Total-Count'] = total_count
         resp.headers['Content-Type'] = 'application/json'
+        resp.headers = {**resp.headers, **pagination_headers(total_count)}
         return resp
 
 


### PR DESCRIPTION
Add Link header to point to next page of paginated data if it exists, modeled after github API: https://docs.github.com/en/rest/guides/traversing-with-pagination

Can be used in code like this: (updated)
```
response = []

r = requests.get("http://172.30.0.1:5000/api/v1.0/jobs?per_page=1", headers=headers)

for i in r.json()['data']['jobs']:
    response.append(i['id'])

while r.links.get('next'):
    r = requests.get(r.links['next']['url'], headers=headers)

    for i in r.json()['data']['jobs']:
        response.append(i['id'])
```