### PR TITLE
Feature.primary group

### DIFF
--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -40,7 +40,8 @@ This will return the entire device entry from the database:
                   "device_type": "DIST",
                   "confhash": null,
                   "last_seen": "2019-02-27 10:30:23.338681",
-                  "port": null
+                  "port": null,
+                  "primary_group": "DEFAULT"
               }
           ]
       }
@@ -96,6 +97,9 @@ have the following format:
 
 There are four mandatory fields that can not be left out: hostname,
 state, platform and device_type.
+
+The field "primary_group" can not be configured via the API but is instead
+assigned via the groups.yml file in the :ref:`settings_repo_ref` repository.
 
 Device state can be one of the following:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -123,12 +123,24 @@ The directory structure looks like this:
 
 groups.yml:
 
-Contains a dictionary named "groups", that contains a list of groups.
+A device in CNaaS-NMS will be a member of exactly one primary group, and
+optionally any number of secandary groups. Primary groups can be used to
+configure settings per group. Secondary groups can be used to assign VXLAN
+memberships, select devices for synchronization or firmware upgrade etc.
+
+groups.yml contains a dictionary named "groups", that contains a list of groups.
 Each group is defined as a dictionary with a single key named "group",
 and that key contains a dictionary with two keys:
 
 - name: A string representing a name. No spaces.
-- regex: A Python style regex that matches on device hostnames
+- regex: A Python style regex that matches on device hostnames.
+- group_priority: Optional integer value 0-100. Specifies which group should
+  have the highest priority when determining the primary group for a device.
+  Higher value means higher priority. Defaults to 0, value of 1 is reserved
+  for builtin group DEFAULT.
+
+There will always exist a group called DEFAULT with group_priority 1 even
+if it's not specified in groups.yml.
 
 All devices that matches the regex will be included in the group.
 
@@ -148,6 +160,15 @@ All devices that matches the regex will be included in the group.
      - group:
          name: 'DIST_ODD'
          regex: '.*-dist[0-9][13579]'
+     - group:
+         name: 'E1'
+         regex: 'eosdist1$'
+         group_priority: 100
+     - group:
+         name: 'E'
+         regex: 'eosdist.*'
+         group_priority: 99
+
 
 routing.yml:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -89,7 +89,8 @@ settings
 Settings are defined at different levels and inherited (possibly overridden) in several steps.
 For example, NTP servers might be defined in the "global" settings to impact the entire
 managed network, but then overridden for a specific device type that needs custom NTP servers.
-The inheritence is defined in these steps: Global -> Core/Dist/Access -> Device specific.
+The inheritence is defined in these steps:
+Global -> Fabric -> Core/Dist/Access -> Group -> Device specific.
 The directory structure looks like this:
 
 - global
@@ -97,6 +98,10 @@ The directory structure looks like this:
   * groups.yml: Definition of custom device groups
   * routing.yml: Definition of global routing settings like fabric underlay and VRFs
   * vxlans.yml: Definition of VXLAN/VLANs
+  * base_system.yml: Base system settings
+
+- fabric (core+dist)
+
   * base_system.yml: Base system settings
 
 - core
@@ -112,6 +117,14 @@ The directory structure looks like this:
 - access:
 
   * base_system.yml: Base system settings
+
+- groups:
+
+  * <group name>
+
+    + base_system.yml
+    + interfaces.yml
+    + routing.yml
 
 - devices:
 

--- a/src/cnaas_nms/api/groups.py
+++ b/src/cnaas_nms/api/groups.py
@@ -6,7 +6,7 @@ from flask_jwt_extended import jwt_required
 
 from cnaas_nms.db.device import Device, DeviceState
 from cnaas_nms.api.generic import empty_result
-from cnaas_nms.db.settings import get_groups, get_group_regex
+from cnaas_nms.db.settings import get_groups, get_group_settings, get_group_regex
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.version import __api_version__
 
@@ -15,7 +15,7 @@ api = Namespace('groups', description='API for handling groups',
                 prefix='/api/{}'.format(__api_version__))
 
 
-def groups_populate(group_name: Optional[str] = None):
+def groups_populate(group_name: Optional[str] = None) -> dict:
     if group_name:
         tmpgroups: dict = {group_name: []}
     else:
@@ -28,6 +28,22 @@ def groups_populate(group_name: Optional[str] = None):
                 if group in tmpgroups:
                     tmpgroups[group].append(dev.hostname)
     return tmpgroups
+
+
+def groups_settings_populate(group_name: Optional[str] = None) -> dict:
+    settings, _ = get_group_settings()
+
+    if group_name:
+        group_list = [item['group'] for item in settings['groups'] if item['group']['name'] == group_name]
+    else:
+        group_list = [item['group'] for item in settings['groups']]
+
+    ret = {}
+    for item in group_list:
+        name = item.pop('name')
+        ret[name] = item
+
+    return ret
 
 
 def groups_osversion_populate(group_name: str):
@@ -57,8 +73,10 @@ class GroupsApi(Resource):
     @jwt_required()
     def get(self):
         """ Get all groups """
-        tmpgroups = groups_populate()
-        result = {'groups': tmpgroups}
+        result = {
+            'groups': groups_populate(),
+            'group_settings': groups_settings_populate()
+        }
         return empty_result(status='success', data=result)
 
 
@@ -66,8 +84,13 @@ class GroupsApiByName(Resource):
     @jwt_required()
     def get(self, group_name):
         """ Get a single group by name """
-        tmpgroups = groups_populate(group_name)
-        result = {'groups': tmpgroups}
+        if group_name not in get_groups():
+            return empty_result(status='error',
+                                data="No such group found, or group is not valid"), 404
+        result = {
+            'groups': groups_populate(group_name),
+            'group_settings': groups_settings_populate(group_name),
+        }
         return empty_result(status='success', data=result)
 
 

--- a/src/cnaas_nms/db/data/default_groups.yml
+++ b/src/cnaas_nms/db/data/default_groups.yml
@@ -1,0 +1,6 @@
+---
+groups:
+  - group:
+      name: 'DEFAULT'
+      regex: '.*'
+      group_priority: 1

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -12,7 +12,8 @@ from redis_lru import RedisLRU
 from cnaas_nms.db.exceptions import ConfigException, RepoStructureException
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.settings import get_settings, SettingsSyntaxError, DIR_STRUCTURE, \
-    check_settings_collisions, get_model_specific_configfiles, VlanConflictError
+    check_settings_collisions, get_model_specific_configfiles, VlanConflictError, \
+    update_device_primary_groups
 from cnaas_nms.db.device import Device, DeviceType
 from cnaas_nms.db.session import sqla_session, redis_session
 from cnaas_nms.db.job import Job, JobStatus
@@ -167,6 +168,7 @@ def _refresh_repo_task(repo_type: RepoType = RepoType.TEMPLATES) -> str:
             with redis_session() as redis_db:
                 cache = RedisLRU(redis_db)
                 cache.clear_all_cache()
+            update_device_primary_groups()
             get_settings()
             test_devtypes = [DeviceType.ACCESS, DeviceType.DIST, DeviceType.CORE]
             for devtype in test_devtypes:

--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -4,10 +4,10 @@ from contextlib import contextmanager
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 from redis import StrictRedis
 
 _sessionmaker = None
+
 
 def get_dbdata(config='/etc/cnaas-nms/db_config.yml'):
     with open(config, 'r') as db_file:
@@ -32,6 +32,7 @@ def get_sqlalchemy_conn_str(**kwargs) -> str:
         f"{db_data['hostname']}:{db_data['port']}/{db_data['database']}"
     )
 
+
 def _get_session():
     global _sessionmaker
     if _sessionmaker is None:
@@ -43,7 +44,7 @@ def _get_session():
 
 
 @contextmanager
-def sqla_session(**kwargs):
+def sqla_session(**kwargs) -> sessionmaker:
     session = _get_session()
     try:
         yield session
@@ -54,17 +55,6 @@ def sqla_session(**kwargs):
     finally:
         session.close()
 
-@contextmanager
-def sqla_test_session(**kwargs):
-    session = Session()
-    try:
-        yield session
-        session.flush()
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
 
 @contextmanager
 def sqla_execute(**kwargs):
@@ -74,8 +64,9 @@ def sqla_execute(**kwargs):
     with engine.connect() as connection:
         yield connection
 
+
 @contextmanager
-def redis_session(**kwargs):
+def redis_session(**kwargs) -> StrictRedis:
     db_data = get_dbdata(**kwargs)
     with StrictRedis(host=db_data['redis_hostname'], port=6379, charset="utf-8", decode_responses=True) as conn:
         yield conn

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -645,6 +645,7 @@ def get_group_settings():
 
 @redis_lru_cache
 def get_groups(hostname: Optional[str] = None) -> List[str]:
+    """Return list of names for valid groups."""
     groups = []
     settings, origin = get_group_settings()
     if settings is None:

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -418,7 +418,7 @@ def check_group_priority_collisions(settings: Optional[dict] = None):
     priorities: Dict[int, str] = {}
     if not settings:
         settings, _ = get_group_settings()
-    if settings:
+    if not settings:
         return
     if not settings.get("groups", None):
         return
@@ -713,7 +713,7 @@ def get_groups(hostname: Optional[str] = None) -> List[str]:
     """Return list of names for valid groups."""
     groups = []
     settings, origin = get_group_settings()
-    if settings:
+    if not settings:
         return groups
     if not settings.get("groups", None):
         return groups
@@ -734,7 +734,7 @@ def get_group_regex(group_name: str) -> Optional[str]:
     """Returns a string containing the regex defining the specified
     group name if it's found."""
     settings, origin = get_group_settings()
-    if settings:
+    if not settings:
         return None
     if not settings.get("groups", None):
         return None

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -695,13 +695,18 @@ def get_group_settings():
     except VerifyPathException as e:
         logger.exception("Exception when verifying settings repository directory structure")
         raise e
+
+    data_dir = pkg_resources.resource_filename(__name__, 'data')
+    with open(os.path.join(data_dir, 'default_groups.yml'), 'r') as f_default_settings:
+        default_settings: dict = yaml.safe_load(f_default_settings)
+
     settings, settings_origin = read_settings(local_repo_path,
                                               ['global', 'groups.yml'],
                                               'global',
                                               settings,
                                               settings_origin)
+    settings['groups'] += default_settings['groups']
     check_settings_syntax(settings, settings_origin)
-    # TODO: always have DEFAULT group with prio1
     return f_groups(**settings).dict(), settings_origin
 
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -780,10 +780,10 @@ def get_device_primary_groups(no_cache: bool = False) -> Dict[str, str]:
     """Returns a dict with {hostname: primary_group}"""
     # update redis if redis is empty
     with redis_session() as redis:
-        if redis.exists("device_primary_group"):
+        if not redis.exists("device_primary_group"):
             no_cache = True
     if no_cache:
-        update_device_primary_groups()  # or just return parsed data, don't update?
+        update_device_primary_groups()
     device_primary_group = {}
     with redis_session() as redis:
         device_primary_group = redis.hgetall("device_primary_group")

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -418,11 +418,9 @@ def check_group_priority_collisions(settings: Optional[dict] = None):
     priorities: Dict[int, str] = {}
     if not settings:
         settings, _ = get_group_settings()
-    if settings is None:
+    if settings:
         return
-    if 'groups' not in settings:
-        return
-    if settings['groups'] is None:
+    if not settings.get("groups", None):
         return
     for group in settings['groups']:
         if 'name' not in group['group']:
@@ -715,11 +713,9 @@ def get_groups(hostname: Optional[str] = None) -> List[str]:
     """Return list of names for valid groups."""
     groups = []
     settings, origin = get_group_settings()
-    if settings is None:
+    if settings:
         return groups
-    if 'groups' not in settings:
-        return groups
-    if settings['groups'] is None:
+    if not settings.get("groups", None):
         return groups
     for group in settings['groups']:
         if 'name' not in group['group']:
@@ -738,11 +734,9 @@ def get_group_regex(group_name: str) -> Optional[str]:
     """Returns a string containing the regex defining the specified
     group name if it's found."""
     settings, origin = get_group_settings()
-    if settings is None:
+    if settings:
         return None
-    if 'groups' not in settings:
-        return None
-    if settings['groups'] is None:
+    if not settings.get("groups", None):
         return None
     for group in settings['groups']:
         if 'name' not in group['group']:
@@ -760,11 +754,9 @@ def get_groups_priorities(hostname: Optional[str] = None,
 
     if not settings:
         settings, _ = get_group_settings()
-    if settings is None:
+    if not settings:
         return groups_priorities
-    if 'groups' not in settings:
-        return groups_priorities
-    if settings['groups'] is None:
+    if not settings.get("groups", None):
         return groups_priorities
     for group in settings['groups']:
         if 'name' not in group['group']:
@@ -828,7 +820,7 @@ def get_device_primary_groups(no_cache: bool = False) -> Dict[str, str]:
     # update redis if redis is empty
     with redis_session() as redis:
         if not redis.exists("device_primary_group"):
-            no_cache = True
+            update_device_primary_groups()
     if no_cache:
         update_device_primary_groups()
     device_primary_group: dict = {}

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -326,7 +326,7 @@ class f_group_item(BaseModel):
 
     @validator('group_priority')
     def reserved_priority(cls, v, values, **kwargs):
-        if v and v == 1:
+        if v and v == 1 and values['name'] != 'DEFAULT':
             raise ValueError("group_priority 1 is reserved for built-in group DEFAULT")
         return v
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -64,6 +64,8 @@ maximum_routes_schema = Field(None, ge=0, le=4294967294, description="Maximum nu
 
 GROUP_NAME = r'^([a-zA-Z0-9_]{1,63}\.?)+$'
 group_name = Field(..., regex=GROUP_NAME, max_length=253)
+group_priority_schema = Field(0, ge=0, le=100,
+                              description="Group priority 0-100, default 0, higher value means higher priority")
 
 
 def validate_ipv4_if(ipv4if: str):
@@ -320,6 +322,8 @@ class f_root(BaseModel):
 class f_group_item(BaseModel):
     name: str = group_name
     regex: str = ''
+    group_priority: int = group_priority_schema
+    redundancy_required: bool = True
 
 
 class f_group(BaseModel):

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -323,7 +323,12 @@ class f_group_item(BaseModel):
     name: str = group_name
     regex: str = ''
     group_priority: int = group_priority_schema
-    redundancy_required: bool = True
+
+    @validator('group_priority')
+    def reserved_priority(cls, v, values, **kwargs):
+        if v and v == 1:
+            raise ValueError("group_priority 1 is reserved for built-in group DEFAULT")
+        return v
 
 
 class f_group(BaseModel):

--- a/src/cnaas_nms/db/tests/test_device.py
+++ b/src/cnaas_nms/db/tests/test_device.py
@@ -8,7 +8,7 @@ import cnaas_nms.db.helper
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.stackmember import Stackmember
 from cnaas_nms.db.linknet import Linknet
-from cnaas_nms.db.session import sqla_test_session
+from cnaas_nms.db.session import sqla_session
 
 class DeviceTests(unittest.TestCase):
 
@@ -25,7 +25,7 @@ class DeviceTests(unittest.TestCase):
     def test_get_linknets(self):
         device1 = DeviceTests.create_test_device('test-device1')
         device2 = DeviceTests.create_test_device('test-device2')
-        with sqla_test_session() as session:
+        with sqla_session() as session:
             session.add(device1)
             session.add(device2)
             test_linknet = Linknet(device_a=device1, device_b=device2)
@@ -37,7 +37,7 @@ class DeviceTests(unittest.TestCase):
     def test_get_links_to(self):
         device1 = DeviceTests.create_test_device('test-device1')
         device2 = DeviceTests.create_test_device('test-device2')
-        with sqla_test_session() as session:
+        with sqla_session() as session:
             session.add(device1)
             session.add(device2)
             test_linknet = Linknet(device_a=device1, device_b=device2)
@@ -49,7 +49,7 @@ class DeviceTests(unittest.TestCase):
     def test_get_neighbors(self):
         device1 = DeviceTests.create_test_device('test-device1')
         device2 = DeviceTests.create_test_device('test-device2')
-        with sqla_test_session() as session:
+        with sqla_session() as session:
             session.add(device1)
             session.add(device2)
             test_linknet = Linknet(device_a=device1, device_b=device2)
@@ -59,7 +59,7 @@ class DeviceTests(unittest.TestCase):
             self.assertEquals([device1], device2.get_neighbors(session))
 
     def test_is_stack(self):
-        with sqla_test_session() as session:
+        with sqla_session() as session:
             new_stack = DeviceTests.create_test_device()
             session.add(new_stack)
             session.flush()
@@ -74,7 +74,7 @@ class DeviceTests(unittest.TestCase):
             self.assertFalse(new_stack.is_stack(session))
 
     def test_get_stackmembers(self):
-        with sqla_test_session() as session:
+        with sqla_session() as session:
             new_stack = DeviceTests.create_test_device()
             session.add(new_stack)
             session.flush()
@@ -94,6 +94,7 @@ class DeviceTests(unittest.TestCase):
             # assert the 2 lists have the same elements (regardless of ordering)
             self.assertCountEqual([stackmember1, stackmember2],
                 new_stack.get_stackmembers(session))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -105,7 +105,7 @@ class SettingsTests(unittest.TestCase):
         self.assertRaises(VlanConflictError, check_vlan_collisions, devices_dict, mgmt_vlans)
         # Check colliding vlan name in same device
         devices_dict = {
-            'device1': {
+            'eosaccess': {
                 'vxlans': {
                     'vxlan1': {
                         'vni': 100200,
@@ -176,11 +176,12 @@ class SettingsTests(unittest.TestCase):
             ]
         }
         result = get_groups_priorities_sorted(settings=group_settings_dict)
+        # Groups with priority 0 is not evaluated in selecting primary group
         self.assertEqual(list(result.keys()),
-                         ['HIGH', 'DEFAULT', 'NONE'],
+                         ['HIGH', 'DEFAULT'],
                          "Unexpected ordering of groups sorted by priority")
         self.assertNotEqual(list(result.keys()),
-                            ['NONE', 'DEFAULT', 'HIGH'],
+                            ['DEFAULT', 'HIGH'],
                             "Unexpected ordering of groups sorted by priority")
 
     def test_get_device_primary_group(self):

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -5,7 +5,8 @@ import pkg_resources
 
 from cnaas_nms.db.settings import get_settings, verify_dir_structure, \
     DIR_STRUCTURE, VerifyPathException, \
-    check_vlan_collisions, VlanConflictError
+    check_vlan_collisions, VlanConflictError, \
+    get_groups_priorities_sorted, get_device_primary_groups
 from cnaas_nms.db.device import DeviceType
 
 class SettingsTests(unittest.TestCase):
@@ -149,6 +150,42 @@ class SettingsTests(unittest.TestCase):
             }
         }
         self.assertIsNone(check_vlan_collisions(devices_dict, mgmt_vlans))
+
+    def test_groups_priorities_sorted(self):
+        group_settings_dict = {
+            "groups": [
+                {
+                    "group": {
+                        "name": "DEFAULT",
+                        "group_priority": 1
+                    },
+                },
+                {
+                    "group": {
+                        "name": "HIGH",
+                        "group_priority": 100
+                    }
+                },
+                {
+                    "group": {
+                        "name": "NONE",
+                        "group_priority": 0
+                    }
+                },
+            ]
+        }
+        result = get_groups_priorities_sorted(settings=group_settings_dict)
+        self.assertEqual(list(result.keys()),
+                         ['HIGH', 'DEFAULT', 'NONE'],
+                         "Unexpected ordering of groups sorted by priority")
+        self.assertNotEqual(list(result.keys()),
+                            ['NONE', 'DEFAULT', 'HIGH'],
+                            "Unexpected ordering of groups sorted by priority")
+
+    def test_get_device_primary_group(self):
+        before = get_device_primary_groups()
+        after = get_device_primary_groups(no_cache=True)
+        self.assertEqual(before, after)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Every device is assigned exactly one primary group, and settings can be applied to this group. In the future maybe authorization can be controlled per primary group. A single device can still belong to multiple secondary groups, and secondary groups can be used to assign vxlans, sync settings, upgrade firmware etc.

settings repo: global/groups.yml syntax:
```
  - group:
      name: 'E1'
      regex: 'eosdist1$'
      group_priority: 100
  - group:
      name: 'E'
      regex: 'eosdist.*'
      group_priority: 99
```

device eosdist1 belongs to group E1, and eosdist2 belongs to group E.
Settings can then be set in settings repo groups/E/base_system.yml for example