### PR TITLE
Feature.nonredundant access

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,5 +1,5 @@
 name: Run CNaaS-NMS unit tests
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   docker-tests:

--- a/docs/apiref/interfaces.rst
+++ b/docs/apiref/interfaces.rst
@@ -140,12 +140,19 @@ You can check what VLAN names exist on a specific switch by using the /settings
 API call and specifying the hostname and then look for the vlan_name field
 under a specific vxlan.
 
-Data can also contain any of these optional keys:
+Data can contain any of these optional keys:
 
+- untagged_vlan: Numeric or string representation of a VLAN/VXLAN from vxlans.yml
+- tagged_vlan_list: List of VLANs/VXLANs
 - description: Description for the interface, this should be a string 0-64 characters.
 - enabled: Set the administrative state of the interface. Defaults to true if not set.
 - aggregate_id: Identifier for configuring LACP etc. Integer value.
   Special value -1 means configure MLAG and use ID based on indexnum.
+- neighbor: Populated at init, contains hostname of peer
+- bpdu_filter: bool defining STP BPDU feature enabled/disabled
+- redundant_link: bool allows specifying if this link allows non-redundant downlinks
+- tags: List of strings, user-defined custom tags to use in templates
+- cli_append_str: String of custom config that is appended to generated CLI config
 
 Setting an optional value to JSON null will remove it from the database.
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -428,6 +428,7 @@ class DeviceInitCheckApi(Resource):
         with sqla_session() as session:
             try:
                 dev = cnaas_nms.confpush.init_device.pre_init_checks(session, device_id)
+                ret['linknets'] = dev.get_linknets()
             except ValueError as e:
                 return empty_result(status='error',
                                     data="ValueError in pre_init_checks: {}".format(e)), 400
@@ -439,6 +440,7 @@ class DeviceInitCheckApi(Resource):
                 try:
                     mlag_peer_dev = cnaas_nms.confpush.init_device.pre_init_checks(
                         session, mlag_peer_id)
+                    ret['linknets'] += mlag_peer_dev.get_linknets()
                 except ValueError as e:
                     return empty_result(status='error',
                                         data="ValueError in pre_init_checks: {}".format(e)), 400
@@ -447,7 +449,7 @@ class DeviceInitCheckApi(Resource):
                                         data="Exception in pre_init_checks: {}".format(e)), 500
 
             try:
-                ret['linknets'] = cnaas_nms.confpush.update.update_linknets(
+                ret['linknets'] += cnaas_nms.confpush.update.update_linknets(
                     session,
                     hostname=dev.hostname,
                     devtype=target_devtype,

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -428,7 +428,7 @@ class DeviceInitCheckApi(Resource):
         with sqla_session() as session:
             try:
                 dev = cnaas_nms.confpush.init_device.pre_init_checks(session, device_id)
-                ret['linknets'] = dev.get_linknets()
+                ret['linknets'] = dev.get_linknets(session)
             except ValueError as e:
                 return empty_result(status='error',
                                     data="ValueError in pre_init_checks: {}".format(e)), 400
@@ -440,7 +440,7 @@ class DeviceInitCheckApi(Resource):
                 try:
                     mlag_peer_dev = cnaas_nms.confpush.init_device.pre_init_checks(
                         session, mlag_peer_id)
-                    ret['linknets'] += mlag_peer_dev.get_linknets()
+                    ret['linknets'] += mlag_peer_dev.get_linknets(session)
                 except ValueError as e:
                     return empty_result(status='error',
                                         data="ValueError in pre_init_checks: {}".format(e)), 400

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -428,7 +428,7 @@ class DeviceInitCheckApi(Resource):
         with sqla_session() as session:
             try:
                 dev = cnaas_nms.confpush.init_device.pre_init_checks(session, device_id)
-                ret['linknets'] = dev.get_linknets(session)
+                ret['linknets'] = dev.get_linknets_as_dict(session)
             except ValueError as e:
                 return empty_result(status='error',
                                     data="ValueError in pre_init_checks: {}".format(e)), 400
@@ -440,7 +440,7 @@ class DeviceInitCheckApi(Resource):
                 try:
                     mlag_peer_dev = cnaas_nms.confpush.init_device.pre_init_checks(
                         session, mlag_peer_id)
-                    ret['linknets'] += mlag_peer_dev.get_linknets(session)
+                    ret['linknets'] += mlag_peer_dev.get_linknets_as_dict(session)
                 except ValueError as e:
                     return empty_result(status='error',
                                         data="ValueError in pre_init_checks: {}".format(e)), 400

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -472,10 +472,14 @@ class DeviceInitCheckApi(Resource):
 
             try:
                 if 'linknets' in ret and ret['linknets']:
-                    ret['neighbors'] = cnaas_nms.confpush.init_device.pre_init_check_neighbors(
-                        session, dev, target_devtype,
-                        ret['linknets'], parsed_args['neighbors'], mlag_peer_dev)
-                    ret['neighbors_compatible'] = True
+                    try:
+                        ret['neighbors'] = cnaas_nms.confpush.init_device.pre_init_check_neighbors(
+                            session, dev, target_devtype,
+                            ret['linknets'], parsed_args['neighbors'], mlag_peer_dev)
+                        ret['neighbors_compatible'] = True
+                    except cnaas_nms.confpush.init_device.InitVerificationError as e:
+                        ret['neighbors_compatible'] = False
+                        ret['neighbors_error'] = str(e)
                 else:
                     ret['neighbors_compatible'] = False
                     ret['neighbors_error'] = "No linknets found"

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -163,6 +163,13 @@ class InterfaceApi(Resource):
                                 errors.append(
                                     "bpdu_filter must be a bool, true or false, got: {}".
                                     format(if_dict['data']['bpdu_filter']))
+                        if 'redundant_link' in if_dict['data']:
+                            if type(if_dict['data']['redundant_link']) == bool:
+                                intfdata['redundant_link'] = if_dict['data']['redundant_link']
+                            else:
+                                errors.append(
+                                    "redundant_link must be a bool, true or false, got: {}".
+                                    format(if_dict['data']['redundant_link']))
                         if 'tags' in if_dict['data']:
                             if isinstance(if_dict['data']['tags'], list):
                                 intfdata['tags'] = if_dict['data']['tags']

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -82,7 +82,7 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
                 uplinks[uplink_intf.name] = uplink_intf.data['neighbor']
             except Exception as e:
                 continue
-        if len(uplinks) == 2:
+        if 1 <= len(uplinks) <= 2:
             logger.debug("Existing uplinks for device {} found: {}".
                          format(hostname, ', '.join(["{}: {}".format(ifname, hostname)
                                                      for ifname, hostname in uplinks.items()])))
@@ -193,52 +193,83 @@ def get_interfacedb_ifs(session, hostname: str) -> List[str]:
     return ret
 
 
-def verify_peer_iftype(local_hostname: str, local_devtype: DeviceType,
+def verify_peer_iftype(session, local_dev: Device,
                        local_device_settings: dict, local_if: str,
-                       remote_hostname: str, remote_devtype: DeviceType,
+                       remote_dev: Device,
                        remote_device_settings: dict, remote_if: str):
+    """Verify that both peers of a linknet are configured with the
+    correct interfaces classes.
+
+    Returns:
+        bool: True if redundant linknet is required.
+
+    Raises:
+        ValueError
+    """
+
     # Make sure interface with peers are configured in settings for CORE and DIST devices
-    if remote_devtype in [DeviceType.DIST, DeviceType.CORE]:
+    if remote_dev.device_type in [DeviceType.DIST, DeviceType.CORE]:
         match = False
         for intf in remote_device_settings['interfaces']:
             if intf['name'] == remote_if:
                 match = True
         if not match:
             raise ValueError("Peer device interface is not configured: "
-                             "{} {}".format(remote_hostname,
+                             "{} {}".format(remote_dev.hostname,
                                             remote_if))
-    if local_devtype in [DeviceType.DIST, DeviceType.CORE]:
+    if local_dev.device_type in [DeviceType.DIST, DeviceType.CORE]:
         match = False
         for intf in local_device_settings['interfaces']:
             if intf['name'] == local_if:
                 match = True
         if not match:
             raise ValueError("Local device interface is not configured: "
-                             "{} {}".format(local_hostname,
+                             "{} {}".format(local_dev.hostname,
                                             local_if))
 
     # Make sure linknets between CORE/DIST devices are configured as fabric
-    if local_devtype in [DeviceType.DIST, DeviceType.CORE] and \
-            remote_devtype in [DeviceType.DIST, DeviceType.CORE]:
+    if local_dev.device_type in [DeviceType.DIST, DeviceType.CORE] and \
+            remote_dev.device_type in [DeviceType.DIST, DeviceType.CORE]:
         for intf in local_device_settings['interfaces']:
             if intf['name'] == local_if and intf['ifclass'] != 'fabric':
                 raise ValueError("Local device interface is not configured as fabric: "
-                                 "{} {} ifclass: {}".format(local_hostname,
+                                 "{} {} ifclass: {}".format(local_dev.hostname,
                                                             intf['name'],
                                                             intf['ifclass']))
         for intf in remote_device_settings['interfaces']:
             if intf['name'] == remote_if and intf['ifclass'] != 'fabric':
                 raise ValueError("Peer device interface is not configured as fabric: "
-                                 "{} {} ifclass: {}".format(remote_hostname,
+                                 "{} {} ifclass: {}".format(remote_dev.hostname,
                                                             intf['name'],
                                                             intf['ifclass']))
 
     # Make sure that an access switch is connected to an interface
     # configured as "downlink" on the remote end
-    if local_devtype == DeviceType.ACCESS and remote_devtype == DeviceType.DIST:
+    if local_dev.device_type == DeviceType.ACCESS and remote_dev.device_type == DeviceType.DIST:
         for intf in remote_device_settings['interfaces']:
             if intf['name'] == remote_if and intf['ifclass'] != 'downlink':
                 raise ValueError("Peer device interface is not configured as downlink: "
-                                 "{} {} ifclass: {}".format(remote_hostname,
+                                 "{} {} ifclass: {}".format(remote_dev.hostname,
                                                             intf['name'],
                                                             intf['ifclass']))
+            if intf['name'] == remote_if and intf['ifclass'] == 'downlink' and \
+                    not intf['redundant_downlink']:
+                return False
+
+    elif local_dev.device_type == DeviceType.ACCESS and remote_dev.device_type == DeviceType.ACCESS:
+        remote_intf: Optional[Interface] = session.query(Interface).\
+            filter((Interface.device == remote_dev) & (Interface.name == remote_if)).\
+            one_or_none()
+        if not remote_intf:
+            raise ValueError("Peer device interface not found in database: {} {}".format(
+                remote_dev.hostname, remote_if
+            ))
+        if not remote_intf.configtype == InterfaceConfigType.ACCESS_DOWNLINK:
+            raise ValueError(
+                "Peer device interface not configured as ACCESS_DOWNLINK: {} {}".format(
+                    remote_dev.hostname, remote_if
+                ))
+        if 'redundant_downlink' in remote_intf.data and not remote_intf.data['redundant_downlink']:
+            return False
+
+    return True

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -175,6 +175,11 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
                 neighbor = linknet['device_b_hostname']
             elif linknet['device_b_hostname'] == dev.hostname:
                 neighbor = linknet['device_a_hostname']
+            elif mlag_peer_dev:
+                if linknet['device_a_hostname'] == mlag_peer_dev.hostname:
+                    neighbor = linknet['device_b_hostname']
+                elif linknet['device_b_hostname'] == mlag_peer_dev.hostname:
+                    neighbor = linknet['device_a_hostname']
             else:
                 raise Exception("Own hostname not found in linknet")
             neighbor_dev: Device = session.query(Device). \

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -172,17 +172,9 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
             if linknet['device_a_hostname'] == linknet['device_b_hostname']:
                 continue  # don't add loopback cables as neighbors
             elif linknet['device_a_hostname'] == dev.hostname:
-                if mlag_peer_dev and linknet['device_b_hostname'] == mlag_peer_dev.hostname:
-                    continue  # only add mlag peer linknet in one direction to avoid duplicate
-                else:
-                    neighbor = linknet['device_b_hostname']
+                neighbor = linknet['device_b_hostname']
             elif linknet['device_b_hostname'] == dev.hostname:
                 neighbor = linknet['device_a_hostname']
-            elif mlag_peer_dev:
-                if linknet['device_a_hostname'] == mlag_peer_dev.hostname:
-                    neighbor = linknet['device_b_hostname']
-                elif linknet['device_b_hostname'] == mlag_peer_dev.hostname:
-                    neighbor = linknet['device_a_hostname']
             else:
                 raise Exception("Own hostname not found in linknet")
             neighbor_dev: Device = session.query(Device). \

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -195,7 +195,7 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
             neighbors.append(neighbor)
 
         if len(uplinks) <= 0:
-            raise Exception(
+            raise InitVerificationError(
                 "No uplink neighbors found for device id: {} ({})".format(dev.id, dev.hostname))
         elif len(uplinks) == 1 and redundant_uplinks == 0:
             logger.debug(
@@ -208,7 +208,7 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
                     dev.id, dev.hostname, uplinks
                 ))
         else:
-            raise Exception(
+            raise InitVerificationError(
                 ("Incompatible uplink neighbors found for device id {} ({}): "
                  """{} - {} has redundancy required ("redundant_link" setting)""").format(
                     dev.id, dev.hostname, uplinks, redundant_uplinks

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -188,7 +188,10 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
             if not neighbor_dev:
                 raise NeighborError("Neighbor device {} not found in database".format(neighbor))
             if neighbor_dev.device_type in [DeviceType.ACCESS, DeviceType.DIST]:
-                if linknet['redundant_link']:
+                if 'redundant_link' in linknet:
+                    if linknet['redundant_link']:
+                        redundant_uplinks += 1
+                else:
                     redundant_uplinks += 1
                 uplinks.append(neighbor)
 

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -345,7 +345,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         # If this is the first device in an MLAG pair
         if mlag_peer_id and mlag_peer_new_hostname:
             mlag_peer_dev = pre_init_checks(session, mlag_peer_id)
-            linknets += mlag_peer_dev.get_linknets()
+            linknets += mlag_peer_dev.get_linknets(session)
             linknets += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS)
             update_interfacedb_worker(session, dev, replace=True, delete_all=False,
                                       mlag_peer_hostname=mlag_peer_dev.hostname)

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -15,7 +15,7 @@ import cnaas_nms.confpush.underlay
 import cnaas_nms.db.helper
 from cnaas_nms.app_settings import api_settings, app_settings
 from cnaas_nms.db.session import sqla_session
-from cnaas_nms.db.device import Device, DeviceState, DeviceType, DeviceStateException
+from cnaas_nms.db.device import Device, DeviceState, DeviceType, DeviceStateError
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.scheduler.wrapper import job_wrapper
@@ -119,7 +119,7 @@ def pre_init_checks(session, device_id) -> Device:
     if not dev:
         raise ValueError(f"No device with id {device_id} found")
     if dev.state != DeviceState.DISCOVERED:
-        raise DeviceStateException("Device must be in state DISCOVERED to begin init")
+        raise DeviceStateError("Device must be in state DISCOVERED to begin init")
     old_hostname = dev.hostname
     # Perform connectivity check
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
@@ -623,7 +623,7 @@ def init_device_step2(device_id: int, iteration: int = -1,
         if dev.state != DeviceState.INIT:
             logger.error("Device with ID {} got to init step2 but is in incorrect state: {}".\
                          format(device_id, dev.state.name))
-            raise DeviceStateException("Device must be in state INIT to continue init step 2")
+            raise DeviceStateError("Device must be in state INIT to continue init step 2")
         hostname = dev.hostname
         devtype: DeviceType = dev.device_type
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -336,7 +336,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
     logger = get_logger()
     with sqla_session() as session:
         dev = pre_init_checks(session, device_id)
-        linknets = dev.get_linknets(session)
+        linknets = dev.get_linknets_as_dict(session)
         mlag_peer_dev: Optional[Device] = None
 
         # update linknets using LLDP data
@@ -345,7 +345,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         # If this is the first device in an MLAG pair
         if mlag_peer_id and mlag_peer_new_hostname:
             mlag_peer_dev = pre_init_checks(session, mlag_peer_id)
-            linknets += mlag_peer_dev.get_linknets(session)
+            linknets += mlag_peer_dev.get_linknets_as_dict(session)
             linknets += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS)
             update_interfacedb_worker(session, dev, replace=True, delete_all=False,
                                       mlag_peer_hostname=mlag_peer_dev.hostname)

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -192,27 +192,28 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
                     redundant_uplinks += 1
                 uplinks.append(neighbor)
 
-            if len(uplinks) <= 0:
-                raise Exception(
-                    "No uplink neighbors found for device id: {} ({})".format(dev.id, dev.hostname))
-            elif len(uplinks) == 1 and redundant_uplinks == 0:
-                logger.debug(
-                    "One non-redundant uplink neighbors found for device id {} ({}): {}".format(
-                        dev.id, dev.hostname, uplinks
-                    ))
-            elif len(uplinks) == 2 and redundant_uplinks == 2:
-                logger.debug(
-                    "Two redundant uplink neighbors found for device id {} ({}): {}".format(
-                        dev.id, dev.hostname, uplinks
-                    ))
-            else:
-                raise Exception(
-                    ("Incompatible uplink neighbors found for device id {} ({}): "
-                     """{} - {} has redundancy required ("redundant_link" setting)""").format(
-                        dev.id, dev.hostname, uplinks, redundant_uplinks
-                    ))
-
             neighbors.append(neighbor)
+
+        if len(uplinks) <= 0:
+            raise Exception(
+                "No uplink neighbors found for device id: {} ({})".format(dev.id, dev.hostname))
+        elif len(uplinks) == 1 and redundant_uplinks == 0:
+            logger.debug(
+                "One non-redundant uplink neighbors found for device id {} ({}): {}".format(
+                    dev.id, dev.hostname, uplinks
+                ))
+        elif len(uplinks) == 2 and redundant_uplinks == 2:
+            logger.debug(
+                "Two redundant uplink neighbors found for device id {} ({}): {}".format(
+                    dev.id, dev.hostname, uplinks
+                ))
+        else:
+            raise Exception(
+                ("Incompatible uplink neighbors found for device id {} ({}): "
+                 """{} - {} has redundancy required ("redundant_link" setting)""").format(
+                    dev.id, dev.hostname, uplinks, redundant_uplinks
+                ))
+
         try:
             cnaas_nms.db.helper.find_mgmtdomain(session, uplinks)
         except Exception as e:

--- a/src/cnaas_nms/confpush/sync_devices.py
+++ b/src/cnaas_nms/confpush/sync_devices.py
@@ -271,6 +271,7 @@ def populate_device_vars(session, dev: Device,
                     fabric_device_variables['interfaces'].append({
                         'name': intf['name'],
                         'ifclass': intf['ifclass'],
+                        'redundant_link': intf['redundant_link'],
                         'indexnum': ifindexnum,
                         'data': data
                     })

--- a/src/cnaas_nms/confpush/tests/data/testdata.yml
+++ b/src/cnaas_nms/confpush/tests/data/testdata.yml
@@ -3,3 +3,50 @@ init_access_old_hostname: mac-0800275C091F
 init_access_new_hostname: eosaccess
 update_hostname: mac-0800275C091F
 copycert_hostname: eosdist1
+linknet_redundant:
+  - description: null
+    device_a_hostname: eosaccess
+    device_a_ip: null
+    device_a_port: Ethernet2
+    device_b_hostname: eosdist1
+    device_b_ip: null
+    device_b_port: Ethernet2
+    ipv4_network: null
+    redundant_link: true
+    site_id: null
+  - description: null
+    device_a_hostname: eosaccess
+    device_a_ip: null
+    device_a_port: Ethernet3
+    device_b_hostname: eosdist2
+    device_b_ip: null
+    device_b_port: Ethernet2
+    ipv4_network: null
+    redundant_link: true
+    site_id: null
+linknet_nonredundant:
+  - description: null
+    device_a_hostname: eosaccess
+    device_a_ip: null
+    device_a_port: Ethernet2
+    device_b_hostname: eosdist1
+    device_b_ip: null
+    device_b_port: Ethernet20
+    ipv4_network: null
+    redundant_link: false
+    site_id: null
+lldp_data_redundant:
+  Ethernet2:
+    - hostname: eosdist1
+      port: Ethernet2
+  Ethernet3:
+    - hostname: eosdist2
+      port: Ethernet2
+lldp_data_nonredundant:
+  Ethernet2:
+    - hostname: eosdist1
+      port: Ethernet20
+lldp_data_nonredundant_error:
+  Ethernet2:
+    - hostname: eosdist1
+      port: Ethernet2

--- a/src/cnaas_nms/confpush/tests/data/testdata.yml
+++ b/src/cnaas_nms/confpush/tests/data/testdata.yml
@@ -7,8 +7,10 @@ linknet_redundant:
   - description: null
     device_a_hostname: eosaccess
     device_a_ip: null
+    device_a_id: null
     device_a_port: Ethernet2
     device_b_hostname: eosdist1
+    device_b_id: null
     device_b_ip: null
     device_b_port: Ethernet2
     ipv4_network: null
@@ -17,9 +19,11 @@ linknet_redundant:
   - description: null
     device_a_hostname: eosaccess
     device_a_ip: null
+    device_a_id: null
     device_a_port: Ethernet3
     device_b_hostname: eosdist2
     device_b_ip: null
+    device_b_id: null
     device_b_port: Ethernet2
     ipv4_network: null
     redundant_link: true
@@ -28,9 +32,11 @@ linknet_nonredundant:
   - description: null
     device_a_hostname: eosaccess
     device_a_ip: null
+    device_a_id: null
     device_a_port: Ethernet2
     device_b_hostname: eosdist1
     device_b_ip: null
+    device_b_id: null
     device_b_port: Ethernet20
     ipv4_network: null
     redundant_link: false

--- a/src/cnaas_nms/confpush/tests/test_update.py
+++ b/src/cnaas_nms/confpush/tests/test_update.py
@@ -1,0 +1,31 @@
+import unittest
+import pkg_resources
+import yaml
+import os
+
+from cnaas_nms.confpush.update import update_linknets
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.device import DeviceType
+
+
+class UpdateTests(unittest.TestCase):
+    def setUp(self):
+        data_dir = pkg_resources.resource_filename(__name__, 'data')
+        with open(os.path.join(data_dir, 'testdata.yml'), 'r') as f_testdata:
+            self.testdata = yaml.safe_load(f_testdata)
+
+    def test_update_linknet(self):
+        with sqla_session() as session:
+            neighbors_data = {
+                "Ethernet2": [{"hostname": "eosdist1", "port": "Ethernet2"}],
+                "Ethernet3": [{"hostname": "eosdist2", "port": "Ethernet2"}],
+            }
+            linknets = update_linknets(session, hostname="eosaccess",
+                                       devtype=DeviceType.ACCESS, ztp_hostname="eosaccess",
+                                       dry_run=True, neighbors_arg=neighbors_data)
+            breakpoint()
+            print(linknets)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cnaas_nms/confpush/tests/test_update.py
+++ b/src/cnaas_nms/confpush/tests/test_update.py
@@ -6,6 +6,7 @@ import os
 from cnaas_nms.confpush.update import update_linknets
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.device import DeviceType
+from cnaas_nms.db.interface import InterfaceError
 
 
 class UpdateTests(unittest.TestCase):
@@ -14,7 +15,7 @@ class UpdateTests(unittest.TestCase):
         with open(os.path.join(data_dir, 'testdata.yml'), 'r') as f_testdata:
             self.testdata = yaml.safe_load(f_testdata)
 
-    def test_update_linknet(self):
+    def test_update_linknet_eosaccess(self):
         with sqla_session() as session:
             neighbors_data = {
                 "Ethernet2": [{"hostname": "eosdist1", "port": "Ethernet2"}],
@@ -23,8 +24,29 @@ class UpdateTests(unittest.TestCase):
             linknets = update_linknets(session, hostname="eosaccess",
                                        devtype=DeviceType.ACCESS, ztp_hostname="eosaccess",
                                        dry_run=True, neighbors_arg=neighbors_data)
-            breakpoint()
-            print(linknets)
+            self.assertListEqual(
+                linknets,
+                [{'description': None, 'device_a_hostname': 'eosaccess', 'device_a_ip': None,
+                  'device_a_port': 'Ethernet2', 'device_b_hostname': 'eosdist1',
+                  'device_b_ip': None, 'device_b_port': 'Ethernet2', 'ipv4_network': None,
+                  'redundant_link': True, 'site_id': None},
+                 {'description': None, 'device_a_hostname': 'eosaccess', 'device_a_ip': None,
+                  'device_a_port': 'Ethernet3', 'device_b_hostname': 'eosdist2',
+                  'device_b_ip': None, 'device_b_port': 'Ethernet2', 'ipv4_network': None,
+                  'redundant_link': True, 'site_id': None}],
+                "Update linknets returned unexpected data for eosaccess links"
+            )
+
+    def test_update_linknet_wrong_porttype(self):
+        with sqla_session() as session:
+            neighbors_data = {
+                "Ethernet2": [{"hostname": "eosdist1", "port": "Ethernet1"}],
+                "Ethernet3": [{"hostname": "eosdist2", "port": "Ethernet1"}],
+            }
+            self.assertRaises(
+                InterfaceError, update_linknets, session, hostname="eosaccess",
+                devtype=DeviceType.ACCESS, ztp_hostname="eosaccess",
+                dry_run=True, neighbors_arg=neighbors_data)
 
 
 if __name__ == '__main__':

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -304,6 +304,25 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
                     )
             ):
                 if not dry_run:
+                    if check_linknet.device_a_id == local_devid:
+                        ret_dict = {
+                            'device_a_hostname': local_device_inst.hostname,
+                            'device_b_hostname': remote_device_inst.hostname,
+                        }
+                    else:
+                        ret_dict = {
+                            'device_a_hostname': remote_device_inst.hostname,
+                            'device_b_hostname': local_device_inst.hostname,
+                        }
+                    ret_dict = {
+                        **ret_dict,
+                        'redundant_link': redundant_link,
+                        **check_linknet.as_dict()
+                    }
+                    del ret_dict['id']
+                    del ret_dict['device_a_id']
+                    del ret_dict['device_b_id']
+                    ret.append({k: ret_dict[k] for k in sorted(ret_dict)})
                     # All info is the same, no update required
                     continue
             else:

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -262,9 +262,11 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
                                                  remote_device_inst.model
                                                  )
 
+        local_device_inst_copy = local_device_inst
+        local_device_inst_copy.device_type = devtype
         redundant_link = verify_peer_iftype(
             session,
-            local_device_inst, local_device_settings, local_if,
+            local_device_inst_copy, local_device_settings, local_if,
             remote_device_inst, remote_device_settings, data[0]['port'])
 
         # Check if linknet object already exists in database

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -262,7 +262,10 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
                                                  remote_device_inst.model
                                                  )
 
-        local_device_inst_copy = local_device_inst
+        local_device_inst_copy = Device(
+            hostname=local_device_inst.hostname,
+            device_type=local_device_inst.device_typ
+        )
         local_device_inst_copy.device_type = devtype
         redundant_link = verify_peer_iftype(
             session,

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -320,8 +320,6 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
                         **check_linknet.as_dict()
                     }
                     del ret_dict['id']
-                    del ret_dict['device_a_id']
-                    del ret_dict['device_b_id']
                     ret.append({k: ret_dict[k] for k in sorted(ret_dict)})
                     # All info is the same, no update required
                     continue
@@ -361,7 +359,5 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
             **new_link.as_dict()
         }
         del ret_dict['id']
-        del ret_dict['device_a_id']
-        del ret_dict['device_b_id']
         ret.append({k: ret_dict[k] for k in sorted(ret_dict)})
     return ret

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -264,7 +264,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
 
         local_device_inst_copy = Device(
             hostname=local_device_inst.hostname,
-            device_type=local_device_inst.device_typ
+            device_type=local_device_inst.device_type
         )
         local_device_inst_copy.device_type = devtype
         redundant_link = verify_peer_iftype(

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -143,6 +143,12 @@ class Device(cnaas_nms.db.base.Base):
             ret.append(linknet)
         return ret
 
+    def get_linknets_as_dict(self, session):
+        ret = []
+        for linknet in self.get_linknets(session):
+            ret.append(linknet.as_dict())
+        return ret
+
     def get_linknet_localif_mapping(self, session) -> dict[str, str]:
         """Return a mapping with local interface name and what peer device hostname
         that interface is connected to."""

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -23,11 +23,11 @@ from cnaas_nms.db.stackmember import Stackmember
 from cnaas_nms.tools.event import add_event
 
 
-class DeviceException(Exception):
+class DeviceError(Exception):
     pass
 
 
-class DeviceStateException(DeviceException):
+class DeviceStateError(DeviceError):
     pass
 
 
@@ -244,7 +244,7 @@ class Device(cnaas_nms.db.base.Base):
                 elif linknet.device_b == self and linknet.device_b_port == intf.name:
                     peers.add(linknet.device_a)
         if len(peers) > 1:
-            raise DeviceException("More than one MLAG peer found: {}".format(
+            raise DeviceError("More than one MLAG peer found: {}".format(
                 [x.hostname for x in peers]
             ))
         elif len(peers) == 1:
@@ -253,7 +253,7 @@ class Device(cnaas_nms.db.base.Base):
                 # Ignore check during INIT, one device might be UNKNOWN
                 pass
             elif self.device_type != peer_devtype:
-                raise DeviceException("MLAG peers are not the same device type")
+                raise DeviceError("MLAG peers are not the same device type")
             return next(iter(peers))
         else:
             return None

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -31,6 +31,10 @@ class DeviceStateError(DeviceError):
     pass
 
 
+class DeviceSyncError(DeviceError):
+    pass
+
+
 class DeviceState(enum.Enum):
     UNKNOWN = 0         # Unhandled programming error
     PRE_CONFIGURED = 1  # Pre-populated, not seen yet

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -146,7 +146,13 @@ class Device(cnaas_nms.db.base.Base):
     def get_linknets_as_dict(self, session):
         ret = []
         for linknet in self.get_linknets(session):
-            ret.append(linknet.as_dict())
+            linknet_dict = linknet.as_dict()
+            linknet_dict = {
+                'device_a_hostname': linknet.device_a.hostname,
+                'device_b_hostname': linknet.device_b.hostname,
+                **linknet_dict
+            }
+            ret.append(linknet_dict)
         return ret
 
     def get_linknet_localif_mapping(self, session) -> dict[str, str]:

--- a/src/cnaas_nms/db/interface.py
+++ b/src/cnaas_nms/db/interface.py
@@ -11,6 +11,10 @@ import cnaas_nms.db.base
 import cnaas_nms.db.device
 
 
+class InterfaceError(Exception):
+    pass
+
+
 class InterfaceConfigType(enum.Enum):
     UNKNOWN = 0
     UNMANAGED = 1

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -129,6 +129,7 @@ class f_evpn_peer(BaseModel):
 class f_interface(BaseModel):
     name: str = ifname_schema
     ifclass: str = ifclass_schema
+    redundant_downlink: bool = True
     config: Optional[str] = None
     description: Optional[str] = ifdescr_schema
     enabled: Optional[bool] = None

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -129,7 +129,7 @@ class f_evpn_peer(BaseModel):
 class f_interface(BaseModel):
     name: str = ifname_schema
     ifclass: str = ifclass_schema
-    redundant_downlink: bool = True
+    redundant_link: bool = True
     config: Optional[str] = None
     description: Optional[str] = ifdescr_schema
     enabled: Optional[bool] = None

--- a/src/cnaas_nms/db/tests/data/testdata.yml
+++ b/src/cnaas_nms/db/tests/data/testdata.yml
@@ -1,3 +1,5 @@
 ---
 query_neighbor_device: 'mac-080027F60C55'
 testdevice: eosaccess
+mgmtdomain_ipv4_gw: '10.0.66.1/24'
+mgmtdomain_vlan: 660

--- a/src/cnaas_nms/db/tests/test_device.py
+++ b/src/cnaas_nms/db/tests/test_device.py
@@ -50,8 +50,8 @@ class DeviceTests(unittest.TestCase):
             test_linknet = Linknet(device_a=device1, device_b=device2)
             device1 = session.query(Device).filter(Device.hostname == 'test-device1').one()
             device2 = session.query(Device).filter(Device.hostname == 'test-device2').one()
-            self.assertEquals([test_linknet], device1.get_linknets(session))
-            self.assertEquals([test_linknet], device2.get_linknets(session))
+            self.assertEqual([test_linknet], device1.get_linknets(session))
+            self.assertEqual([test_linknet], device2.get_linknets(session))
 
     def test_get_links_to(self):
         device1 = DeviceTests.create_test_device('test-device1')
@@ -62,8 +62,8 @@ class DeviceTests(unittest.TestCase):
             test_linknet = Linknet(device_a=device1, device_b=device2)
             device1 = session.query(Device).filter(Device.hostname == 'test-device1').one()
             device2 = session.query(Device).filter(Device.hostname == 'test-device2').one()
-            self.assertEquals([test_linknet], device1.get_links_to(session, device2))
-            self.assertEquals([test_linknet], device2.get_links_to(session, device1))
+            self.assertEqual([test_linknet], device1.get_links_to(session, device2))
+            self.assertEqual([test_linknet], device2.get_links_to(session, device1))
 
     def test_get_neighbors(self):
         device1 = DeviceTests.create_test_device('test-device1')
@@ -74,8 +74,8 @@ class DeviceTests(unittest.TestCase):
             test_linknet = Linknet(device_a=device1, device_b=device2)
             device1 = session.query(Device).filter(Device.hostname == 'test-device1').one()
             device2 = session.query(Device).filter(Device.hostname == 'test-device2').one()
-            self.assertEquals([device2], device1.get_neighbors(session))
-            self.assertEquals([device1], device2.get_neighbors(session))
+            self.assertEqual([device2], device1.get_neighbors(session))
+            self.assertEqual([device1], device2.get_neighbors(session))
 
     def test_is_stack(self):
         with sqla_session() as session:

--- a/src/cnaas_nms/db/tests/test_mgmtdomain.py
+++ b/src/cnaas_nms/db/tests/test_mgmtdomain.py
@@ -11,58 +11,78 @@ import cnaas_nms.db.helper
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
+from cnaas_nms.db.tests.test_device import DeviceTests
 
 
 class MgmtdomainTests(unittest.TestCase):
-    def setUp(self):
+    @staticmethod
+    def get_testdata():
         data_dir = pkg_resources.resource_filename(__name__, 'data')
         with open(os.path.join(data_dir, 'testdata.yml'), 'r') as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            return yaml.safe_load(f_testdata)
 
-    def add_mgmtdomain(self):
+    def setUp(self):
+        self.testdata = self.get_testdata()
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.add_mgmtdomain()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.delete_mgmtdomain()
+
+    @classmethod
+    def add_mgmtdomain(cls):
+        testdata = cls.get_testdata()
         with sqla_session() as session:
-            d_a = session.query(Device).filter(Device.hostname == 'eosdist1').one()
-            d_b = session.query(Device).filter(Device.hostname == 'eosdist2').one()
-            #TODO: get params from testdata.yml
+            d_a = DeviceTests.create_test_device("mgmtdomaintest1")
+            d_b = DeviceTests.create_test_device("mgmtdomaintest2")
+            session.add(d_a)
+            session.add(d_b)
             new_mgmtd = Mgmtdomain()
             new_mgmtd.device_a = d_a
             new_mgmtd.device_b = d_b
-            new_mgmtd.ipv4_gw = '10.0.6.1/24'
-            new_mgmtd.vlan = 600
-            result = session.add(new_mgmtd)
+            new_mgmtd.ipv4_gw = testdata['mgmtdomain_ipv4_gw']
+            new_mgmtd.vlan = testdata['mgmtdomain_vlan']
+            session.add(new_mgmtd)
+            session.commit()
 
-        pprint.pprint(result)
-        # Inventory dict should contain these top level keys
-        #self.assertListEqual(
-        #    ['hosts', 'groups', 'defaults'],
-        #    list(result.keys()))
-        # Hosts key should include atleast 1 item
-        #self.assertLessEqual(
-        #    1,
-        #    len(result['hosts'].items()))
-
-    def delete_mgmtdomain(self):
+    @classmethod
+    def delete_mgmtdomain(cls):
         with sqla_session() as session:
-            d_a = session.query(Device).filter(Device.hostname == 'eosdist1').one()
+            d_a = session.query(Device).filter(Device.hostname == 'mgmtdomaintest1').one()
             instance = session.query(Mgmtdomain).filter(Mgmtdomain.device_a == d_a).first()
-            if instance:
-                session.delete(instance)
-                session.commit()
-            else:
-                print(f"Mgmtdomain for device {d_a.hostname} not found")
+            session.delete(instance)
+            d_a = session.query(Device).filter(Device.hostname == "mgmtdomaintest1").one()
+            d_b = session.query(Device).filter(Device.hostname == "mgmtdomaintest2").one()
+            session.delete(d_a)
+            session.delete(d_b)
 
-    def test_find_mgmt_omain(self):
+    def test_find_mgmtdomain_invalid(self):
+        with sqla_session() as session:
+            self.assertRaises(ValueError, cnaas_nms.db.helper.find_mgmtdomain, session, [])
+            self.assertRaises(ValueError, cnaas_nms.db.helper.find_mgmtdomain, session, [1, 2, 3])
+
+    def test_find_mgmtdomain_twodist(self):
         with sqla_session() as session:
             mgmtdomain = cnaas_nms.db.helper.find_mgmtdomain(session, ['eosdist1', 'eosdist2'])
-            if mgmtdomain:
-                pprint.pprint(mgmtdomain.as_dict())
+            self.assertIsNotNone(mgmtdomain, "No mgmtdomain found for eosdist1 + eosdist2")
+
+    def test_find_mgmtdomain_onedist(self):
+        with sqla_session() as session:
+            mgmtdomain = cnaas_nms.db.helper.find_mgmtdomain(session, ['eosdist1'])
+            self.assertIsNotNone(mgmtdomain, "No mgmtdomain found for eosdist1")
+
+    def test_find_mgmtdomain_oneaccess(self):
+        with sqla_session() as session:
+            mgmtdomain = cnaas_nms.db.helper.find_mgmtdomain(session, ['eosaccess'])
+            self.assertIsNotNone(mgmtdomain, "No mgmtdomain found for eosaccess")
 
     def test_find_free_mgmt_ip(self):
-        mgmtdomain_id = 1
         with sqla_session() as session:
-            mgmtdomain = session.query(Mgmtdomain).filter(Mgmtdomain.id == mgmtdomain_id).one()
-            if mgmtdomain:
-                print(mgmtdomain.find_free_mgmt_ip(session))
+            mgmtdomain = session.query(Mgmtdomain).limit(1).one()
+            mgmtdomain.find_free_mgmt_ip(session)
 
     def test_find_mgmtdomain_by_ip(self):
         with sqla_session() as session:

--- a/src/cnaas_nms/tools/tests/test_jinja_helpers.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_helpers.py
@@ -17,16 +17,16 @@ class EnvironmentSecretsTest(unittest.TestCase):
 
     def test_that_individual_secrets_are_present(self):
         secrets = get_environment_secrets()
-        self.assertEquals(secrets['TEMPLATE_SECRET_FOO'], 'bar')
-        self.assertEquals(secrets['TEMPLATE_SECRET_TEST_TYPE'], 'cromulent')
+        self.assertEqual(secrets['TEMPLATE_SECRET_FOO'], 'bar')
+        self.assertEqual(secrets['TEMPLATE_SECRET_TEST_TYPE'], 'cromulent')
 
     def test_that_secret_dict_is_set_properly(self):
         secrets = get_environment_secrets()
         self.assertIn('TEMPLATE_SECRET', secrets)
 
         secret_dict = secrets.get('TEMPLATE_SECRET')
-        self.assertEquals(secret_dict['FOO'], 'bar')
-        self.assertEquals(secret_dict['TEST_TYPE'], 'cromulent')
+        self.assertEqual(secret_dict['FOO'], 'bar')
+        self.assertEqual(secret_dict['TEST_TYPE'], 'cromulent')
 
     def test_that_non_secret_variables_arent_included(self):
         secrets = get_environment_secrets()


### PR DESCRIPTION
Allow init of access switches with no redundancy on uplinks if downlink interface is configured with redundant_link: False

Suggested templates update which still builds port-channel but with a single link/no ESI, under interface port-channel:
```
 {% if intf.redundant_link is not defined or intf.redundant_link is true %}
  {% if mgmtdomains|length > 0 %}
<esi config>
  {% endif %}
 {% endif %}

```