### PR TITLE
Bugfix: only check that uplink devices are in sync

### DIFF
--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -387,7 +387,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
                 logger.debug("Found valid neighbors for INIT of {}: {}".format(
                     new_hostname, ", ".join(verified_neighbors)
                 ))
-                check_neighbor_sync(session, verified_neighbors)
+                check_neighbor_sync(session, uplink_hostnames)
         except DeviceSyncError as e:
             logger.warn("Uplink device not in sync during init of {}: {}".format(
                 new_hostname, e


### PR DESCRIPTION
only check that uplink devices are in sync not all verified neighbors. bug introduced via commit 0ad7793be50456e45d1b8636ede9efa477cc3a2c