### PR TITLE
Implement custom JSON encoder class

### DIFF
--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -13,6 +13,7 @@ from flask_jwt_extended.exceptions import NoAuthorizationError
 from flask import jsonify
 from flask_cors import CORS
 
+from cnaas_nms.api.json import CNaaSJSONEncoder
 from cnaas_nms.version import __api_version__
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.app_settings import api_settings
@@ -76,6 +77,8 @@ class CnaasApi(Api):
 
 
 app = Flask(__name__)
+app.config['RESTX_JSON'] = {'cls': CNaaSJSONEncoder}
+
 # TODO: make origins configurable
 cors = CORS(app,
             resources={r"/api/*": {"origins": "*"}},

--- a/src/cnaas_nms/api/json.py
+++ b/src/cnaas_nms/api/json.py
@@ -1,0 +1,12 @@
+"""Custom JSON encoder utilities for API"""
+
+import json
+from ipaddress import _IPAddressBase
+
+
+class CNaaSJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, _IPAddressBase):
+            return str(o)
+        else:
+            return super().default(self, o)


### PR DESCRIPTION
In our custom settings, we convert IP address values to `ipaddress.IPv*Address` and `ipaddress.IPv*Interface` objects, which allows for more flexibility in manipulating addresses in configuration templates.

However, the JSON encoder used by Flask-RESTX does not support serializing IP address objects, causing an exception to be raised whenever CNaaS-NMS attempts to generate a full configuration context as a JSON response to the settings API endpoint.

This adds a custom JSONEncoder subclass that simply encodes IP address objects as their string representations, and configures Flask-RESTX to use it in the CNaaS-NMS app.