### PR TITLE
Build the test docker image from the source repo

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -42,11 +42,15 @@ jobs:
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
+      - name: Get repo URL
+        shell: bash
+        run: echo "CNAAS_REPO=$(echo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY})" >> $GITHUB_ENV
+
       - name: Print branch name
-        run: echo ${{ env.BRANCH_NAME }}
+        run: echo ${{ env.BRANCH_NAME }} at ${{ env.CNAAS_REPO }}
 
       - name: Build docker
-        run: docker-compose -f docker/docker-compose_test.yaml build --build-arg BUILDBRANCH=${{ env.BRANCH_NAME }}
+        run: docker-compose -f docker/docker-compose_test.yaml build --build-arg GITREPO_BASE=${{ env.CNAAS_REPO }} --build-arg BUILDBRANCH=${{ env.BRANCH_NAME }}
 
       - name: Start docker
         run: docker-compose -f docker/docker-compose_test.yaml up -d


### PR DESCRIPTION
Whether the source repo for a triggered workflow is the upstream repo or a fork, this should ensure the docker image is built from the right version.

I would, of course, prefer a version that builds the image from the current checkout, rather than make its own, since this would be more compatible with typival development workflows, but that can come later.