### PR TITLE
Fix broken COVERAGE option check

### DIFF
--- a/src/cnaas_nms/run.py
+++ b/src/cnaas_nms/run.py
@@ -15,9 +15,13 @@ os.environ['PYTHONPATH'] = os.getcwd()
 stop_websocket_threads = False
 
 
+def is_coverage_enabled():
+    return os.getenv('COVERAGE', '0').strip() not in ('0', 'off', 'false', 'no')
+
+
 print("Code coverage collection for worker in pid {}: {}".format(
     os.getpid(), ('COVERAGE' in os.environ)))
-if 'COVERAGE' in os.environ:
+if is_coverage_enabled():
     cov = coverage.coverage(
         data_file='/coverage/.coverage-{}'.format(os.getpid()),
         concurrency="gevent")
@@ -131,7 +135,7 @@ if __name__ == '__main__':
     stop_websocket_threads = True
     t_websocket_events.join()
 
-    if 'COVERAGE' in os.environ:
+    if is_coverage_enabled():
         save_coverage()
 
 else:
@@ -145,5 +149,5 @@ else:
 
     cnaas_app = get_app()
 
-    if 'COVERAGE' in os.environ:
+    if is_coverage_enabled():
         save_coverage()


### PR DESCRIPTION
The default `docker-compose.yml` sets the environment variable `COVERAGE` to an empty value. However, at runtime, the value of the environment variable is never verified: The presence of the variable in the environment is enough to enable coverage reporting in the code base.

Due to this, there is also no way to override the `COVERAGE` setting in e.g. `docker-compose.override.yml`, since you cannot get docker-compose to *remove* the variable from the environment, and you cannot give it a value that disabled coverage reporting.

This appears to cause coverage to be collected even in production settings, which is a performance no-no. Also, in our case, there is some privilege or dependency problem that crashes the API server in production, as the coverage module is unable to create a coverage report SQLite database in the configured/preferred location.