### PR TITLE
Fix Redis DeprecationWarning for charset/encoding

### DIFF
--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -43,5 +43,5 @@ def sqla_execute(**kwargs):
 
 @contextmanager
 def redis_session(**kwargs) -> StrictRedis:
-    with StrictRedis(host=app_settings.REDIS_HOSTNAME, port=app_settings.REDIS_PORT, charset="utf-8", decode_responses=True) as conn:
+    with StrictRedis(host=app_settings.REDIS_HOSTNAME, port=app_settings.REDIS_PORT, encoding="utf-8", decode_responses=True) as conn:
         yield conn


### PR DESCRIPTION
Redis library keeps complaining of deprecated usage of the `charset` argument. The argument is now known as `encoding`:

./lib/python3.7/site-packages/redis/client.py:905: DeprecationWarning: "charset" is deprecated. Use "encoding" instead