### PR TITLE
Add settings for global_unique_vlans and init_mgmt_timeout

### DIFF
--- a/docker/api/config/api.yml
+++ b/docker/api/config/api.yml
@@ -6,3 +6,5 @@ verify_tls_device: False
 cafile: /opt/cnaas/cacert/rootCA.crt
 cakeyfile: /opt/cnaas/cacert/rootCA.key
 certpath: /tmp/devicecerts/
+global_unique_vlans: True
+init_mgmt_timeout: 30

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -29,6 +29,11 @@ Defines parameters for the API:
 - cakeyfile: Path to CA key, used to sign device certificates after generation.
 - certpath: Path to store generated device certificates in.
 - allow_apply_config_liverun: Allow liverun on apply_config API call. Defaults to False.
+- global_unique_vlans: If True VLAN IDs has to be globally unique, if False
+  different DIST switches can reuse same VLAN IDs for different L2 domains.
+  Defaults to True.
+- init_mgmt_timeout: Timeout to wait for device to apply changed management IP.
+  Defaults to 30, specified in seconds (integer).
 
 /etc/cnaas-nms/repository.yml
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/cnaas_nms/api/system.py
+++ b/src/cnaas_nms/api/system.py
@@ -7,7 +7,8 @@ from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from cnaas_nms.api.generic import empty_result
 from cnaas_nms.api import app
 import cnaas_nms.version
-from cnaas_nms.tools.security import jwt_required
+from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.security import get_jwt_identity, jwt_required
 from cnaas_nms.version import __api_version__
 
 
@@ -19,6 +20,9 @@ class ShutdownApi(Resource):
     @jwt_required
     def post(self):
         print("System shutdown API called, exiting...")
+        scheduler = Scheduler()
+        scheduler.shutdown_mule()
+        scheduler.shutdown()
         app.socketio.stop()
         exit()
 

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -115,12 +115,16 @@ class DeviceTests(unittest.TestCase):
 
     def equipmenttest_initcheck_distdevice(self):
         device_id = self.testdata['initcheck_device_id']
+        pre_state = self.client.get(f'/api/v1.0/device/{device_id}').\
+            json['data']['devices'][0]['state']
         self.client.put(f'/api/v1.0/device/{device_id}', json={'state': 'DISCOVERED'})
         device_data = {"hostname": "distcheck", "device_type": "DIST"}
         result = self.client.post(f'/api/v1.0/device_initcheck/{device_id}', json=device_data)
-        self.assertEqual(result.status_code, 200)
+        self.client.put(f'/api/v1.0/device/{device_id}', json={'state': pre_state})
+        self.assertEqual(result.status_code, 500)
         json_data = json.loads(result.data.decode())
-        self.assertEqual(json_data['data']['compatible'], False)
+#        self.assertEqual(json_data['data']['compatible'], False)
+        self.assertEqual(json_data['status'], "error")
 
     def test_get_stackmembers_invalid_device(self):
         result = self.client.get(f'/api/v1.0/device/{"nonexisting"}/stackmember')

--- a/src/cnaas_nms/app_settings.py
+++ b/src/cnaas_nms/app_settings.py
@@ -44,6 +44,8 @@ class ApiSettings(BaseSettings):
     FIRMWARE_URL: str = HTTPD_URL
     JWT_ENABLED: bool = True
     PLUGIN_FILE: Path = "/etc/cnaas-nms/plugins.yml"
+    GLOBAL_UNIQUE_VLANS: bool = True
+    INIT_MGMT_TIMEOUT: int = 30
 
 
 def construct_api_settings() -> ApiSettings:
@@ -68,6 +70,8 @@ def construct_api_settings() -> ApiSettings:
             CAKEYFILE=config.get("cakeyfile", ApiSettings().CAKEYFILE),
             CERTPATH=config.get("certpath", ApiSettings().CERTPATH),
             FIRMWARE_URL=firmware_url,
+            GLOBAL_UNIQUE_VLANS=config.get("global_unique_vlans", True),
+            INIT_MGMT_TIMEOUT=config.get("init_mgmt_timeout", 30),
         )
     else:
         return ApiSettings()

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -106,7 +106,7 @@ def push_base_management(task, device_variables: dict, devtype: DeviceType, job_
     task.host["config"] = r.result
     # Use extra low timeout for this since we expect to loose connectivity after changing IP
     connopts_napalm = task.host.connection_options["napalm"]
-    connopts_napalm.extras["timeout"] = 30
+    connopts_napalm.extras["timeout"] = api_settings.INIT_MGMT_TIMEOUT
 
     try:
         task.run(task=napalm_configure,
@@ -495,9 +495,10 @@ def init_access_device_step1(device_id: int, new_hostname: str,
 
     # step3. register apscheduler job that continues steps
     if mlag_peer_id and mlag_peer_new_hostname:
-        step2_delay = 30+60+30  # account for delayed start of peer device plus mgmt timeout
+        # account for delayed start of peer device plus mgmt timeout
+        step2_delay = 60+2*api_settings.INIT_MGMT_TIMEOUT
     else:
-        step2_delay = 30
+        step2_delay = api_settings.INIT_MGMT_TIMEOUT
     scheduler = Scheduler()
     next_job_id = scheduler.add_onetime_job(
         'cnaas_nms.confpush.init_device:init_device_step2',

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -9,7 +9,7 @@ from git.exc import NoSuchPathError, GitCommandError
 import yaml
 from redis_lru import RedisLRU
 
-from cnaas_nms.app_settings import app_settings
+from cnaas_nms.app_settings import app_settings, api_settings
 from cnaas_nms.db.exceptions import ConfigException, RepoStructureException
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.db.settings import get_settings, SettingsSyntaxError, DIR_STRUCTURE, \
@@ -177,7 +177,7 @@ def _refresh_repo_task(repo_type: RepoType = RepoType.TEMPLATES) -> str:
                 devtype = DeviceType[devtype_str]
                 for device_model in device_models:
                     get_settings('nonexisting', devtype, device_model)
-            check_settings_collisions()
+            check_settings_collisions(api_settings.GLOBAL_UNIQUE_VLANS)
         except SettingsSyntaxError as e:
             logger.exception("Error in settings repo configuration: {}".format(str(e)))
             raise e

--- a/src/cnaas_nms/run.py
+++ b/src/cnaas_nms/run.py
@@ -20,7 +20,9 @@ def is_coverage_enabled():
 
 
 print("Code coverage collection for worker in pid {}: {}".format(
-    os.getpid(), ('COVERAGE' in os.environ)))
+    os.getpid(), is_coverage_enabled()))
+
+
 if is_coverage_enabled():
     cov = coverage.coverage(
         data_file='/coverage/.coverage-{}'.format(os.getpid()),

--- a/src/cnaas_nms/scheduler/scheduler.py
+++ b/src/cnaas_nms/scheduler/scheduler.py
@@ -121,6 +121,19 @@ class Scheduler(object, metaclass=SingletonType):
         """Remove job from local scheduler."""
         return self._scheduler.remove_job(str(job_id))
 
+    def shutdown_mule(self):
+        """Send a message to the mule worker to shut itself down."""
+        if self.use_mule:
+            try:
+                import uwsgi
+            except Exception as e:
+                logger.exception("use_mule is set but not running in uwsgi")
+                raise e
+            args = {
+                "scheduler_action": "shutdown_mule"
+            }
+            uwsgi.mule_msg(json.dumps(args))
+
     def remove_scheduled_job(self, job_id, abort_message="removed"):
         """Remove scheduled job from mule worker or local scheduler depending
         on setup."""

--- a/src/cnaas_nms/scheduler_mule.py
+++ b/src/cnaas_nms/scheduler_mule.py
@@ -75,7 +75,12 @@ def main_loop():
 
     while True:
         mule_data = uwsgi.mule_get_msg()
-        data: dict = json.loads(mule_data)
+        try:
+            data: dict = json.loads(mule_data)
+        except json.JSONDecodeError as e:
+            logger.exception("Mule received non-JSON data: {}".format(e))
+            logger.debug("Mule received data: {}".format(mule_data))
+            continue
         action = "add"
         if 'scheduler_action' in data:
             if data['scheduler_action'] == "remove":

--- a/src/cnaas_nms/scheduler_mule.py
+++ b/src/cnaas_nms/scheduler_mule.py
@@ -14,10 +14,16 @@ from cnaas_nms.tools.log import get_logger
 
 
 logger = get_logger()
-logger.info("Code coverage collection for mule in pid {}: {}".format(
-    os.getpid(), ('COVERAGE' in os.environ)))
 
-if 'COVERAGE' in os.environ:
+
+def is_coverage_enabled():
+    return os.getenv('COVERAGE', '0').strip() not in ('0', 'off', 'false', 'no')
+
+
+logger.info("Code coverage collection for mule in pid {}: {}".format(
+    os.getpid(), is_coverage_enabled()))
+
+if is_coverage_enabled():
     cov = coverage.coverage(data_file='/coverage/.coverage-{}'.format(os.getpid()))
     cov.start()
 

--- a/src/cnaas_nms/scheduler_mule.py
+++ b/src/cnaas_nms/scheduler_mule.py
@@ -91,6 +91,8 @@ def main_loop():
         if 'scheduler_action' in data:
             if data['scheduler_action'] == "remove":
                 action = "remove"
+            elif data['scheduler_action'] == "shutdown_mule":
+                action = "shutdown_mule"
         if 'when' in data and isinstance(data['when'], int):
             data['run_date'] = datetime.datetime.utcnow() + datetime.timedelta(seconds=data['when'])
             del data['when']
@@ -110,6 +112,9 @@ def main_loop():
                                     id=data['id'], run_date=data['run_date'], name=data['func'])
         elif action == "remove":
             scheduler.remove_local_job(data['id'])
+        elif action == "shutdown_mule":
+            scheduler.get_scheduler().shutdown()
+            return
 
 
 if __name__ == '__main__':

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -99,7 +99,6 @@ MULE_PID="`docker logs docker_cnaas_api_1 | awk '/spawned uWSGI mule/{print $6}'
 echo "Found mule at pid $MULE_PID"
 # Allow for code coverage files to be saved
 docker-compose exec -u root -T cnaas_api chown -R www-data:www-data /opt/cnaas/venv/cnaas-nms/src/
-docker-compose exec -u root -T cnaas_api kill $MULE_PID
 curl -ks -H "Authorization: Bearer $JWT_AUTH_TOKEN" "https://localhost/api/v1.0/system/shutdown" -d "{}" -X POST -H "Content-Type: application/json"
 sleep 3
 


### PR DESCRIPTION
More customization with new settings:

- global_unique_vlans: If True VLAN IDs has to be globally unique, if False
  different DIST switches can reuse same VLAN IDs for different L2 domains.
  Defaults to True.
- init_mgmt_timeout: Timeout to wait for device to apply changed management IP.
  Defaults to 30, specified in seconds (integer).
