### PR TITLE
Bugfix ZTP: update linknets after checks

### DIFF
--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -459,6 +459,7 @@ class DeviceInitCheckApi(Resource):
                     hostname=dev.hostname,
                     devtype=target_devtype,
                     ztp_hostname=target_hostname,
+                    mlag_peer_dev=mlag_peer_dev,
                     dry_run=True
                 )
                 if mlag_peer_dev:
@@ -467,6 +468,7 @@ class DeviceInitCheckApi(Resource):
                         hostname=mlag_peer_dev.hostname,
                         devtype=target_devtype,
                         ztp_hostname=mlag_peer_target_hostname,
+                        mlag_peer_dev=dev,
                         dry_run=True
                     )
                 ret['linknets'] = Linknet.deduplicate_linknet_dicts(linknets_all)

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -435,7 +435,7 @@ class DeviceInitCheckApi(Resource):
 
         with sqla_session() as session:
             try:
-                dev = cnaas_nms.confpush.init_device.pre_init_checks(session, device_id)
+                dev: Device = cnaas_nms.confpush.init_device.pre_init_checks(session, device_id)
                 linknets_all = dev.get_linknets_as_dict(session)
             except ValueError as e:
                 return empty_result(status='error',
@@ -446,7 +446,7 @@ class DeviceInitCheckApi(Resource):
 
             if mlag_peer_id:
                 try:
-                    mlag_peer_dev = cnaas_nms.confpush.init_device.pre_init_checks(
+                    mlag_peer_dev: Device = cnaas_nms.confpush.init_device.pre_init_checks(
                         session, mlag_peer_id)
                     linknets_all += mlag_peer_dev.get_linknets_as_dict(session)
                 except ValueError as e:
@@ -513,7 +513,7 @@ class DeviceInitCheckApi(Resource):
         ret['parsed_args'] = parsed_args
         if mlag_peer_id and not ret['mlag_compatible']:
             ret['compatible'] = False
-        if ret['linknets_compatible'] and ret['neighbors_compatible']:
+        elif ret['linknets_compatible'] and ret['neighbors_compatible']:
             ret['compatible'] = True
         else:
             ret['compatible'] = False

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -80,8 +80,11 @@ device_init_model = device_init_api.model('device_init', {
     'device_type': fields.String(required=False)})
 
 device_initcheck_model = device_initcheck_api.model('device_initcheck', {
-    'hostname': fields.String(required=False),
-    'device_type': fields.String(required=False)})
+    'hostname': fields.String(required=True),
+    'device_type': fields.String(required=True),
+    'mlag_peer_id': fields.Integer(required=False),
+    'mlag_peer_hostname': fields.String(required=False),
+})
 
 device_discover_model = device_discover_api.model('device_discover', {
     'ztp_mac': fields.String(required=True),

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -123,14 +123,15 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
     return uplinks
 
 
-def get_mlag_ifs(session, hostname, mlag_peer_hostname) -> Dict[str, int]:
+def get_mlag_ifs(session, hostname: str, mlag_peer_hostname: str,
+                 linknets: Optional[List[dict]] = None) -> Dict[str, int]:
     """Returns dict with mapping of interface -> neighbor id
     Return id instead of hostname since mlag peer will change hostname during init"""
     logger = get_logger()
     mlag_ifs = {}
 
     dev = session.query(Device).filter(Device.hostname == hostname).one()
-    for neighbor_d in dev.get_neighbors(session):
+    for neighbor_d in dev.get_neighbors(session, linknets=linknets):
         if neighbor_d.hostname == mlag_peer_hostname:
             for local_if in dev.get_neighbor_local_ifnames(session, neighbor_d):
                 mlag_ifs[local_if] = neighbor_d.id

--- a/src/cnaas_nms/confpush/get.py
+++ b/src/cnaas_nms/confpush/get.py
@@ -65,7 +65,7 @@ def get_neighbors(hostname: Optional[str] = None, group: Optional[str] = None)\
 
 def get_uplinks(session, hostname: str, recheck: bool = False,
                 neighbors: Optional[List[Device]] = None,
-                linknets = None) -> Dict[str, str]:
+                linknets: Optional[List[dict]] = None) -> Dict[str, str]:
     """Returns dict with mapping of interface -> neighbor hostname"""
     logger = get_logger()
     uplinks = {}
@@ -89,11 +89,11 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
 
     neighbor_d: Device
     if not neighbors:
-        neighbors = dev.get_neighbors(session)
+        neighbors = dev.get_neighbors(session, linknets)
 
     for neighbor_d in neighbors:
         if neighbor_d.device_type == DeviceType.DIST:
-            local_if = dev.get_neighbor_local_ifname(session, neighbor_d)
+            local_if = dev.get_neighbor_local_ifname(session, neighbor_d, linknets)
             # Neighbor interface ifclass is already verified in
             # update_linknets -> verify_peer_iftype
             if local_if:
@@ -104,8 +104,8 @@ def get_uplinks(session, hostname: str, recheck: bool = False,
             if not intfs:
                 continue
             try:
-                local_if = dev.get_neighbor_local_ifname(session, neighbor_d)
-                remote_if = neighbor_d.get_neighbor_local_ifname(session, dev)
+                local_if = dev.get_neighbor_local_ifname(session, neighbor_d, linknets)
+                remote_if = neighbor_d.get_neighbor_local_ifname(session, dev, linknets)
             except ValueError as e:
                 logger.debug("Ignoring possible uplinks to neighbor {}: {}".format(
                     neighbor_d.hostname, e))

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -370,11 +370,12 @@ def init_access_device_step1(device_id: int, new_hostname: str,
             linknets_all += mlag_peer_dev.get_linknets_as_dict(session)
             linknets_all += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS,
                                             mlag_peer_dev=dev, dry_run=True)
+            linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
             update_interfacedb_worker(
                 session, dev, replace=True, delete_all=False,
-                mlag_peer_hostname=mlag_peer_dev.hostname, linknets=linknets_all)
+                mlag_peer_hostname=mlag_peer_dev.hostname, linknets=linknets)
             update_interfacedb_worker(session, mlag_peer_dev, replace=True, delete_all=False,
-                                      mlag_peer_hostname=dev.hostname, linknets=linknets_all)
+                                      mlag_peer_hostname=dev.hostname, linknets=linknets)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
             uplink_hostnames += mlag_peer_dev.get_uplink_peer_hostnames(session)
             # check that both devices see the correct MLAG peer
@@ -390,12 +391,12 @@ def init_access_device_step1(device_id: int, new_hostname: str,
             # update linknets using LLDP data
             linknets_all += update_linknets(
                 session, dev.hostname, DeviceType.ACCESS, dry_run=True)
+            linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
             update_interfacedb_worker(
-                session, dev, replace=True, delete_all=False, linknets=linknets_all)
+                session, dev, replace=True, delete_all=False, linknets=linknets)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
 
         try:
-            linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
             # Verify uplink neighbors only for first device in MLAG pair
             if not uplink_hostnames_arg:
                 verified_neighbors = pre_init_check_neighbors(

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -362,17 +362,17 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         mlag_peer_dev: Optional[Device] = None
 
         # update linknets using LLDP data
-        linknets_all += update_linknets(session, dev.hostname, DeviceType.ACCESS)
+        linknets_all += update_linknets(session, dev.hostname, DeviceType.ACCESS, dry_run=True)
 
         # If this is the first device in an MLAG pair
         if mlag_peer_id and mlag_peer_new_hostname:
             mlag_peer_dev = pre_init_checks(session, mlag_peer_id)
             linknets_all += mlag_peer_dev.get_linknets_as_dict(session)
-            linknets_all += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS)
+            linknets_all += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=True)
             update_interfacedb_worker(session, dev, replace=True, delete_all=False,
-                                      mlag_peer_hostname=mlag_peer_dev.hostname)
+                                      mlag_peer_hostname=mlag_peer_dev.hostname, linknets=linknets_all)
             update_interfacedb_worker(session, mlag_peer_dev, replace=True, delete_all=False,
-                                      mlag_peer_hostname=dev.hostname)
+                                      mlag_peer_hostname=dev.hostname, linknets=linknets_all)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
             uplink_hostnames += mlag_peer_dev.get_uplink_peer_hostnames(session)
             # check that both devices see the correct MLAG peer
@@ -385,7 +385,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
             raise ValueError("mlag_peer_id and mlag_peer_new_hostname must be specified together")
         # If this device is not part of an MLAG pair
         else:
-            update_interfacedb_worker(session, dev, replace=True, delete_all=False)
+            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets_all)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
 
         try:
@@ -403,6 +403,14 @@ def init_access_device_step1(device_id: int, new_hostname: str,
                 new_hostname, e
             ))
         except (Exception, NeighborError) as e:
+            raise e
+
+        try:
+            update_linknets(session, dev.hostname, DeviceType.ACCESS, dry_run=False)
+            if mlag_peer_dev:
+                update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=False)
+        except Exception as e:
+            session.rollback()
             raise e
 
         # TODO: check compatability, same dist pair and same ports on dists

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -362,11 +362,11 @@ def init_mlag_peer_only(device_id: int, mlag_peer_id: int, mlag_peer_new_hostnam
             raise DeviceStateError(
                 "First MLAG device must be in state MANAGED to restart MLAG peer init")
         mlag_peer_dev: Device = pre_init_checks(
-            session, mlag_peer_id, accepted_state=[DeviceState.DISCOVERED, DeviceState.INIT])
+            session, mlag_peer_id, accepted_state=[DeviceState.DISCOVERED])
         logger.info(
             "Found MLAG pair in MANAGED/INIT state: {}={}, {}={} restarting peer init".format(
-            device_id, dev.state, mlag_peer_id, mlag_peer_dev.state
-        ))
+                device_id, dev.state, mlag_peer_id, mlag_peer_dev.state
+            ))
         uplink_hostnames = dev.get_uplink_peer_hostnames(session)
         uplink_hostnames += mlag_peer_dev.get_uplink_peer_hostnames(session)
         schedule_mlag_peer_init(

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -384,6 +384,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         # If this is the second device in an MLAG pair
         elif uplink_hostnames_arg:
             uplink_hostnames = uplink_hostnames_arg
+            linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
         elif mlag_peer_id or mlag_peer_new_hostname:
             raise ValueError("mlag_peer_id and mlag_peer_new_hostname must be specified together")
         # If this device is not part of an MLAG pair

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -403,6 +403,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
                 new_hostname, e
             ))
         except (Exception, NeighborError) as e:
+            session.rollback()
             raise e
 
         try:
@@ -428,6 +429,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
                 mgmtdomain.id, mgmtdomain.description))
         reserved_ip = ReservedIP(device=dev, ip=mgmt_ip)
         session.add(reserved_ip)
+        session.commit()
         # Populate variables for template rendering
         mgmt_gw_ipif = IPv4Interface(mgmtdomain.ipv4_gw)
         mgmt_variables = {

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -232,7 +232,7 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
 
         if mlag_peer_dev and len(mlag_peers) < 2:
             raise InitVerificationError(
-                ("MLAG requires at least two MLAG peer links, {} found for"
+                ("MLAG requires at least two MLAG peer links, {} found for "
                  "device id {} ({})").format(
                     len(mlag_peers), dev.id, dev.hostname
                 ))
@@ -370,8 +370,8 @@ def init_access_device_step1(device_id: int, new_hostname: str,
             linknets_all += update_linknets(session, dev.hostname, DeviceType.ACCESS,
                                             mlag_peer_dev=mlag_peer_dev, dry_run=True)
             linknets_all += mlag_peer_dev.get_linknets_as_dict(session)
-            linknets_all += update_linknets(
-                session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=True)
+            linknets_all += update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS,
+                                            mlag_peer_dev=dev, dry_run=True)
             update_interfacedb_worker(
                 session, dev, replace=True, delete_all=False,
                 mlag_peer_hostname=mlag_peer_dev.hostname, linknets=linknets_all)

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -416,7 +416,7 @@ def init_access_device_step1(device_id: int, new_hostname: str,
             update_linknets(session, dev.hostname, DeviceType.ACCESS,
                             mlag_peer_dev=mlag_peer_dev, dry_run=False)
             if mlag_peer_dev:
-                update_linknets(session, mlag_peer_dev, DeviceType.ACCESS, dry_run=False)
+                update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=False)
         except Exception as e:
             session.rollback()
             raise e

--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -206,8 +206,9 @@ def pre_init_check_neighbors(session, dev: Device, devtype: DeviceType,
                 else:
                     redundant_uplinks += 1
                 uplinks.append(neighbor)
-
-            neighbors.append(neighbor)
+                neighbors.append(neighbor)
+            elif mlag_peer_dev and neighbor_dev == mlag_peer_dev:
+                neighbors.append(neighbor)
 
         if len(uplinks) <= 0:
             raise InitVerificationError(

--- a/src/cnaas_nms/confpush/nornir_plugins/cnaas_inventory.py
+++ b/src/cnaas_nms/confpush/nornir_plugins/cnaas_inventory.py
@@ -54,7 +54,8 @@ class CnaasInventory:
                         "enforce_verification": True,
                         "context": ssl_context
                     }
-                })
+                }),
+                "netmiko": ConnectionOptions(extras={})
             }
         )
         insecure_device_states = [
@@ -66,7 +67,8 @@ class CnaasInventory:
         insecure_connection_options = {
             "napalm": ConnectionOptions(extras={
                 "optional_args": {"enforce_verification": False}
-            })
+            }),
+            "netmiko": ConnectionOptions(extras={})
         }
 
         groups = Groups()

--- a/src/cnaas_nms/confpush/tests/data/testdata.yml
+++ b/src/cnaas_nms/confpush/tests/data/testdata.yml
@@ -56,3 +56,32 @@ lldp_data_nonredundant_error:
   Ethernet2:
     - hostname: eosdist1
       port: Ethernet2
+mlag_dev_a: mlagpeer1
+mlag_dev_b: mlagpeer2
+mlag_dev_nonpeer: nonpeer
+linknets_mlag_peers:
+- description: null
+  device_a_ip: null
+  device_a_port: Ethernet25
+  device_b_ip: null
+  device_b_port: Ethernet51
+  ipv4_network: null
+  redundant_link: true
+  site_id: null
+- description: null
+  device_a_ip: null
+  device_a_port: Ethernet26
+  device_b_ip: null
+  device_b_port: Ethernet52
+  ipv4_network: null
+  redundant_link: true
+  site_id: null
+linknets_mlag_nonpeers:
+  - description: null
+    device_a_ip: null
+    device_a_port: Ethernet20
+    device_b_ip: null
+    device_b_port: Ethernet20
+    ipv4_network: null
+    redundant_link: true
+    site_id: null

--- a/src/cnaas_nms/confpush/tests/test_get.py
+++ b/src/cnaas_nms/confpush/tests/test_get.py
@@ -1,14 +1,13 @@
-import cnaas_nms.confpush.get
-
 import pprint
 import unittest
 import pkg_resources
 import yaml
 import os
 
+import cnaas_nms.confpush.get
 import cnaas_nms.confpush.update
 from cnaas_nms.db.session import sqla_session
-from cnaas_nms.db.device import DeviceType
+from cnaas_nms.db.device import Device, DeviceType, DeviceState
 
 
 class GetTests(unittest.TestCase):
@@ -16,6 +15,17 @@ class GetTests(unittest.TestCase):
         data_dir = pkg_resources.resource_filename(__name__, 'data')
         with open(os.path.join(data_dir, 'testdata.yml'), 'r') as f_testdata:
             self.testdata = yaml.safe_load(f_testdata)
+
+    @classmethod
+    def create_test_device(cls, hostname="unittest"):
+        return Device(
+            ztp_mac="000000000000",
+            hostname=hostname,
+            platform="eos",
+            management_ip=None,
+            state=DeviceState.MANAGED,
+            device_type=DeviceType.ACCESS,
+        )
 
     def test_get_inventory(self):
         result = cnaas_nms.confpush.get.get_inventory()
@@ -28,6 +38,45 @@ class GetTests(unittest.TestCase):
         self.assertLessEqual(
             1,
             len(result['hosts'].items()))
+
+    def test_get_mlag_ifs(self):
+        with sqla_session() as session:
+            try:
+                dev_a: Device = self.create_test_device(self.testdata['mlag_dev_a'])
+                dev_b: Device = self.create_test_device(self.testdata['mlag_dev_b'])
+                dev_nonpeer: Device = self.create_test_device(self.testdata['mlag_dev_nonpeer'])
+                session.add(dev_a)
+                session.add(dev_b)
+                session.add(dev_nonpeer)
+                session.commit()
+                linknets = []
+                for linknet in self.testdata['linknets_mlag_peers']:
+                    linknet['device_a_hostname'] = dev_a.hostname
+                    linknet['device_a_id'] = dev_a.id
+                    linknet['device_b_hostname'] = dev_b.hostname
+                    linknet['device_b_id'] = dev_b.id
+                    linknets.append(linknet)
+                for linknet in self.testdata['linknets_mlag_nonpeers']:
+                    linknet['device_a_hostname'] = dev_a.hostname
+                    linknet['device_a_id'] = dev_a.id
+                    linknet['device_b_hostname'] = dev_nonpeer.hostname
+                    linknet['device_b_id'] = dev_nonpeer.id
+                    linknets.append(linknet)
+
+                res = cnaas_nms.confpush.get.get_mlag_ifs(
+                    session, dev_a, self.testdata['mlag_dev_b'], linknets)
+                self.assertEqual(res, {'Ethernet25': dev_b.id, 'Ethernet26': dev_b.id})
+            except Exception as e:
+                session.rollback()
+                session.delete(dev_a)
+                session.delete(dev_b)
+                session.delete(dev_nonpeer)
+                raise e
+            else:
+                session.rollback()
+                session.delete(dev_a)
+                session.delete(dev_b)
+                session.delete(dev_nonpeer)
 
     def equipmenttest_update_links(self):
         with sqla_session() as session:

--- a/src/cnaas_nms/confpush/tests/test_update.py
+++ b/src/cnaas_nms/confpush/tests/test_update.py
@@ -28,6 +28,10 @@ class UpdateTests(unittest.TestCase):
     def test_update_linknet_eosaccess(self):
         with sqla_session() as session:
             linknets = self.get_linknets(session)
+            for ln in linknets:
+                ln['device_a_id'] = None
+                ln['device_b_id'] = None
+            breakpoint()
             self.assertListEqual(
                 linknets,
                 self.testdata['linknet_redundant'],
@@ -37,6 +41,9 @@ class UpdateTests(unittest.TestCase):
     def test_update_linknet_eosaccess_nonredundant(self):
         with sqla_session() as session:
             linknets = self.get_linknets(session, self.testdata['lldp_data_nonredundant'])
+            for ln in linknets:
+                ln['device_a_id'] = None
+                ln['device_b_id'] = None
             self.assertListEqual(
                 linknets,
                 self.testdata['linknet_nonredundant'],

--- a/src/cnaas_nms/confpush/tests/test_update.py
+++ b/src/cnaas_nms/confpush/tests/test_update.py
@@ -31,7 +31,6 @@ class UpdateTests(unittest.TestCase):
             for ln in linknets:
                 ln['device_a_id'] = None
                 ln['device_b_id'] = None
-            breakpoint()
             self.assertListEqual(
                 linknets,
                 self.testdata['linknet_redundant'],

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -242,7 +242,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
         if not remote_device_inst:
             logger.debug(f"Unknown neighbor device, ignoring: {data[0]['hostname']}")
             continue
-        if remote_device_inst == mlag_peer_dev:
+        if remote_device_inst.id == mlag_peer_dev.id:
             # In case of MLAG init the peer does not have the correct devtype set yet,
             # use same devtype as local device instead
             remote_devtype = devtype

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -204,7 +204,8 @@ def update_facts(hostname: str,
 
 
 def update_linknets(session, hostname: str, devtype: DeviceType,
-                    ztp_hostname: Optional[str] = None, dry_run: bool = False,
+                    ztp_hostname: Optional[str] = None,
+                    mlag_peer_dev: Optional[Device] = None, dry_run: bool = False,
                     neighbors_arg: Optional[Dict[str, list]] = None) -> List[dict]:
     """Update linknet data for specified device using LLDP neighbor data.
 
@@ -241,7 +242,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
         if not remote_device_inst:
             logger.debug(f"Unknown neighbor device, ignoring: {data[0]['hostname']}")
             continue
-        if remote_device_inst.state in [DeviceState.DISCOVERED, DeviceState.INIT]:
+        if remote_device_inst == mlag_peer_dev:
             # In case of MLAG init the peer does not have the correct devtype set yet,
             # use same devtype as local device instead
             remote_devtype = devtype

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -46,7 +46,7 @@ def update_interfacedb_worker(session, dev: Device, replace: bool, delete_all: b
     iflist = get_interfaces_names(dev.hostname)  # query nornir for current interfaces
     uplinks = get_uplinks(session, dev.hostname, recheck=replace, linknets=linknets)
     if mlag_peer_hostname:
-        mlag_ifs = get_mlag_ifs(session, dev.hostname, mlag_peer_hostname)
+        mlag_ifs = get_mlag_ifs(session, dev.hostname, mlag_peer_hostname, linknets=linknets)
     else:
         mlag_ifs = {}
     phy_interfaces = filter_interfaces(iflist, platform=dev.platform, include='physical')

--- a/src/cnaas_nms/confpush/update.py
+++ b/src/cnaas_nms/confpush/update.py
@@ -46,7 +46,7 @@ def update_interfacedb_worker(session, dev: Device, replace: bool, delete_all: b
     iflist = get_interfaces_names(dev.hostname)  # query nornir for current interfaces
     uplinks = get_uplinks(session, dev.hostname, recheck=replace, linknets=linknets)
     if mlag_peer_hostname:
-        mlag_ifs = get_mlag_ifs(session, dev.hostname, mlag_peer_hostname, linknets=linknets)
+        mlag_ifs = get_mlag_ifs(session, dev, mlag_peer_hostname, linknets=linknets)
     else:
         mlag_ifs = {}
     phy_interfaces = filter_interfaces(iflist, platform=dev.platform, include='physical')
@@ -242,7 +242,7 @@ def update_linknets(session, hostname: str, devtype: DeviceType,
         if not remote_device_inst:
             logger.debug(f"Unknown neighbor device, ignoring: {data[0]['hostname']}")
             continue
-        if remote_device_inst.id == mlag_peer_dev.id:
+        if mlag_peer_dev and remote_device_inst.id == mlag_peer_dev.id:
             # In case of MLAG init the peer does not have the correct devtype set yet,
             # use same devtype as local device instead
             remote_devtype = devtype

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -222,19 +222,6 @@ class Device(cnaas_nms.db.base.Base):
         elif linknet_dict['device_b_id'] == self.id:
             return linknet_dict['device_b_port']
 
-    def get_neighbor_local_ifnames(self, session, peer_device: Device) -> List[str]:
-        """Get the local interface name on this device that links to peer_device."""
-        linknets = self.get_links_to(session, peer_device)
-        ifnames = []
-        if not linknets:
-            return ifnames
-        for linknet in linknets:
-            if linknet.device_a_id == self.id:
-                ifnames.append(linknet.device_a_port)
-            elif linknet.device_b_id == self.id:
-                ifnames.append(linknet.device_b_port)
-        return ifnames
-
     def get_neighbor_local_ipif(self, session, peer_device: Device) -> Optional[str]:
         """Get the local interface IP on this device that links to peer_device."""
         linknets = self.get_links_to(session, peer_device)

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -5,7 +5,7 @@ import datetime
 import enum
 import re
 import json
-from typing import Optional, List, Set
+from typing import Optional, List, Set, Union
 
 from sqlalchemy import Column, Integer, Unicode, String, UniqueConstraint
 from sqlalchemy import Enum, DateTime, Boolean
@@ -119,15 +119,23 @@ class Device(cnaas_nms.db.base.Base):
             d[col.name] = value
         return d
 
-    def get_neighbors(self, session) -> List[Device]:
+    def get_neighbors(self, session,
+                      linknets: Optional[List[dict]] = None) -> List[Device]:
         """Look up neighbors from cnaas_nms.db.linknet.Linknets and return them as a list of Device objects."""
-        linknets = self.get_linknets(session)
+        if not linknets:
+            linknets = self.get_linknets(session)
         ret = []
         for linknet in linknets:
-            if linknet.device_a_id == self.id:
-                ret.append(session.query(Device).filter(Device.id == linknet.device_b_id).one())
+            if isinstance(linknet, cnaas_nms.db.linknet.Linknet):
+                device_a_id = linknet.device_a_id
+                device_b_id = linknet.device_b_id
             else:
-                ret.append(session.query(Device).filter(Device.id == linknet.device_a_id).one())
+                device_a_id = linknet['device_a_id']
+                device_b_id = linknet['device_b_id']
+            if device_a_id == self.id:
+                ret.append(session.query(Device).filter(Device.id == device_b_id).one())
+            else:
+                ret.append(session.query(Device).filter(Device.id == device_a_id).one())
         return ret
 
     def get_linknets(self, session) -> List[cnaas_nms.db.linknet.Linknet]:
@@ -182,19 +190,37 @@ class Device(cnaas_nms.db.base.Base):
                  (cnaas_nms.db.linknet.Linknet.device_a_id == peer_device.id))
             ).all()
 
-    def get_neighbor_local_ifname(self, session, peer_device: Device) -> Optional[str]:
+    def get_neighbor_local_ifname(self, session, peer_device: Device,
+                                  linknets_arg: [Optional[List[dict]]] = None) -> Optional[str]:
         """Get the local interface name on this device that links to peer_device."""
-        linknets = self.get_links_to(session, peer_device)
+        if linknets_arg:
+            def peer_linknet(linknet_match: dict):
+                if (
+                        linknet_match['device_a_id'] == self.id and
+                        linknet_match['device_b_id'] == peer_device.id
+                ) or (
+                        linknet_match['device_b_id'] == self.id and
+                        linknet_match['device_a_id'] == peer_device.id
+                ):
+                    return linknet_match
+            linknets = list(filter(peer_linknet, linknets_arg))
+        else:
+            linknets = self.get_links_to(session, peer_device)
         if not linknets:
             return None
         elif len(linknets) > 1:
             raise ValueError("Multiple linknets between devices not supported")
         else:
-            linknet = linknets[0]
-        if linknet.device_a_id == self.id:
-            return linknet.device_a_port
-        elif linknet.device_b_id == self.id:
-            return linknet.device_b_port
+            linknet_obj: Union[cnaas_nms.db.linknet.Linknet, dict] = linknets[0]
+            if isinstance(linknet_obj, cnaas_nms.db.linknet.Linknet):
+                linknet_dict = linknet_obj.as_dict()
+            else:
+                linknet_dict = linknet_obj
+
+        if linknet_dict['device_a_id'] == self.id:
+            return linknet_dict['device_a_port']
+        elif linknet_dict['device_b_id'] == self.id:
+            return linknet_dict['device_b_port']
 
     def get_neighbor_local_ifnames(self, session, peer_device: Device) -> List[str]:
         """Get the local interface name on this device that links to peer_device."""

--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -160,7 +160,7 @@ class Device(cnaas_nms.db.base.Base):
                 'device_b_hostname': linknet.device_b.hostname,
                 **linknet_dict
             }
-            ret.append(linknet_dict)
+            ret.append({k: linknet_dict[k] for k in sorted(linknet_dict)})
         return ret
 
     def get_linknet_localif_mapping(self, session) -> dict[str, str]:


### PR DESCRIPTION
Don't update the linknets until after pre checks have passed, this should make it so that there is no stale data left in the database after unsuccessful init attempts.
Clean up result output of init jobs, no need to save traceback of expected connection timeouts etc
initcheck won't return neighbor data of devices that are not part of the init process
Updated API model for initcheck