### PR TITLE
Allow updating of neighbor_id on interface

### DIFF
--- a/docs/apiref/interfaces.rst
+++ b/docs/apiref/interfaces.rst
@@ -148,11 +148,14 @@ Data can contain any of these optional keys:
 - enabled: Set the administrative state of the interface. Defaults to true if not set.
 - aggregate_id: Identifier for configuring LACP etc. Integer value.
   Special value -1 means configure MLAG and use ID based on indexnum.
-- neighbor: Populated at init, contains hostname of peer
 - bpdu_filter: bool defining STP BPDU feature enabled/disabled
 - redundant_link: bool allows specifying if this link allows non-redundant downlinks
 - tags: List of strings, user-defined custom tags to use in templates
 - cli_append_str: String of custom config that is appended to generated CLI config
+- neighbor: Populated at init, contains hostname of peer. Should normally never
+  have to be updated via API.
+- neighbor_id: Populated at init, contains device id of peer. Should normally never
+  have to be updated via API.
 
 Setting an optional value to JSON null will remove it from the database.
 

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -126,9 +126,21 @@ class InterfaceApi(Resource):
                             if isinstance(if_dict['data']['neighbor'], str) and \
                                     Device.valid_hostname(if_dict['data']['neighbor']):
                                 intfdata['neighbor'] = if_dict['data']['neighbor']
+                            elif if_dict['data']['neighbor'] is None:
+                                if 'neighbor' in intfdata:
+                                    del intfdata['neighbor']
                             else:
                                 errors.append("Neighbor must be valid hostname, got: {}".format(
                                     if_dict['data']['neighbor']))
+                        if 'neighbor_id' in if_dict['data']:
+                            if isinstance(if_dict['data']['neighbor_id'], int):
+                                intfdata['neighbor_id'] = if_dict['data']['neighbor_id']
+                            elif if_dict['data']['neighbor_id'] is None:
+                                if 'neighbor_id' in intfdata:
+                                    del intfdata['neighbor_id']
+                            else:
+                                errors.append("Neighbor_id must be valid integer, got: {}".format(
+                                    if_dict['data']['neighbor_id']))
                         if 'description' in if_dict['data']:
                             if isinstance(if_dict['data']['description'], str) and \
                                     len(if_dict['data']['description']) <= 64:

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -313,6 +313,36 @@ class ApiTests(unittest.TestCase):
         self.assertEqual(result.json['status'], 'success')
         self.assertEqual(ifname in result.json['data']['updated'], True)
 
+    def test_update_interface_data_neighbor(self):
+        ifname = self.testdata['interface_update']
+        data = {
+            "interfaces": {
+                ifname: {
+                    "data": {
+                        "neighbor_id": 123,
+                        "neighbor": "testhostname"
+                    }
+                }
+            }
+        }
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json['status'], 'success')
+        self.assertEqual(ifname in result.json['data']['updated'], True)
+        # Reset
+        data['interfaces'][ifname]['data']['neighbor_id'] = None
+        data['interfaces'][ifname]['data']['neighbor'] = None
+        result = self.client.put(
+            "/api/v1.0/device/{}/interfaces".format(self.testdata['interface_device']),
+            json=data
+        )
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json['status'], 'success')
+        self.assertEqual(ifname in result.json['data']['updated'], True)
+
     def test_add_new_device(self):
         data = {
             "hostname": "unittestdevice",


### PR DESCRIPTION
Allow updating of neighbor_id on interface even though it should normally never have to be updated via API.