### PR TITLE
Recalculate group memberships after ZTP

### DIFF
--- a/src/cnaas_nms/confpush/init_device.py
+++ b/src/cnaas_nms/confpush/init_device.py
@@ -513,6 +513,17 @@ def init_access_device_step1(device_id: int, new_hostname: str,
         session.commit()
         hostname = dev.hostname
 
+    # Rebuild settings caches to make sure group memberships are updated after
+    # setting new hostname
+    try:
+        rebuild_settings_cache()
+    except SettingsSyntaxError as e:
+        logger.error("Error in settings repo configuration: {}".format(e))
+        raise e
+    except VlanConflictError as e:
+        logger.error("VLAN conflict in repo configuration: {}".format(e))
+        raise e
+
     nr = cnaas_nms.confpush.nornir_helper.cnaas_init()
     nr_filtered = nr.filter(name=hostname)
 

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -159,10 +159,10 @@ def _refresh_repo_task(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         try:
             rebuild_settings_cache()
         except SettingsSyntaxError as e:
-            logger.exception("Error in settings repo configuration: {}".format(str(e)))
+            logger.error("Error in settings repo configuration: {}".format(e))
             raise e
         except VlanConflictError as e:
-            logger.exception("VLAN conflict in repo configuration: {}".format(str(e)))
+            logger.error("VLAN conflict in repo configuration: {}".format(e))
             raise e
         logger.debug("Files changed in settings repository: {}".format(changed_files))
         updated_devtypes, updated_hostnames = settings_syncstatus(updated_settings=changed_files)


### PR DESCRIPTION
Currently you have to refresh settings after ZTP of a new device to get it deploy configured VLANs based on group memberships