### PR TITLE
Jinja filters: netutils and base/hash

### DIFF
--- a/src/cnaas_nms/confpush/nornir_helper.py
+++ b/src/cnaas_nms/confpush/nornir_helper.py
@@ -9,6 +9,7 @@ from nornir.core.task import AggregatedResult, MultiResult
 from nornir.core.filter import F
 from nornir.core.plugins.inventory import InventoryPluginRegister
 from jinja2 import Environment as JinjaEnvironment, FileSystemLoader
+from netutils.utils import jinja2_convenience_function
 
 from cnaas_nms.confpush.nornir_plugins.cnaas_inventory import CnaasInventory
 from cnaas_nms.scheduler.jobresult import JobResult
@@ -37,6 +38,7 @@ def get_jinja_env(path):
         cache_size=0,
     )
     jinja_env.filters.update(jinja_filters.FILTERS)
+    jinja_env.filters.update(jinja2_convenience_function())
     return jinja_env
 
 

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -2,6 +2,8 @@
 
 import ipaddress
 import re
+import base64
+import hashlib
 from typing import Union, Optional, Callable, Any
 
 # This global dict can be used to update the Jinja environment filters dict to include all
@@ -152,3 +154,63 @@ def get_interface(
 
     host = network[index]
     return ipaddress.ip_interface(f"{host}/{network.prefixlen}")
+
+
+@template_filter()
+def b64encode(s: str) -> str:
+    """Returns base64 encoded string.
+
+    Args:
+        s: String to encode"""
+    return base64.b64encode(s.encode()).decode()
+
+
+@template_filter()
+def b64decode(s: str) -> str:
+    """Returns base64 decoded string.
+
+    Args:
+        s: String to decode"""
+    return base64.b64decode(s.encode()).decode()
+
+
+@template_filter()
+def b16encode(s: str) -> str:
+    """Returns base16 encoded string.
+
+    Args:
+        s: String to encode"""
+    return base64.b16encode(s.encode()).decode()
+
+
+@template_filter()
+def b16decode(s: str) -> str:
+    """Returns base16 decoded string.
+
+    Args:
+        s: String to decode"""
+    return base64.b16decode(s.encode()).decode()
+
+
+@template_filter()
+def sha1(s: str) -> str:
+    """Return SHA1 hexdigest of string s."""
+    return hashlib.sha1(s.encode()).hexdigest()
+
+
+@template_filter()
+def sha256(s: str) -> str:
+    """Return SHA256 hexdigest of string s."""
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+@template_filter()
+def sha512(s: str) -> str:
+    """Return SHA256 hexdigest of string s."""
+    return hashlib.sha512(s.encode()).hexdigest()
+
+
+@template_filter()
+def md5(s: str) -> str:
+    """Return SHA256 hexdigest of string s."""
+    return hashlib.md5(s.encode()).hexdigest()

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -7,6 +7,14 @@ from cnaas_nms.tools.jinja_filters import (
     ipv4_to_ipv6,
     get_interface,
     ipwrap,
+    b16encode,
+    b16decode,
+    b64encode,
+    b64decode,
+    sha1,
+    sha256,
+    sha512,
+    md5,
 )
 
 
@@ -134,6 +142,50 @@ class GetInterfaceTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             invalid_network = '2001:700:0:::/64'
             get_interface(invalid_network, 2)
+
+
+class BaseCodingTests(unittest.TestCase):
+    def test_b64(self):
+        teststr = "aB1_/ö# [;"
+        self.assertEqual(
+            teststr,
+            b64decode(b64encode(teststr))
+        )
+
+    def test_b16(self):
+        teststr = "aB1_/ö# [;"
+        self.assertEqual(
+            teststr,
+            b16decode(b16encode(teststr))
+        )
+
+
+class HashTests(unittest.TestCase):
+    def test_sha1(self):
+        self.assertEqual(
+            sha1("M7urErP1V7Pi6S+PjR3/mQ6iXAs="),
+            "5196ef4746d7ea377114f2f052c74a1533621ec3",
+        )
+
+    def test_sha256(self):
+        self.assertEqual(
+            sha256("zaoW4e3+2R2nAt5uXolY0pwiU/CjpriaY6EOvi26UoY="),
+            "3525c9b29e65cc46645c755bb91c3bfbb36c6f122b8e33845b4e3e728854dba9",
+        )
+
+    def test_sha512(self):
+        self.assertEqual(
+            sha512("Zij3NjTWHt9W4Ljuez7QpJTo5O/Fg+z8bKzWMev+n3lXcEhTv9dnL1Zs"
+                   "fJBocAR19QBjLz747LhqkDiQBOuOuw=="),
+            "6f7affc55e52d24b6da48182ceae1007a3f7fcdee6ad7e3eae0858e02d98786"
+            "cc04e9a329126d31cdf427214ea07428dd61e67b56b9f568e221c4553f391d02e",
+        )
+
+    def test_md5(self):
+        self.assertEqual(
+            md5("zKEPXmRX2X9itoaaI2kWyQ=="),
+            "88a23549d423a601c96b4bf90018bde6",
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
New jinja filters:
- b64encode
- b64decode
- b16encode
- b16decode
- sha1
- sha256
- sha512
- md5
New jinja filters from netutils:
https://github.com/networktocode/netutils/tree/develop/netutils
- asn_to_int
- name_to_bits
- name_to_bytes
- bits_to_name
- bytes_to_name
- name_to_name
- clean_config
- sanitize_config
- config_compliance
- config_section_not_parsed
- diff_network_config
- feature_compliance
- find_unordered_cfg_lines
- section_config
- fqdn_to_ip
- is_fqdn_resolvable
- interface_range_expansion
- interface_range_compress
- split_interface
- canonical_interface_name
- canonical_interface_name_list
- abbreviated_interface_name
- abbreviated_interface_name_list
- sort_interface_list
- ip_to_hex
- ip_addition
- ip_to_bin
- ip_subtract
- is_ip
- is_netmask
- netmask_to_cidr
- cidr_to_netmask
- cidr_to_netmaskv6
- get_all_host
- get_broadcast_address
- get_first_usable
- get_peer_ip
- get_usable_range
- ipaddress_address
- ipaddress_interface
- ipaddress_network
- is_valid_mac
- mac_to_format
- mac_to_int
- mac_type
- mac_normalize
- get_oui
- compare_type5
- compare_type7
- decrypt_type7
- encrypt_type5
- encrypt_type7
- get_hash_salt
- tcp_ping
- longest_prefix_match
- vlanlist_to_config
- vlanconfig_to_list
- normalise_delimiter_caret_c
- delimiter_change
- uptime_seconds_to_string
- uptime_string_to_seconds
- get_napalm_getters
