### PR TITLE
Proof of concept of tox integration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-testpaths: src
-pythonpath: src
-markers =
-    integration: mark a test that will only run on a fully integrated CNaaS-NMS deployment
-    equipment: mark a test that requires live equipment to be available for testing
-
-addopts = --docker-compose=../docker/docker-compose_pytest.yaml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+# -*- indent-tabs-mode: nil; -*-
+[tox]
+envlist = py{37,38,39}
+skipsdist = True
+basepython = python3.7
+
+[pytest]
+testpaths = src
+pythonpath = src
+markers =
+    integration: mark a test that will only run on a fully integrated CNaaS-NMS deployment
+    equipment: mark a test that requires live equipment to be available for testing
+
+[testenv]
+passenv = USER HOME
+
+deps =
+    -r requirements.txt
+
+commands =
+    pytest --docker-compose={toxinidir}/docker/docker-compose_pytest.yaml {posargs}


### PR DESCRIPTION
This sets up a default config for tox, with an environment list for Python versions 3.7 through 3.9, and moves the pytest config into `tox.ini` while we're at it.

I can now run the test suite (minus equipment tests, in my case) on three versions of Python by just running this:

```shell
tox -- -m 'not equipment'
```

If I want to run on just Python 3.7, like before, I do

```shell
tox -e py37 -- -m 'not equipment'
```