### PR TITLE
Commit confirmed

### DIFF
--- a/docker/api/config/api.yml
+++ b/docker/api/config/api.yml
@@ -9,3 +9,5 @@ certpath: /tmp/devicecerts/
 global_unique_vlans: True
 init_mgmt_timeout: 30
 mgmtdomain_reserved_count: 5
+commit_confirmed_mode: 1
+commit_confirmed_timeout: 300

--- a/docker/api/pytest.sh
+++ b/docker/api/pytest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PYTESTARGS=()
+PYTESTARGS=("-vv" "--showlocals")
 
 if [ ! -z "$NO_EQUIPMENTTEST" ] ; then
 	PYTESTARGS+=("-m" "not equipment")

--- a/docs/apiref/syncto.rst
+++ b/docs/apiref/syncto.rst
@@ -36,6 +36,23 @@ The status success in this case only means that the job was scheduled successful
 you have to poll the job API to see that result of what was done, the job itself might still
 fail.
 
+Configuration changes can be made in a way that requires a separate confirm call since version 1.5.
+If the change can not be confirmed because the device is not unreachable for example, the device
+will roll back the configuration. Before version 1.5 this concept was not supported, but from this
+version it's supported and enabled by default using mode 1.
+
+Commit confirm modes:
+ - 0 = No confirm commit (default up to version 1.4)
+ - 1 = Commit is immediately confirmed for each device when that device is configured
+   (default from version 1.5)
+ - 2 = Commit is confirmed after all devices in the job has been configured, but only if all were
+   successful. This mode is only supported for EOS and JunOS so far, and only supported for small
+   number of devices per commit (max 50). If mode 2 is specified and an unsupported device is
+   selected that device will use mode 1 instead.
+
+Commit confirm mode can be specified in the configuration file, but it's also possible to override
+that setting for a specific job using the API argument confirm_mode (see below).
+
 Arguments:
 ----------
 
@@ -59,6 +76,8 @@ Arguments:
    This should be a string with max 255 characters.
  - ticket_ref: Optionally reference a service ticket associated with this job.
    This should be a string with max 32 characters.
+ - confirm_mode: Optionally override the default commit confirm mode (see above) for this job.
+   Must be an integer 0, 1 or 2 if specified.
 
 If neither hostname or device_type is specified all devices that needs to be sycnhronized
 will be selected.

--- a/docs/apiref/syncto.rst
+++ b/docs/apiref/syncto.rst
@@ -41,6 +41,8 @@ If the change can not be confirmed because the device is not unreachable for exa
 will roll back the configuration. Before version 1.5 this concept was not supported, but from this
 version it's supported and enabled by default using mode 1.
 
+.. _commit_confirm_modes:
+
 Commit confirm modes:
  - 0 = No confirm commit (default up to version 1.4)
  - 1 = Commit is immediately confirmed for each device when that device is configured

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -38,6 +38,10 @@ Defines parameters for the API:
   each defined management domain when assigning new management IP addresses to devices.
   Defaults to 5 (e.g. meaning 10.0.0.1 through 10.0.0.5 would remain unassigned on
   a domain for 10.0.0.0/24).
+- commit_confirmed_mode: Integer specifying default commit confirm mode
+  (see :ref:`commit_confirm_modes`). Defaults to 1.
+- commit_confirmed_timeout: Time to wait before rolling back an unconfirmed commit,
+  specified in seconds. Defaults to 300.
 
 /etc/cnaas-nms/repository.yml
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -116,6 +116,7 @@ device_syncto_model = device_syncto_api.model(
         "force": fields.Boolean(required=False),
         "auto_push": fields.Boolean(required=False),
         "resync": fields.Boolean(required=False),
+        "confirm_mode": fields.Integer(required=False),
     },
 )
 
@@ -623,6 +624,16 @@ class DeviceSyncApi(Resource):
             kwargs["job_comment"] = json_data["comment"]
         if "ticket_ref" in json_data and isinstance(json_data["ticket_ref"], str):
             kwargs["job_ticket_ref"] = json_data["ticket_ref"]
+        if "confirm_mode" in json_data and isinstance(json_data["confirm_mode"], int):
+            if 0 >= json_data["confirm_mode"] >= 2:
+                kwargs["confirm_mode_override"] = json_data["confirm_mode"]
+            else:
+                return (
+                    empty_result(
+                        status="error", data="If optional value confirm_mode is specified it must be an integer 0-2"
+                    ),
+                    400,
+                )
 
         total_count: Optional[int] = None
         nr = cnaas_init()

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -222,7 +222,6 @@ class InterfaceApi(Resource):
                     elif "data" in if_dict and not if_dict["data"]:
                         intfdata = None
 
-
                     if intfdata != intfdata_original:
                         intf.data = intfdata
                         updated = True

--- a/src/cnaas_nms/app_settings.py
+++ b/src/cnaas_nms/app_settings.py
@@ -51,6 +51,7 @@ class ApiSettings(BaseSettings):
     MGMTDOMAIN_RESERVED_COUNT: int = 5
     COMMIT_CONFIRMED_MODE: int = 1
     COMMIT_CONFIRMED_TIMEOUT: int = 300
+    SETTINGS_OVERRIDE: Optional[dict] = None
 
 
 def construct_api_settings() -> ApiSettings:
@@ -80,6 +81,7 @@ def construct_api_settings() -> ApiSettings:
             MGMTDOMAIN_RESERVED_COUNT=config.get("mgmtdomain_reserved_count", 5),
             COMMIT_CONFIRMED_MODE=config.get("commit_confirmed_mode", 1),
             COMMIT_CONFIRMED_TIMEOUT=config.get("commit_confirmed_timeout", 300),
+            SETTINGS_OVERRIDE=config.get("settings_override", None),
         )
     else:
         return ApiSettings()

--- a/src/cnaas_nms/app_settings.py
+++ b/src/cnaas_nms/app_settings.py
@@ -49,6 +49,8 @@ class ApiSettings(BaseSettings):
     GLOBAL_UNIQUE_VLANS: bool = True
     INIT_MGMT_TIMEOUT: int = 30
     MGMTDOMAIN_RESERVED_COUNT: int = 5
+    COMMIT_CONFIRMED_MODE: int = 1
+    COMMIT_CONFIRMED_TIMEOUT: int = 300
 
 
 def construct_api_settings() -> ApiSettings:
@@ -76,6 +78,8 @@ def construct_api_settings() -> ApiSettings:
             GLOBAL_UNIQUE_VLANS=config.get("global_unique_vlans", True),
             INIT_MGMT_TIMEOUT=config.get("init_mgmt_timeout", 30),
             MGMTDOMAIN_RESERVED_COUNT=config.get("mgmtdomain_reserved_count", 5),
+            COMMIT_CONFIRMED_MODE=config.get("commit_confirmed_mode", 1),
+            COMMIT_CONFIRMED_TIMEOUT=config.get("commit_confirmed_timeout", 300),
         )
     else:
         return ApiSettings()

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -368,7 +368,7 @@ def napalm_configure_confirmed(
     replace=None,
     commit_message: str = "",
     job_id: int = 0,
-    commit_confirm_override: Optional[int] = None,
+    confirm_mode_override: Optional[int] = None,
 ):
     """Configure device and set configure confirmed timeout to revert changes unless a confirm is received"""
     logger = get_logger()
@@ -380,7 +380,7 @@ def napalm_configure_confirmed(
     if diff:
         n_device.commit_config(revert_in=api_settings.COMMIT_CONFIRMED_TIMEOUT)
         mode_2_supported = False
-        if get_confirm_mode(commit_confirm_override) == 2:
+        if get_confirm_mode(confirm_mode_override) == 2:
             if isinstance(n_device, (NapalmEOSDriver, NapalmJunOSDriver)):
                 mode_2_supported = True
             else:
@@ -389,7 +389,7 @@ def napalm_configure_confirmed(
                     f"Falling back to mode 1 for device: {task.host.name}."
                 )
 
-        if get_confirm_mode(commit_confirm_override) == 1 or not mode_2_supported:
+        if get_confirm_mode(confirm_mode_override) == 1 or not mode_2_supported:
             if n_device.has_pending_commit():
                 n_device.confirm_commit()
             else:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -456,6 +456,9 @@ def napalm_confirm_commit(task, job_id: int, prev_job_id: int):
     elif isinstance(n_device, NapalmJunOSDriver):
         n_device.confirm_commit()
     logger.debug("Commit for job {} confirmed on device {}".format(prev_job_id, task.host.name))
+    if job_id:
+        with redis_session() as db:
+            db.lpush("finished_devices_" + str(job_id), task.host.name)
 
 
 def push_sync_device(

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -401,12 +401,14 @@ def napalm_configure_confirmed(
 
 def napalm_confirm_commit(task, prev_job_id: int = 0):
     """Confirm a previous pending configure session"""
+    logger = get_logger()
     n_device = task.host.get_connection("napalm", task.nornir.config)
     if isinstance(n_device, NapalmEOSDriver):
         n_device.config_session = "job{}".format(prev_job_id)
         n_device.confirm_commit()
     elif isinstance(n_device, NapalmJunOSDriver):
         n_device.confirm_commit()
+    logger.debug("Commit for job {} confirmed on device {}".format(prev_job_id, task.host.name))
 
 
 def push_sync_device(

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple
 
 import yaml
 from napalm.eos import EOSDriver as NapalmEOSDriver
+from napalm.junos import JunOSDriver as NapalmJunOSDriver
 from nornir.core import Nornir
 from nornir.core.task import MultiResult, Result
 from nornir_jinja2.plugins.tasks import template_file
@@ -364,7 +365,7 @@ def napalm_configure_confirmed(
         n_device.commit_config(revert_in=api_settings.COMMIT_CONFIRMED_TIMEOUT)
         mode_2_supported = False
         if api_settings.COMMIT_CONFIRMED_MODE == 2:
-            if isinstance(n_device, NapalmEOSDriver):
+            if isinstance(n_device, (NapalmEOSDriver, NapalmJunOSDriver)):
                 mode_2_supported = True
             else:
                 logger.warn(
@@ -387,6 +388,8 @@ def napalm_confirm_commit(task, prev_job_id: int = 0):
     n_device = task.host.get_connection("napalm", task.nornir.config)
     if isinstance(n_device, NapalmEOSDriver):
         n_device.config_session = "job{}".format(prev_job_id)
+        n_device.confirm_commit()
+    elif isinstance(n_device, NapalmJunOSDriver):
         n_device.confirm_commit()
 
 

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -888,7 +888,7 @@ def sync_devices(
                 "cnaas_nms.devicehandler.sync_devices:confirm_devices",
                 when=0,
                 scheduled_by=scheduled_by,
-                kwargs={"prev_job_id": job_id, "hostnames": changed_hosts},
+                kwargs={"prev_job_id": job_id, "hostnames": changed_hosts, "scheduled_by": scheduled_by},
             )
             logger.info(f"Commit-confirm for job id {job_id} scheduled as job id {next_job_id}")
 

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -445,8 +445,9 @@ def napalm_configure_confirmed(
     return Result(host=task.host, diff=diff, changed=len(diff) > 0)
 
 
-def napalm_confirm_commit(task, prev_job_id: int = 0):
+def napalm_confirm_commit(task, job_id: int, prev_job_id: int):
     """Confirm a previous pending configure session"""
+    set_thread_data(job_id)
     logger = get_logger()
     n_device = task.host.get_connection("napalm", task.nornir.config)
     if isinstance(n_device, NapalmEOSDriver):
@@ -716,7 +717,7 @@ def confirm_devices(
     logger.info("Device(s) selected for commit-confirm ({}): {}".format(dev_count, ", ".join(device_list)))
 
     try:
-        nrresult = nr_filtered.run(task=napalm_confirm_commit, prev_job_id=prev_job_id)
+        nrresult = nr_filtered.run(task=napalm_confirm_commit, job_id=job_id, prev_job_id=prev_job_id)
     except Exception as e:
         logger.exception("Exception while confirm-commit devices: {}".format(str(e)))
         try:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -465,6 +465,11 @@ def push_sync_device(
         else:
             task_args["task"] = napalm_configure_confirmed
             task_args["job_id"] = job_id
+        logger.debug(
+            "Commit confirm mode for host {}: {} (dry_run: {})".format(
+                task.host.name, api_settings.COMMIT_CONFIRMED_MODE, dry_run
+            )
+        )
         task.run(**task_args)
         if api_settings.COMMIT_CONFIRMED_MODE != 2:
             task.host.close_connection("napalm")

--- a/src/cnaas_nms/devicehandler/tests/data/testdata.yml
+++ b/src/cnaas_nms/devicehandler/tests/data/testdata.yml
@@ -85,3 +85,7 @@ linknets_mlag_nonpeers:
     ipv4_network: null
     redundant_link: true
     site_id: null
+syncto_device_hostnames:
+  - "eosdist1"
+syncto_settings_override:
+  cli_append_str: "interface Management1\ndescription test"

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -5,6 +5,7 @@ from typing import Optional
 import pkg_resources
 import pytest
 import yaml
+from apscheduler.schedulers.base import STATE_STOPPED
 
 from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.session import sqla_session
@@ -23,7 +24,8 @@ def testdata(scope="session"):
 @pytest.fixture
 def scheduler(scope="session"):
     scheduler = Scheduler()
-    scheduler.start()
+    if scheduler.get_scheduler().state == STATE_STOPPED:
+        scheduler.start()
     return scheduler
 
 
@@ -49,6 +51,5 @@ def test_syncto_commitmode_1(testdata, scheduler):
                 job_dict = job_res.as_dict()
             else:
                 break
-    breakpoint()
     assert job_dict["status"] == "FINISHED"
     assert job_dict["result"]["devices"]["eosdist1"]["failed"] is False

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -45,18 +45,22 @@ def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[
                 job_dict = job_res.as_dict()
                 # if next_job_id scheduled for confirm action, wait for that also
                 if job_res.next_job_id:
-                    next_job_res = Optional[Job] = None
+                    confirm_job_res: Optional[Job] = None
+                    confirm_job_dict: Optional[dict] = None
                     for j in range(1, 30):
                         time.sleep(1)
-                        if not next_job_res or next_job_res.status in jobstatus_wait:
-                            next_job_res = session.query(Job).filter(Job.id == job_res.next_job_id).one()
-                            session.refresh(next_job_res)
+                        if not confirm_job_res or confirm_job_res.status in jobstatus_wait:
+                            confirm_job_res = session.query(Job).filter(Job.id == job_res.next_job_id).one()
+                            session.refresh(confirm_job_res)
+                            confirm_job_dict = confirm_job_res.as_dict()
                         else:
                             break
+                    if confirm_job_dict and confirm_job_dict["status"] != "FINISHED":
+                        logger.warning("test run_syncto_job confirm job bad status: {}".format(confirm_job_dict))
             else:
                 break
     if job_dict["status"] != "FINISHED":
-        logger.debug("test run_syncto_job job status '{}': {}".format(job_dict["status"], job_dict))
+        logger.warning("test run_syncto_job job bad status: {}".format(job_dict))
     return job_dict
 
 

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -38,6 +38,7 @@ def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[
         kwargs={
             "hostnames": testdata["syncto_device_hostnames"],
             "dry_run": dry_run,
+            "resync": True,
         },
     )
     job_res: Optional[Job] = None

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -44,7 +44,7 @@ def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[
     job_dict: Optional[dict] = None
     with sqla_session() as session:
         time.sleep(2)
-        for i in range(1, 5):
+        for i in range(1, 15):
             if not job_res or job_res.status == JobStatus.SCHEDULED or job_res.status == JobStatus.RUNNING:
                 job_res = session.query(Job).filter(Job.id == job_id).one()
                 job_dict = job_res.as_dict()

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -29,7 +29,7 @@ def scheduler(scope="session"):
     return scheduler
 
 
-@pytest.mark.integration
+@pytest.mark.equipment
 def test_syncto_commitmode_1(testdata, scheduler):
     api_settings.COMMIT_CONFIRMED_MODE = 1
     api_settings.SETTINGS_OVERRIDE = {"cli_append_str": "interface Management1\ndescription test"}

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -30,13 +30,14 @@ def scheduler(scope="session"):
     return scheduler
 
 
-def run_syncto_job(scheduler, testdata: dict) -> Optional[dict]:
+def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[dict]:
     job_id = scheduler.add_onetime_job(
         sync_devices,
         when=0,
         scheduled_by="test_user",
         kwargs={
             "hostnames": testdata["syncto_device_hostnames"],
+            "dry_run": dry_run,
         },
     )
     job_res: Optional[Job] = None
@@ -61,7 +62,7 @@ def test_syncto_commitmode_0(testdata, scheduler, settings_directory, templates_
         hostname = testdata["syncto_device_hostnames"][0]
         assert f"Commit confirm mode for host {hostname}: 0" in caplog.text
     assert job_dict["status"] == "FINISHED"
-    assert job_dict["result"]["devices"]["eosdist1"]["failed"] is False
+    assert job_dict["result"]["devices"][hostname]["failed"] is False
 
 
 @pytest.mark.equipment
@@ -73,7 +74,7 @@ def test_syncto_commitmode_1(testdata, scheduler, settings_directory, templates_
         hostname = testdata["syncto_device_hostnames"][0]
         assert f"Commit confirm mode for host {hostname}: 1" in caplog.text
     assert job_dict["status"] == "FINISHED"
-    assert job_dict["result"]["devices"]["eosdist1"]["failed"] is False
+    assert job_dict["result"]["devices"][hostname]["failed"] is False
 
 
 @pytest.mark.equipment
@@ -81,8 +82,16 @@ def test_syncto_commitmode_2(testdata, scheduler, settings_directory, templates_
     api_settings.COMMIT_CONFIRMED_MODE = 2
     api_settings.SETTINGS_OVERRIDE = testdata["syncto_settings_override"]
     with caplog.at_level(logging.DEBUG):
-        job_dict = run_syncto_job(scheduler, testdata)
+        job_dict = run_syncto_job(scheduler, testdata, dry_run=False)
         hostname = testdata["syncto_device_hostnames"][0]
         assert f"Commit confirm mode for host {hostname}: 2" in caplog.text
     assert job_dict["status"] == "FINISHED"
-    assert job_dict["result"]["devices"]["eosdist1"]["failed"] is False
+    assert job_dict["result"]["devices"][hostname]["failed"] is False
+
+    # Revert change
+    api_settings.SETTINGS_OVERRIDE = None
+    with caplog.at_level(logging.DEBUG):
+        job_dict = run_syncto_job(scheduler, testdata, dry_run=False)
+        assert "selected for commit-confirm" in caplog.text
+    assert job_dict["status"] == "FINISHED"
+    assert job_dict["result"]["devices"][hostname]["failed"] is False

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -11,25 +11,14 @@ from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.settings import api_settings
 from cnaas_nms.devicehandler.sync_devices import sync_devices
-from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.tools.log import get_logger
 
 
 @pytest.fixture
-def testdata(scope="session"):
+def testdata(scope="module"):
     data_dir = pkg_resources.resource_filename(__name__, "data")
     with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
         return yaml.safe_load(f_testdata)
-
-
-@pytest.fixture
-def scheduler(scope="module"):
-    scheduler = Scheduler()
-    scheduler.start()
-    yield scheduler
-    time.sleep(3)
-    scheduler.get_scheduler().print_jobs()
-    scheduler.shutdown()
 
 
 def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[dict]:

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -1,0 +1,54 @@
+import os
+import time
+from typing import Optional
+
+import pkg_resources
+import pytest
+import yaml
+
+from cnaas_nms.db.job import Job, JobStatus
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import api_settings
+from cnaas_nms.devicehandler.sync_devices import sync_devices
+from cnaas_nms.scheduler.scheduler import Scheduler
+
+
+@pytest.fixture
+def testdata(scope="session"):
+    data_dir = pkg_resources.resource_filename(__name__, "data")
+    with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
+        return yaml.safe_load(f_testdata)
+
+
+@pytest.fixture
+def scheduler(scope="session"):
+    scheduler = Scheduler()
+    scheduler.start()
+    return scheduler
+
+
+@pytest.mark.integration
+def test_syncto_commitmode_1(testdata, scheduler):
+    api_settings.COMMIT_CONFIRMED_MODE = 1
+    api_settings.SETTINGS_OVERRIDE = {"cli_append_str": "interface Management1\ndescription test"}
+    job_id = scheduler.add_onetime_job(
+        sync_devices,
+        when=0,
+        scheduled_by="test_user",
+        kwargs={
+            "hostnames": ["eosdist1"],
+        },
+    )
+    job_res: Optional[Job] = None
+    job_dict: Optional[dict] = None
+    with sqla_session() as session:
+        time.sleep(2)
+        for i in range(1, 5):
+            if not job_res or job_res.status == JobStatus.SCHEDULED or job_res.status == JobStatus.RUNNING:
+                job_res = session.query(Job).filter(Job.id == job_id).one()
+                job_dict = job_res.as_dict()
+            else:
+                break
+    breakpoint()
+    assert job_dict["status"] == "FINISHED"
+    assert job_dict["result"]["devices"]["eosdist1"]["failed"] is False

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -45,7 +45,7 @@ def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[
     job_dict: Optional[dict] = None
     jobstatus_wait = [JobStatus.SCHEDULED, JobStatus.RUNNING]
     with sqla_session() as session:
-        for i in range(1, 30):
+        for i in range(1, 300):
             time.sleep(1)
             if not job_res or job_res.status in jobstatus_wait:
                 job_res: Job = session.query(Job).filter(Job.id == job_id).one()
@@ -53,7 +53,7 @@ def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[
                 # if next_job_id scheduled for confirm action, wait for that also
                 if job_res.next_job_id:
                     next_job_res = Optional[Job] = None
-                    for j in range(1, 30):
+                    for j in range(1, 300):
                         time.sleep(1)
                         if not next_job_res or next_job_res.status in jobstatus_wait:
                             next_job_res = session.query(Job).filter(Job.id == job_res.next_job_id).one()

--- a/src/cnaas_nms/scheduler/tests/test_scheduler.py
+++ b/src/cnaas_nms/scheduler/tests/test_scheduler.py
@@ -5,6 +5,7 @@ import unittest
 import pkg_resources
 import pytest
 import yaml
+from apscheduler.schedulers.base import STATE_STOPPED
 
 from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.session import sqla_session
@@ -35,7 +36,8 @@ class InitTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         scheduler = Scheduler()
-        scheduler.start()
+        if scheduler.get_scheduler().state == STATE_STOPPED:
+            scheduler.start()
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/src/cnaas_nms/scheduler/tests/test_scheduler.py
+++ b/src/cnaas_nms/scheduler/tests/test_scheduler.py
@@ -1,16 +1,10 @@
-import os
 import time
-import unittest
 
-import pkg_resources
 import pytest
-import yaml
-from apscheduler.schedulers.base import STATE_STOPPED
 
 from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.scheduler.jobresult import DictJobResult
-from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.scheduler.wrapper import job_wrapper
 
 
@@ -27,68 +21,40 @@ def job_testfunc_exception(text="", job_id=None, scheduled_by=None):
 
 
 @pytest.mark.integration
-class InitTests(unittest.TestCase):
-    @pytest.fixture(autouse=True)
-    def requirements(self, postgresql):
-        """Ensures the required pytest fixtures are loaded implicitly for all these tests"""
-        pass
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        scheduler = Scheduler()
-        if scheduler.get_scheduler().state == STATE_STOPPED:
-            scheduler.start()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        scheduler = Scheduler()
-        time.sleep(3)
-        scheduler.get_scheduler().print_jobs()
-        scheduler.shutdown()
-
-    def setUp(self):
-        data_dir = pkg_resources.resource_filename(__name__, "data")
-        with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
-
-    def test_add_schedule(self):
-        scheduler = Scheduler()
-        job1_id = scheduler.add_onetime_job(
-            job_testfunc_success, when=1, scheduled_by="test_user", kwargs={"text": "success"}
-        )
-        job2_id = scheduler.add_onetime_job(
-            job_testfunc_exception, when=1, scheduled_by="test_user", kwargs={"text": "exception"}
-        )
-        assert isinstance(job1_id, int)
-        assert isinstance(job2_id, int)
-        print(f"Test job 1 scheduled as ID { job1_id }")
-        print(f"Test job 2 scheduled as ID { job2_id }")
-        time.sleep(3)
-        with sqla_session() as session:
-            job1 = session.query(Job).filter(Job.id == job1_id).one_or_none()
-            self.assertIsInstance(job1, Job, "Test job 1 could not be found")
-            self.assertEqual(job1.status, JobStatus.FINISHED, "Test job 1 did not finish")
-            self.assertEqual(job1.result, {"status": "success"}, "Test job 1 returned bad status")
-            job2 = session.query(Job).filter(Job.id == job2_id).one_or_none()
-            self.assertIsInstance(job2, Job, "Test job 2 could not be found")
-            self.assertEqual(job2.status, JobStatus.EXCEPTION, "Test job 2 did not make exception")
-            self.assertIn("message", job2.exception, "Test job 2 did not contain message in exception")
-
-    def test_abort_schedule(self):
-        scheduler = Scheduler()
-        job3_id = scheduler.add_onetime_job(
-            job_testfunc_success, when=600, scheduled_by="test_user", kwargs={"text": "abort"}
-        )
-        assert isinstance(job3_id, int)
-        print(f"Test job 3 scheduled as ID { job3_id }")
-        scheduler.remove_scheduled_job(job3_id)
-        time.sleep(3)
-        with sqla_session() as session:
-            job3 = session.query(Job).filter(Job.id == job3_id).one_or_none()
-            self.assertIsInstance(job3, Job, "Test job 3 could not be found")
-            self.assertEqual(job3.status, JobStatus.ABORTED, "Test job 3 did not abort")
-            self.assertEqual(job3.result, {"message": "removed"}, "Test job 3 returned bad status")
+def test_add_schedule(postgresql, scheduler):
+    job1_id = scheduler.add_onetime_job(
+        job_testfunc_success, when=1, scheduled_by="test_user", kwargs={"text": "success"}
+    )
+    job2_id = scheduler.add_onetime_job(
+        job_testfunc_exception, when=1, scheduled_by="test_user", kwargs={"text": "exception"}
+    )
+    assert isinstance(job1_id, int)
+    assert isinstance(job2_id, int)
+    print(f"Test job 1 scheduled as ID { job1_id }")
+    print(f"Test job 2 scheduled as ID { job2_id }")
+    time.sleep(3)
+    with sqla_session() as session:
+        job1 = session.query(Job).filter(Job.id == job1_id).one_or_none()
+        assert isinstance(job1, Job), "Test job 1 could not be found"
+        assert job1.status == JobStatus.FINISHED, "Test job 1 did not finish"
+        assert job1.result == {"status": "success"}, "Test job 1 returned bad status"
+        job2 = session.query(Job).filter(Job.id == job2_id).one_or_none()
+        assert isinstance(job2, Job), "Test job 2 could not be found"
+        assert job2.status == JobStatus.EXCEPTION, "Test job 2 did not make exception"
+        assert "message" in job2.exception, "Test job 2 did not contain message in exception"
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.integration
+def test_abort_schedule(postgresql, scheduler):
+    job3_id = scheduler.add_onetime_job(
+        job_testfunc_success, when=600, scheduled_by="test_user", kwargs={"text": "abort"}
+    )
+    assert isinstance(job3_id, int)
+    print(f"Test job 3 scheduled as ID { job3_id }")
+    scheduler.remove_scheduled_job(job3_id)
+    time.sleep(3)
+    with sqla_session() as session:
+        job3 = session.query(Job).filter(Job.id == job3_id).one_or_none()
+        assert isinstance(job3, Job), "Test job 3 could not be found"
+        assert job3.status == JobStatus.ABORTED, "Test job 3 did not abort"
+        assert job3.result == {"message": "removed"}, "Test job 3 returned bad status"

--- a/src/cnaas_nms/scheduler/wrapper.py
+++ b/src/cnaas_nms/scheduler/wrapper.py
@@ -53,7 +53,7 @@ def job_wrapper(func):
             errmsg = "Missing job_id when starting job for {}".format(func.__name__)
             logger.error(errmsg)
             raise ValueError(errmsg)
-        progress_funcitons = ["sync_devices", "device_upgrade"]
+        progress_funcitons = ["sync_devices", "device_upgrade", "confirm_devices"]
         with sqla_session() as session:
             job = session.query(Job).filter(Job.id == job_id).one_or_none()
             if not job:

--- a/src/cnaas_nms/version.py
+++ b/src/cnaas_nms/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.4.0b3"
+__version__ = "1.5.0a1"
 __version_info__ = tuple([field for field in __version__.split(".")])
 __api_version__ = "v1.0"

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -96,8 +96,8 @@ def wait_for_port(host: str, port: int, tries=10) -> bool:
     return False
 
 
-@pytest.fixture
-def scheduler(scope="session"):
+@pytest.fixture(scope="session")
+def scheduler():
     scheduler = Scheduler()
     scheduler.start()
     yield scheduler

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -5,6 +5,8 @@ import time
 from contextlib import closing
 
 import pytest
+
+from cnaas_nms.scheduler.scheduler import Scheduler
 from git import Repo
 
 
@@ -92,3 +94,13 @@ def wait_for_port(host: str, port: int, tries=10) -> bool:
         time.sleep(0.5)
     print(f"NO RESPONSE from {host}:{port}")
     return False
+
+
+@pytest.fixture
+def scheduler(scope="session"):
+    scheduler = Scheduler()
+    scheduler.start()
+    yield scheduler
+    time.sleep(3)
+    scheduler.get_scheduler().print_jobs()
+    scheduler.shutdown()


### PR DESCRIPTION
Try supporting different modes of commit confirmed via configuration
mode 0: no commit confirm
mode 1: confirm immediately after config push
mode 2: confirm after all devices in sync job has been configured, confirm is performed in separate job (might not work well with high number of devices)