### PR TITLE
Ensure SQL schema is updated before test run

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,10 +1,10 @@
 import os
 import socket
+import subprocess
 import time
 from contextlib import closing
 
 import pytest
-
 from git import Repo
 
 
@@ -71,7 +71,14 @@ def postgresql(request):
     # A more complete solution would check that we can actually establish a PostgreSQL client
     # connection.
     time.sleep(5)
+    request.getfixturevalue("alembic_upgrade")
     yield True
+
+
+@pytest.fixture(scope="session")
+def alembic_upgrade(pytestconfig):
+    """Ensures the sql database schema is up-to-date at the start of a test run"""
+    subprocess.check_call(["alembic", "upgrade", "head"], cwd=pytestconfig.rootpath)
 
 
 def wait_for_port(host: str, port: int, tries=10) -> bool:


### PR DESCRIPTION
The PostgreSQL test database is usually initialized through some SQL fixture file. This fixture doesn't necessarily include all the latest schema changes.

This ensures that once the test PostgreSQL database is up and running, alembic is used to apply all the available migrations up to the head revision.