### PR TITLE
Support branch refspecs also for dhcpd image

### DIFF
--- a/docker/dhcpd/dhcpd.sh
+++ b/docker/dhcpd/dhcpd.sh
@@ -6,7 +6,12 @@ if [ ! -z "$GITREPO_ETC" ]
 then
 	cd /opt/cnaas
 	rm -rf /opt/cnaas/etc
-	git clone $GITREPO_ETC etc
+        base_url=$(echo $GITREPO_ETC | cut -d\# -f1)
+        branch=$(echo $GITREPO_ETC | cut -d\# -s -f2)
+        if [ -n "$branch" ]; then
+           branch="-b $branch"
+        fi
+	git clone $branch $base_url etc
 	if [ -f "/opt/cnaas/etc/dhcpd/dhcpd.conf" ]
 	then
 		cp /opt/cnaas/etc/dhcpd/dhcpd.conf /opt/cnaas/dhcpd.conf


### PR DESCRIPTION
While #223 added refspec support to Git repo URLs in the Python codebase of CNaaS-NMS, it did not do the same for the shell-based code of the `dhcpd` Docker service image also defined in cnaas-nms.

The dhcpd docker image clones `GITREPO_ETC` using a shell script, and consequently did not support a branch refspec anchor, as is supported by the Python codebase of CNaaS-NMS.

This adds refspec support for `GITREPO_ETC` in the dhcpd service by splitting off the anchor using shell commands available in the docker image (specifically, `cut`).