### PR TITLE
Init neighbor check sync status

### DIFF
--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -657,7 +657,7 @@ def check_neighbor_sync(session, hostnames: List[str]):
             raise DeviceStateError("Neighbor device {} not in state MANAGED".format(hostname))
         if not dev.synchronized:
             raise DeviceSyncError("Neighbor device {} not synchronized".format(hostname))
-    confcheck_devices(hostnames)
+    confcheck_devices(session, hostnames)
 
 
 @job_wrapper

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -664,7 +664,7 @@ def update_config_hash(task):
             logger.debug("Config hash for {} updated to {}".format(task.host.name, new_config_hash))
 
 
-def confcheck_devices(hostnames: List[str], job_id=None):
+def confcheck_devices(session, hostnames: List[str], job_id=None):
     nr = cnaas_init()
     nr_filtered, dev_count, skipped_hostnames = inventory_selector(nr, hostname=hostnames)
 
@@ -674,6 +674,9 @@ def confcheck_devices(hostnames: List[str], job_id=None):
         raise e
     else:
         if nrresult.failed:
+            for hostname in nrresult.failed_hosts.keys():
+                dev: Device = session.query(Device).filter(Device.hostname == hostname).one()
+                dev.synchronized = False
             raise Exception("Configuration hash check failed for {}".format(" ".join(nrresult.failed_hosts.keys())))
 
 


### PR DESCRIPTION
When doing init of a new device, negihbor/uplink device sync statuses are checked, but if they have local changes saved the devices were not marked as unsynced in database