### PR TITLE
Feature.settings campus spring2023

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -367,14 +367,55 @@ base_system.yml:
 
 Contains base system settings like:
 
-- ntp_servers
-- snmp_servers
-- dns_servers
-- syslog_servers
-- flow_collectors
-- dhcp_relays
-- internal_vlans
+- ntp_servers: List of
+
+  * host: IP address or hostname of NTP server
+
+- snmp_servers: List of
+
+  * host: IP address or hostname of SNMP trap target
+  * port: Port number. Optional
+
+- dns_servers: List of
+
+  * host: IP address to DNS server
+
+- syslog_servers: List of
+
+  * host: IP address or hostname to syslog server
+  * port: Port number. Optional
+
+- flow_collectors: List of
+
+  * host: IP address or hostname to flow collector
+  * port: Port number. Optional
+
+- dhcp_relays: List of
+
+  * host: IP address or hostname to DHCP relay
+
+- users: List of
+
+  * username: Username string
+  * ssh_key: SSH public key string. Optional
+  * uid: UserID number. Optional
+  * password_hash_arista: Hashed password string for Arista devices. Optional
+  * password_hash_cisco: Hashed password string for Cisco devices. Optional
+  * password_hash_juniper: Hashed password string for Juniper devices. Optional
+  * permission_arista: String to specify user access level for Arista, ex "privilege 15 role network-admin". Optional
+  * permission_cisco: String to specify user access level for Cisco, ex "privilege 15". Optional
+  * permission_juniper: String to specify user access level for Juniper, ex "superuser". Optional
+  * groups: A list of device groups that this user should be provisioned on
+
+- internal_vlans:
+
+  * vlan_low: Low end of internal VLAN range
+  * vlan_high: High end of internal VLAN range
+  * allocation_order: Allocation order, default "ascending"
+
 - dot1x_fail_vlan: Numeric ID of authentication fail VLAN
+- dot1x_multi_host: Allow multiple clients behind a dot1x authenticated port. Default false
+- poe_reboot_maintain: Maintain POE supply during reboot of the switch. Default false
 - organization_name: Free format string describing organization name
 - domain_name: DNS domain (suffix)
 
@@ -405,9 +446,6 @@ Example of base_system.yml:
      vlan_id_high: 4094
    dot1x_fail_vlan: 13
 
-
-syslog_servers and radius_severs can optionally have the key "port" specified
-to indicate a non-defalut layer4 (TCP/UDP) port number.
 
 internal_vlans can optionally be specified if you want to manually define
 the range of internal VLANs on L3 switches. You can also specify the option

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -556,9 +556,17 @@ def get_settings(
         settings_origin[k] = "default"
 
     # 2. Get settings repo global settings
-    settings, settings_origin = read_settings(
-        local_repo_path, ["global", "base_system.yml"], "global->base_system.yml", settings, settings_origin
-    )
+    if hostname:
+        # Some settings parsing require knowledge of group memberships
+        groups = get_groups(hostname)
+        settings, settings_origin = read_settings(
+            local_repo_path, ["global", "base_system.yml"], "global->base_system.yml", settings, settings_origin, groups
+        )
+    else:
+        settings, settings_origin = read_settings(
+            local_repo_path, ["global", "base_system.yml"], "global->base_system.yml", settings, settings_origin
+        )
+
     # 3. Get settings from special fabric classification (dist + core)
     if device_type and (device_type == DeviceType.DIST or device_type == DeviceType.CORE):
         settings, settings_origin = read_settings(
@@ -576,8 +584,6 @@ def get_settings(
             settings_origin,
         )
     if hostname:
-        # Some settings parsing require knowledge of group memberships
-        groups = get_groups(hostname)
         settings, settings_origin = read_settings(
             local_repo_path, ["global", "routing.yml"], "global->routing.yml", settings, settings_origin, groups
         )

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -296,6 +296,19 @@ class f_underlay(BaseModel):
     bgp_asn: Optional[as_num_type] = as_num_schema
 
 
+class f_user(BaseModel):
+    username: str
+    ssh_key: Optional[str] = None
+    uid: Optional[int] = None
+    password_hash_arista: Optional[str] = None
+    password_hash_cisco: Optional[str] = None
+    password_hash_juniper: Optional[str] = None
+    permission_arista: Optional[str] = None
+    permission_cisco: Optional[str] = None
+    permission_juniper: Optional[str] = None
+    groups: List[str] = []
+
+
 class f_root(BaseModel):
     ntp_servers: List[f_ntp_server] = []
     radius_servers: List[f_radius_server] = []
@@ -318,6 +331,9 @@ class f_root(BaseModel):
     cli_append_str: str = ""
     organization_name: str = ""
     domain_name: Optional[str] = domain_name_schema
+    users: List[f_user] = []
+    dot1x_multi_host: bool = False
+    poe_reboot_maintain: bool = False
 
 
 class f_group_item(BaseModel):


### PR DESCRIPTION
Add support for users settings, with some vendor specific fields for password hashes and permissions. Add support for some campus settings dot1x_multi_host and poe_reboot_maintain

```
- users: List of

  * username: Username string
  * ssh_key: SSH public key string. Optional
  * uid: UserID number. Optional
  * password_hash_arista: Hashed password string for Arista devices. Optional
  * password_hash_cisco: Hashed password string for Cisco devices. Optional
  * password_hash_juniper: Hashed password string for Juniper devices. Optional
  * permission_arista: String to specify user access level for Arista, ex "privilege 15 role network-admin". Optional
  * permission_cisco: String to specify user access level for Cisco, ex "privilege 15". Optional
  * permission_juniper: String to specify user access level for Juniper, ex "superuser". Optional
  * groups: A list of device groups that this user should be provisioned on

- dot1x_multi_host: Allow multiple clients behind a dot1x authenticated port. Default false
- poe_reboot_maintain: Maintain POE supply during reboot of the switch. Default false
```