### PR TITLE
Bug with commit confirmed / commit_message on EOS

### DIFF
--- a/docs/apiref/interfaces.rst
+++ b/docs/apiref/interfaces.rst
@@ -149,7 +149,8 @@ Data can contain any of these optional keys:
 - aggregate_id: Identifier for configuring LACP etc. Integer value.
   Special value -1 means configure MLAG and use ID based on indexnum.
 - bpdu_filter: bool defining STP BPDU feature enabled/disabled
-- redundant_link: bool allows specifying if this link allows non-redundant downlinks
+- redundant_link: bool specifying if access switch connections to this interface requires
+  redundant connections, which is the default. Set to false to allow non-redundant downlink.
 - tags: List of strings, user-defined custom tags to use in templates
 - cli_append_str: String of custom config that is appended to generated CLI config
 - neighbor: Populated at init, contains hostname of peer. Should normally never

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Version 1.5.1
+-------------
+
+Bug fixes:
+
+  - Fix commit confirm mode 0 for EOS
+  - Update documentation for redundant_link
+
 Version 1.5.0
 -------------
 

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -546,7 +546,6 @@ def push_sync_device(
             "replace": True,
             "configuration": task.host["config"],
             "dry_run": dry_run,
-            "commit_message": "Job id {}".format(job_id),
         }
         if dry_run:
             task_args["task"] = napalm_configure
@@ -949,11 +948,12 @@ def sync_devices(
             dev.last_seen = datetime.datetime.utcnow()
         if not dry_run and get_confirm_mode(confirm_mode_override) != 2:
             if failed_hosts:
-                logger.error(
-                    "One or more devices failed to commit configuration, they will roll back configuration"
-                    " in {}s: {}".format(api_settings.COMMIT_CONFIRMED_TIMEOUT, ", ".join(failed_hosts))
-                )
-                time.sleep(api_settings.COMMIT_CONFIRMED_TIMEOUT)
+                if get_confirm_mode(confirm_mode_override) == 1:
+                    logger.error(
+                        "One or more devices failed to commit configuration, they will roll back configuration"
+                        " in {}s: {}".format(api_settings.COMMIT_CONFIRMED_TIMEOUT, ", ".join(failed_hosts))
+                    )
+                    time.sleep(api_settings.COMMIT_CONFIRMED_TIMEOUT)
             logger.info("Releasing lock for devices from syncto job: {}".format(job_id))
             Joblock.release_lock(session, job_id=job_id)
 

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -947,13 +947,12 @@ def sync_devices(
             remove_sync_events(hostname)
             dev.last_seen = datetime.datetime.utcnow()
         if not dry_run and get_confirm_mode(confirm_mode_override) != 2:
-            if failed_hosts:
-                if get_confirm_mode(confirm_mode_override) == 1:
-                    logger.error(
-                        "One or more devices failed to commit configuration, they will roll back configuration"
-                        " in {}s: {}".format(api_settings.COMMIT_CONFIRMED_TIMEOUT, ", ".join(failed_hosts))
-                    )
-                    time.sleep(api_settings.COMMIT_CONFIRMED_TIMEOUT)
+            if failed_hosts and get_confirm_mode(confirm_mode_override) == 1:
+                logger.error(
+                    "One or more devices failed to commit configuration, they will roll back configuration"
+                    " in {}s: {}".format(api_settings.COMMIT_CONFIRMED_TIMEOUT, ", ".join(failed_hosts))
+                )
+                time.sleep(api_settings.COMMIT_CONFIRMED_TIMEOUT)
             logger.info("Releasing lock for devices from syncto job: {}".format(job_id))
             Joblock.release_lock(session, job_id=job_id)
 


### PR DESCRIPTION
commit_message not implemented on napalm EOS driver, causes error with commit_mode 0. don't wait for rollback on commit mode 0