### PR TITLE
Small bugfix: Added audience variable

### DIFF
--- a/src/cnaas_nms/app_settings.py
+++ b/src/cnaas_nms/app_settings.py
@@ -70,6 +70,7 @@ class AuthSettings(BaseSettings):
     OIDC_CLIENT_ID: str = "client-id"
     OIDC_ENABLED: bool = False
     OIDC_CLIENT_SCOPE: str = "openid"
+    AUDIENCE: str = OIDC_CLIENT_ID
 
 
 def construct_api_settings() -> ApiSettings:
@@ -153,6 +154,7 @@ def construct_auth_settings() -> AuthSettings:
             OIDC_CLIENT_SECRET=config.get("oidc_client_secret", AuthSettings().OIDC_CLIENT_SECRET),
             OIDC_CLIENT_ID=config.get("oidc_client_id", AuthSettings().OIDC_CLIENT_ID),
             OIDC_CLIENT_SCOPE=config.get("oidc_client_scope", AuthSettings().OIDC_CLIENT_SCOPE),
+            AUDIENCE=config.get("audience", AuthSettings().AUDIENCE),
         )
     else:
         return AuthSettings()


### PR DESCRIPTION
After discussion with Johan:
Currently in the code the audience is set like: audience=auth_settings.OIDC_CLIENT_ID
This is good for the web frontend etc, but if I have another client (like the cli client), I guess that should have another client_id and then I get invalid token because "invalid audience". 