### PR TITLE
make refresh repo log job id for each line, not just the first ones

### DIFF
--- a/src/cnaas_nms/api/repository.py
+++ b/src/cnaas_nms/api/repository.py
@@ -13,7 +13,7 @@ api = Namespace("repository", description="API for handling repositories", prefi
 repository_model = api.model(
     "repository",
     {
-        "action": fields.String(required=True),
+        "action": fields.String(required=True, example="REFRESH"),
     },
 )
 


### PR DESCRIPTION
```
[2024-06-13 15:23:54,742] INFO in git job #4: Trying 
[2024-06-13 15:23:54,785] DEBUG in git job #4: git pu
[2024-06-13 15:23:57,244] DEBUG in settings job #4: C
[2024-06-13 15:23:57,248] DEBUG in settings job #4: R
[2024-06-13 15:23:57,250] DEBUG in settings job #4: R
[2024-06-13 15:23:57,402] DEBUG in settings job #4: R
[2024-06-13 15:23:57,423] DEBUG in settings job #4: R
[2024-06-13 15:23:57,426] WARNING in settings job #4:

```
with "job #4" on each line