### PR TITLE
Clean up init_device fails and make it more consistent

### DIFF
--- a/src/cnaas_nms/db/device.py
+++ b/src/cnaas_nms/db/device.py
@@ -260,6 +260,20 @@ class Device(cnaas_nms.db.base.Base):
                 peer_hostnames.append(intf.data["neighbor"])
         return peer_hostnames
 
+    def reset_uplink_interfaces(self, session):
+        intfs = (
+            session.query(Interface)
+            .filter(Interface.device == self)
+            .filter(Interface.configtype == InterfaceConfigType.ACCESS_UPLINK)
+            .all()
+        )
+        intf: Interface = Interface()
+        for intf in intfs:
+            intf.configtype = InterfaceConfigType.ACCESS_AUTO
+            if intf.data:
+                intf.data = {}
+        session.commit()
+
     def get_mlag_peer(self, session) -> Optional[Device]:
         intfs = (
             session.query(Interface)


### PR DESCRIPTION
Cleanup uplink interfaces on failed init. Cleanup tasks that are supposed to fail for fabric devices in the same way as for access devices. Raise exception on napalm ReplaceConfigException