### PR TITLE
Replace fcntl lib to portalocker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ greenlet==3.0.3
 pydantic_settings==2.4.0
 Authlib==1.3.1
 python-jose==3.3.0
+portalocker==2.8.2

--- a/src/cnaas_nms/scheduler/scheduler.py
+++ b/src/cnaas_nms/scheduler/scheduler.py
@@ -36,8 +36,8 @@ class Scheduler(object, metaclass=SingletonType):
         # If scheduler is already started, use uwsgi ipc to send job to mule process
         self.lock_f = open("/tmp/scheduler.lock", "w")
         try:
-            portalocker.Lock(self.lock_f, flags=portalocker.LOCK_EX | portalocker.LOCK_NB)
-        except BlockingIOError:
+            portalocker.lock(self.lock_f, flags=portalocker.LOCK_EX | portalocker.LOCK_NB)
+        except portalocker.exceptions.LockException:
             try:
                 import uwsgi  # noqa: F401
             except Exception:


### PR DESCRIPTION
As discussed in #329
We used a different locker, named portalocker that is os independent. 