### PR TITLE
Settings: interface_tag_options, vxlan_vni_range, external_routing_policies, remove_private_as

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -298,6 +298,10 @@ Can contain the following dictionaries with specified keys:
       * match_type: String, ex "ipv4 prefix-set"
       * match_target: String, referring to prefix-set for example: "default-route"
 
+- external_routing_policies: List of strings, referring to routing policies defined in external
+  sources such as templates repository. BGP neighbor route maps must refer to a policy defined in
+  either this list or the routing_policies setting described above.
+
 
 routing.yml examples:
 
@@ -514,6 +518,13 @@ Contains base system settings like:
 - poe_reboot_maintain: Maintain POE supply during reboot of the switch. Default false
 - organization_name: Free format string describing organization name
 - domain_name: DNS domain (suffix)
+- interface_tag_options: Dictionary of {<name>, <description>}:
+
+  * name: Name of the tag, as defined in templates
+  * description: Description of the tag to be displayed in WebUI etc.
+
+- vxlan_vni_range: Define a range of VNIs to be used for VXLANs, ex "10000-99999". If any VXLANs are
+  configured with VNIs outside of this range an error will be raised when refreshing settings.
 
 Example of base_system.yml:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -274,6 +274,8 @@ Can contain the following dictionaries with specified keys:
       * update_source: Specify local source interface for the BGP session
       * auth_string: String used to calculate MD5 hash for authentication (password)
       * description: Description of remote peer (optional, defaults to "undefined")
+      * remove_private_as: Optional, if set must be either "all" or "replace".
+        Remove all private AS numbers from AS_PATH, or replace private AS numbers with local AS.
       * cli_append_str: Custom configuration to append to this peer (optional)
     * neighbor_v6:
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -319,6 +319,7 @@ def check_settings_collisions(unique_vlans: bool = True):
 
     check_vlan_collisions(devices_dict, mgmt_vlans, unique_vlans)
     check_group_priority_collisions()
+    check_routing_policies(devices_dict)
 
 
 def get_internal_vlan_range(settings) -> range:
@@ -336,6 +337,34 @@ def get_internal_vlan_range(settings) -> range:
         )
     else:
         return range(0)
+
+
+def check_bgp_neighbor_routemaps(hostname: str, vrfs: List, defined_policies: set[str]):
+    for vrf in vrfs:
+        for v4_neighbor in vrf["neighbor_v4"]:
+            if v4_neighbor["route_map_in"] and v4_neighbor["route_map_in"] not in defined_policies:
+                raise ValueError(f"{hostname}: BGP neighbor route map {v4_neighbor['route_map_in']} is not defined")
+            if v4_neighbor["route_map_out"] and v4_neighbor["route_map_out"] not in defined_policies:
+                raise ValueError(f"{hostname}: BGP neighbor route map {v4_neighbor['route_map_out']} is not defined")
+        for v6_neighbor in vrf["neighbor_v6"]:
+            if v6_neighbor["route_map_in"] and v6_neighbor["route_map_in"] not in defined_policies:
+                raise ValueError(f"{hostname}: BGP neighbor route map {v6_neighbor['route_map_in']} is not defined")
+            if v6_neighbor["route_map_out"] and v6_neighbor["route_map_out"] not in defined_policies:
+                raise ValueError(f"{hostname}: BGP neighbor route map {v6_neighbor['route_map_out']} is not defined")
+
+
+def check_routing_policies(devices_dict: Dict[str, dict]):
+    # save global VLAN IDs and their unique vxlan name
+    defined_policies = set()
+
+    for hostname, settings in devices_dict.items():
+        if "external_routing_policies" in settings:
+            defined_policies.update(settings["external_routing_policies"])
+        try:
+            defined_policies.update(settings["routing_policies"].keys())
+            check_bgp_neighbor_routemaps(hostname, settings["extroute_bgp"]["vrfs"], defined_policies)
+        except (KeyError, TypeError):
+            pass
 
 
 def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], unique_vlans: bool = True):
@@ -359,6 +388,15 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], u
             if "vni" not in vxlan_data or not isinstance(vxlan_data["vni"], int):
                 logger.error("VXLAN {} is missing vni".format(vxlan_name))
                 continue
+            if settings["vxlan_vni_range"] and "-" in settings["vxlan_vni_range"]:
+                vni_range = settings["vxlan_vni_range"].split("-")
+                if not int(vni_range[0]) < vxlan_data["vni"] < int(vni_range[1]):
+                    raise VlanConflictError(
+                        "VXLAN VNI {} is outside of the allowed range {}".format(
+                            vxlan_data["vni"], settings["vxlan_vni_range"]
+                        )
+                    )
+
             if vxlan_data["vni"] in global_vnis and global_vnis[vxlan_data["vni"]] != vxlan_name:
                 raise VlanConflictError(
                     "VXLAN VNI {} used in VXLAN {} is already used elsewhere".format(vxlan_data["vni"], vxlan_name)
@@ -423,7 +461,8 @@ def check_group_priority_collisions(settings: Optional[dict] = None):
             continue
         if group["group"]["group_priority"] in priorities.keys():
             raise ValueError(
-                "Groups must have unique group_priority values, " "but group {} and {} both have priority {}".format(
+                "Groups must have unique group_priority values, "
+                "but group {} and {} both have priority {}".format(
                     priorities[group["group"]["group_priority"]],
                     group["group"]["name"],
                     group["group"]["group_priority"],

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -388,7 +388,7 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], u
             if "vni" not in vxlan_data or not isinstance(vxlan_data["vni"], int):
                 logger.error("VXLAN {} is missing vni".format(vxlan_name))
                 continue
-            if settings["vxlan_vni_range"] and "-" in settings["vxlan_vni_range"]:
+            if "vxlan_vni_range" in settings and settings["vxlan_vni_range"]:
                 vni_range = settings["vxlan_vni_range"].split("-")
                 if not int(vni_range[0]) < vxlan_data["vni"] < int(vni_range[1]):
                     raise VlanConflictError(

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -272,6 +272,7 @@ class f_extroute_bgp_neighbor_v6(BaseModel):
     maximum_routes: Optional[int] = maximum_routes_schema
     auth_type: Optional[str] = None
     auth_string: Optional[str] = None
+    remove_private_as: Optional[RemovePrivateASEnum] = None
     cli_append_str: str = ""
 
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -1,3 +1,4 @@
+from enum import StrEnum, auto
 from ipaddress import AddressValueError, IPv4Interface
 from typing import Annotated, Dict, List, Optional, Union
 
@@ -71,6 +72,11 @@ group_name = Field(..., pattern=GROUP_NAME, max_length=253)
 group_priority_schema = Field(
     0, ge=0, le=100, description="Group priority 0-100, default 0, higher value means higher priority"
 )
+
+
+class RemovePrivateASEnum(StrEnum):
+    ALL = auto()
+    REPLACE = auto()
 
 
 def validate_ipv4_if(ipv4if: str):
@@ -248,6 +254,7 @@ class f_extroute_bgp_neighbor_v4(BaseModel):
     maximum_routes: Optional[int] = maximum_routes_schema
     auth_type: Optional[str] = None
     auth_string: Optional[str] = None
+    remove_private_as: Optional[RemovePrivateASEnum] = None
     cli_append_str: str = ""
 
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -132,13 +132,24 @@ class f_evpn_peer(BaseModel):
     hostname: str = hostname_schema
 
 
-def vlan_range_check(v: str):
+def vlan_range_check(v: str) -> str:
     if "-" in v:
         start, end = v.split("-")
         assert int(start) < int(end), "Start of range must be less than end of range"
         assert int(start) >= 1 and int(end) <= 4095, "VLAN IDs in range must be between 1-4095"
     else:
         assert 1 <= int(v) <= 4095, "VLAN IDs in range must be between 1-4095"
+    return v
+
+
+def vni_range_required_check(v: str) -> str:
+    if "-" in v:
+        start, end = v.split("-")
+        assert int(start) < int(end), "Start of range must be less than end of range"
+        assert int(start) >= 1 and int(end) <= 16777215, "VNI IDs in range must be between 1-16777215"
+    else:
+        raise ValueError("Range must be specified, ex '10000-99999'")
+    return v
 
 
 class f_interface(BaseModel):
@@ -366,6 +377,11 @@ class f_routingpolicy(BaseModel):
     statements: List[f_rpolicy_statement]
 
 
+class f_interface_tag(BaseModel):
+    description: str = ""
+    groups: Optional[List[str]] = None
+
+
 class f_root(BaseModel):
     ntp_servers: List[f_ntp_server] = []
     radius_servers: List[f_radius_server] = []
@@ -393,6 +409,9 @@ class f_root(BaseModel):
     poe_reboot_maintain: bool = False
     prefix_sets: Dict[str, f_prefixset] = {}
     routing_policies: Dict[str, f_routingpolicy] = {}
+    external_routing_policies: List[str] = []
+    interface_tag_options: Dict[str, f_interface_tag] = {}
+    vxlan_vni_range: Optional[Annotated[str, AfterValidator(vni_range_required_check)]] = None
 
 
 class f_group_item(BaseModel):

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -11,6 +11,7 @@ from cnaas_nms.db.settings import (
     DIR_STRUCTURE,
     VerifyPathException,
     VlanConflictError,
+    check_bgp_neighbor_routemaps,
     check_group_priority_collisions,
     check_vlan_collisions,
     get_device_primary_groups,
@@ -170,6 +171,21 @@ class SettingsTests(unittest.TestCase):
             },
         }
         self.assertIsNone(check_vlan_collisions(devices_dict, mgmt_vlans))
+
+    def test_routing_policy(self):
+        test_device_name = "policytest"
+        test_vrfs = [
+            {
+                "name": "testvrf",
+                "neighbor_v4": [{"route_map_in": "routemap1", "route_map_out": "routemap1"}],
+                "neighbor_v6": [{"route_map_in": "routemap2", "route_map_out": "routemap2"}],
+            }
+        ]
+        with self.assertRaises(ValueError, msg="Undefined route map routemap1 should raise error"):
+            check_bgp_neighbor_routemaps(test_device_name, test_vrfs, {})
+        check_bgp_neighbor_routemaps(test_device_name, test_vrfs, {"routemap1", "routemap2"})
+        with self.assertRaises(KeyError):
+            check_bgp_neighbor_routemaps(test_device_name, [{"name": "emptyvrf"}], {})
 
     def test_groups_priorities_sorted(self):
         group_settings_dict = {

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -182,10 +182,10 @@ class SettingsTests(unittest.TestCase):
             }
         ]
         with self.assertRaises(ValueError, msg="Undefined route map routemap1 should raise error"):
-            check_bgp_neighbor_routemaps(test_device_name, test_vrfs, {})
+            check_bgp_neighbor_routemaps(test_device_name, test_vrfs, set())
         check_bgp_neighbor_routemaps(test_device_name, test_vrfs, {"routemap1", "routemap2"})
         with self.assertRaises(KeyError):
-            check_bgp_neighbor_routemaps(test_device_name, [{"name": "emptyvrf"}], {})
+            check_bgp_neighbor_routemaps(test_device_name, [{"name": "emptyvrf"}], set())
 
     def test_groups_priorities_sorted(self):
         group_settings_dict = {


### PR DESCRIPTION
- external_routing_policies: List of strings, referring to routing policies defined in external
  sources such as templates repository. BGP neighbor route maps must refer to a policy defined in
  either this list or the routing_policies setting described above.
- interface_tag_options: Dictionary of {<name>, <description>}:

  * name: Name of the tag, as defined in templates
  * description: Description of the tag to be displayed in WebUI etc.

- vxlan_vni_range: Define a range of VNIs to be used for VXLANs, ex "10000-99999". If any VXLANs are
  configured with VNIs outside of this range an error will be raised when refreshing settings.

BGP neighbors
* remove_private_as: Optional, if set must be either "all" or "replace".
        Remove all private AS numbers from AS_PATH, or replace private AS numbers with local AS.