### PR TITLE
Issue/398/custom encoding

### DIFF
--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -165,63 +165,63 @@ def get_interface(
 
 
 @template_filter()
-def b64encode(s: str) -> str:
+def b64encode(s: str, encoding="utf-8") -> str:
     """Returns base64 encoded string.
 
     Args:
         s: String to encode"""
-    return base64.b64encode(s.encode()).decode()
+    return base64.b64encode(s.encode(encoding=encoding)).decode(encoding=encoding)
 
 
 @template_filter()
-def b64decode(s: str) -> str:
+def b64decode(s: str, encoding="utf-8") -> str:
     """Returns base64 decoded string.
 
     Args:
         s: String to decode"""
-    return base64.b64decode(s.encode()).decode()
+    return base64.b64decode(s.encode(encoding=encoding)).decode(encoding=encoding)
 
 
 @template_filter()
-def b16encode(s: str) -> str:
+def b16encode(s: str, encoding="utf-8") -> str:
     """Returns base16 encoded string.
 
     Args:
         s: String to encode"""
-    return base64.b16encode(s.encode()).decode()
+    return base64.b16encode(s.encode(encoding=encoding)).decode(encoding=encoding)
 
 
 @template_filter()
-def b16decode(s: str) -> str:
+def b16decode(s: str, encoding="utf-8") -> str:
     """Returns base16 decoded string.
 
     Args:
         s: String to decode"""
-    return base64.b16decode(s.encode()).decode()
+    return base64.b16decode(s.encode(encoding=encoding)).decode(encoding=encoding)
 
 
 @template_filter()
-def sha1(s: str) -> str:
+def sha1(s: str, encoding="utf-8") -> str:
     """Return SHA1 hexdigest of string s."""
-    return hashlib.sha1(s.encode()).hexdigest()
+    return hashlib.sha1(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()
-def sha256(s: str) -> str:
+def sha256(s: str, encoding="utf-8") -> str:
     """Return SHA256 hexdigest of string s."""
-    return hashlib.sha256(s.encode()).hexdigest()
+    return hashlib.sha256(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()
-def sha512(s: str) -> str:
+def sha512(s: str, encoding="utf-8") -> str:
     """Return SHA256 hexdigest of string s."""
-    return hashlib.sha512(s.encode()).hexdigest()
+    return hashlib.sha512(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()
-def md5(s: str) -> str:
+def md5(s: str, encoding: str = "utf-8") -> str:
     """Return SHA256 hexdigest of string s."""
-    return hashlib.md5(s.encode()).hexdigest()
+    return hashlib.md5(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()

--- a/src/cnaas_nms/tools/jinja_filters.py
+++ b/src/cnaas_nms/tools/jinja_filters.py
@@ -165,7 +165,7 @@ def get_interface(
 
 
 @template_filter()
-def b64encode(s: str, encoding="utf-8") -> str:
+def b64encode(s: str, encoding: str = "utf-8") -> str:
     """Returns base64 encoded string.
 
     Args:
@@ -174,7 +174,7 @@ def b64encode(s: str, encoding="utf-8") -> str:
 
 
 @template_filter()
-def b64decode(s: str, encoding="utf-8") -> str:
+def b64decode(s: str, encoding: str = "utf-8") -> str:
     """Returns base64 decoded string.
 
     Args:
@@ -183,7 +183,7 @@ def b64decode(s: str, encoding="utf-8") -> str:
 
 
 @template_filter()
-def b16encode(s: str, encoding="utf-8") -> str:
+def b16encode(s: str, encoding: str = "utf-8") -> str:
     """Returns base16 encoded string.
 
     Args:
@@ -192,7 +192,7 @@ def b16encode(s: str, encoding="utf-8") -> str:
 
 
 @template_filter()
-def b16decode(s: str, encoding="utf-8") -> str:
+def b16decode(s: str, encoding: str = "utf-8") -> str:
     """Returns base16 decoded string.
 
     Args:
@@ -201,19 +201,19 @@ def b16decode(s: str, encoding="utf-8") -> str:
 
 
 @template_filter()
-def sha1(s: str, encoding="utf-8") -> str:
+def sha1(s: str, encoding: str = "utf-8") -> str:
     """Return SHA1 hexdigest of string s."""
     return hashlib.sha1(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()
-def sha256(s: str, encoding="utf-8") -> str:
+def sha256(s: str, encoding: str = "utf-8") -> str:
     """Return SHA256 hexdigest of string s."""
     return hashlib.sha256(s.encode(encoding=encoding)).hexdigest()
 
 
 @template_filter()
-def sha512(s: str, encoding="utf-8") -> str:
+def sha512(s: str, encoding: str = "utf-8") -> str:
     """Return SHA256 hexdigest of string s."""
     return hashlib.sha512(s.encode(encoding=encoding)).hexdigest()
 

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -167,7 +167,7 @@ class HashTests(unittest.TestCase):
 
     def test_sha512(self):
         self.assertEqual(
-            sha512("Zij3NjTWHt9W4Ljuez7QpJTo5O/Fg+z8bKzWMev+n3lXcEhTv9dnL1ZsfJBocAR19QBjLz747LhqkDiQBOuOuw=="),
+            sha512("Zij3NjTWHt9W4Ljuez7QpJTo5O/Fg+z8bKzWMev+n3lXcEhTv9dnL1Zs" "fJBocAR19QBjLz747LhqkDiQBOuOuw=="),
             "6f7affc55e52d24b6da48182ceae1007a3f7fcdee6ad7e3eae0858e02d98786"
             "cc04e9a329126d31cdf427214ea07428dd61e67b56b9f568e221c4553f391d02e",
         )

--- a/src/cnaas_nms/tools/tests/test_jinja_filters.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_filters.py
@@ -167,7 +167,7 @@ class HashTests(unittest.TestCase):
 
     def test_sha512(self):
         self.assertEqual(
-            sha512("Zij3NjTWHt9W4Ljuez7QpJTo5O/Fg+z8bKzWMev+n3lXcEhTv9dnL1Zs" "fJBocAR19QBjLz747LhqkDiQBOuOuw=="),
+            sha512("Zij3NjTWHt9W4Ljuez7QpJTo5O/Fg+z8bKzWMev+n3lXcEhTv9dnL1ZsfJBocAR19QBjLz747LhqkDiQBOuOuw=="),
             "6f7affc55e52d24b6da48182ceae1007a3f7fcdee6ad7e3eae0858e02d98786"
             "cc04e9a329126d31cdf427214ea07428dd61e67b56b9f568e221c4553f391d02e",
         )
@@ -177,6 +177,13 @@ class HashTests(unittest.TestCase):
             md5("zKEPXmRX2X9itoaaI2kWyQ=="),
             "88a23549d423a601c96b4bf90018bde6",
         )
+
+
+class DecodeHashTests(unittest.TestCase):
+    def test_ssh_key_to_md5(self):
+        ssh_key = "AAAAB3NzaC1yc2EAAAADAQABAAABAQC/SIee+JR7J87Uty3a6Uv/sdXFq9lMuJ5zCQ1nI94VVMwmDJIfRuvdOOUTwnqxCkrOXyDsNur7rXSzHw8NBeRrPAlk8e7qIIhDhZWYRQWyGW27s7sl0wehJ0e57PeeE9NdZ2O4pRGtuuom5y/N7ed0Ll/z/EDgOqYJpD5r39yoc02efWn+G81Ahl8twi+uS+3Y/hXLvkT9AB0XKPYt8DI2yAygt+3E+BWL53a+UICLP6pUvnwY9TUXqk3S27gD/gJZ/DSC8WtBfrHVuYk3QMA4kASKqu1Bt/FGYegsD7qv16hum4if+8bPioTccd1V7Qx3jtQ3s6pW8AWVxnpWydzl"
+        ssh_key_md5 = "79ed70709499afede0f6b865bd641b68"
+        self.assertEqual(ssh_key_md5, md5(b64decode(ssh_key, encoding="latin-1"), encoding="latin-1"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
My attempt to fix #398.
Moves the default encoding up to the filter functions so it can be customized, default for string encode and string decode is "utf-8".

Added a test for my specific use-case as well with a ssh-key b64decode -> md5sum.


All tests pass
```bash
.venv) ➜  src git:(issue/398/custom-encoding) python3 -m cnaas_nms.tools.tests.test_jinja_filters
.........................
----------------------------------------------------------------------
Ran 25 tests in 0.003s

OK
```

Feel free to provide input for this change.