### PR TITLE
Groups redesign

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -63,13 +63,18 @@ jobs:
 
       - name: Get repo URL
         shell: bash
-        run: echo "CNAAS_REPO=$(echo ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY})" >> $GITHUB_ENV
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "CNAAS_REPO=${{ github.event.pull_request.head.repo.clone_url }}" >> $GITHUB_ENV
+          else
+            echo "CNAAS_REPO=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
+          fi
 
       - name: Print branch name
         run: echo ${{ env.BRANCH_NAME }} at ${{ env.CNAAS_REPO }}
 
       - name: Build docker
-        run: docker compose -f docker/docker-compose_test.yaml build --build-arg GITREPO_BASE=${{ env.CNAAS_REPO }} --build-arg BUILDBRANCH=${{ env.BRANCH_NAME }}
+        run: docker compose -f docker/docker-compose_test.yaml build --build-arg GITREPO_BASE=${{ env.CNAAS_REPO }} --build-arg BUILDBRANCH=${{ env.BRANCH_NAME }} --build-arg GIT_COMMIT=${{ github.sha }}
 
       - name: Start docker
         run: docker compose -f docker/docker-compose_test.yaml up -d

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -73,7 +73,7 @@ ARG BUILDBRANCH=develop
 ARG GITREPO_BASE=https://github.com/SUNET/cnaas-nms.git
 # Branch specific, don't cache
 ARG GIT_COMMIT=unknown
-RUN echo $GIT_COMMIT
+RUN echo "$GIT_COMMIT"
 # Cnaas setup script
 RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 # Freeze source

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -71,11 +71,10 @@ RUN mkdir /tmp/devicecerts \
 
 ARG BUILDBRANCH=develop
 ARG GITREPO_BASE=https://github.com/SUNET/cnaas-nms.git
-# Branch specific, don't cache
+# Branch specific, don't cache and run cnaas setup script
 ARG GIT_COMMIT=unknown
-RUN echo "$GIT_COMMIT"
-# Cnaas setup script
-RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
+RUN echo "$GIT_COMMIT" \ 
+    &&  /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 # Freeze source
 USER root
 RUN chown -R root:www-data /opt/cnaas/venv/cnaas-nms/ && chmod -R u=rwX,g=rX,o= /opt/cnaas/venv/cnaas-nms/

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -72,7 +72,8 @@ RUN mkdir /tmp/devicecerts \
 ARG BUILDBRANCH=develop
 ARG GITREPO_BASE=https://github.com/SUNET/cnaas-nms.git
 # Branch specific, don't cache
-ADD "https://api.github.com/repos/SUNET/cnaas-nms/git/refs/heads/" latest_commit
+ARG GIT_COMMIT=unknown
+RUN echo $GIT_COMMIT
 # Cnaas setup script
 RUN /opt/cnaas/cnaas-setup.sh ${GITREPO_BASE} ${BUILDBRANCH}
 # Freeze source

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -13,7 +13,7 @@ In each of these directories there needs to be a file called "mapping.yml", this
 what template files should be used for each device type. For example, in mapping.yml there
 might be a definition of templates for an access switch specified like this:
 
-::
+.. code-block:: yaml
 
     ACCESS:
         entrypoint: access.j2
@@ -144,12 +144,15 @@ configure settings per group. Secondary groups can be used to assign VXLAN
 memberships, select devices for synchronization or firmware upgrade etc.
 
 groups.yml contains a dictionary named "groups", that contains a list of groups.
-Each group is defined as a dictionary with a single key named "group",
-and that key contains a dictionary with two keys:
+Each group is defined as a dictionary with the following keys:
 
-- name: A string representing a name. No spaces.
-- regex: A Python style regex that matches on device hostnames.
-- group_priority: Optional integer value 0-100. Specifies which group should
+- name: A unique string representing a name. No spaces.
+- device_filter: A dictionary of match conditions on the following fields: hostname, device_type, model, os_version and platform.
+  If multiple match criteria are set all must match for a device to be included in the group.
+  This field cannot be used together with devices list.
+- devices: A list of device hostnames for direct matching.
+  This field cannot be used together with device_filter.
+- group_priority: Optional unique integer value 0-100. Specifies which group should
   have the highest priority when determining the primary group for a device.
   Higher value means higher priority. Defaults to 0, value of 1 is reserved
   for builtin group DEFAULT.
@@ -161,33 +164,73 @@ and that key contains a dictionary with two keys:
 There will always exist a group called DEFAULT with group_priority 1 even
 if it's not specified in groups.yml.
 
-All devices that matches the regex will be included in the group.
+Migrate to new group format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To migrate to the new group-format you can run the following command.
+Prerequisites: install `yq <https://github.com/mikefarah/yq>`_.
 
-::
+.. code-block:: bash
 
-   ---
-   groups:
-     - group:
-         name: 'ALL'
-         regex: '.*'
-     - group:
-         name: 'BORDER_DIST'
-         regex: '(south-dist0[1-2]|north-dist0[1-2])'
-     - group:
-         name: 'DIST_EVEN'
-         regex: '.*-dist[0-9][02468]'
-     - group:
-         name: 'DIST_ODD'
-         regex: '.*-dist[0-9][13579]'
-     - group:
-         name: 'E1'
-         regex: 'eosdist1$'
-         group_priority: 100
-         templates_branch: "new_dist_features"
-     - group:
-         name: 'E'
-         regex: 'eosdist.*'
-         group_priority: 99
+  # cd to your settings-repo
+  # view what changes the command will do
+  yq '.groups |= map(
+    .group | {
+      "name": .name,
+      "device_filter":
+        {"hostname": .regex},
+      "group_priority": .group_priority,
+      "templates_branch": .templates_branch
+    } | with_entries(select(.value != null))
+  )' global/groups.yml
+
+  # modify file inplace
+  yq -i '.groups |= map(
+    .group | {
+      "name": .name,
+      "device_filter":
+        {"hostname": .regex},
+      "group_priority": .group_priority,
+      "templates_branch": .templates_branch
+    } | with_entries(select(.value != null))
+  )' global/groups.yml
+
+Group examples
+^^^^^^^^^^^^^^
+.. code-block:: yaml
+
+  ---
+  groups:
+    - name: 'ALL'
+      device_filter:
+        hostname: '.*'
+    - name: 'BORDER_DIST'
+      devices:
+        - south-dist01
+        - south-dist02
+        - north-dist01
+        - north-dist02
+    - name: 'DIST_EVEN'
+      device_filter:
+        hostname: '[0-9][02468]'
+        device_type: 'DIST'
+    - name: 'DIST_ODD'
+      device_filter:
+        hostname: '[0-9][13579]'
+        device_type: 'DIST'
+    - name: 'ACCESS_EOS_POE'
+      device_filter:
+        model: '.*DP.*'
+        platform: 'eos'
+        device_type: 'ACCESS'
+    - name: 'E1'
+      device_filter:
+        hostname: 'eosdist1$'
+      group_priority: 100
+      templates_branch: "new_dist_features"
+    - name: 'E'
+      device_filter:
+        hostname: 'eosdist.*'
+      group_priority: 99
 
 
 routing.yml:
@@ -307,7 +350,7 @@ Can contain the following dictionaries with specified keys:
 
 routing.yml examples:
 
-::
+.. code-block:: yaml
 
    ---
    extroute_bgp:
@@ -550,7 +593,7 @@ Contains base system settings like:
 
 Example of base_system.yml:
 
-::
+.. code-block:: yaml
 
    ---
    ntp_servers:

--- a/src/cnaas_nms/api/groups.py
+++ b/src/cnaas_nms/api/groups.py
@@ -31,9 +31,9 @@ def groups_settings_populate(group_name: Optional[str] = None) -> dict:
     settings, _ = get_group_settings()
 
     if group_name:
-        group_list = [group for group in settings["groups"] if group["name"] == group_name]
+        group_list = [group for group in settings.groups if group.name == group_name]
     else:
-        group_list = settings["groups"]
+        group_list = settings.groups
 
     ret = {}
     for group in group_list:

--- a/src/cnaas_nms/api/groups.py
+++ b/src/cnaas_nms/api/groups.py
@@ -1,4 +1,3 @@
-import re
 from typing import List, Optional
 
 from flask_restx import Namespace, Resource
@@ -6,7 +5,7 @@ from flask_restx import Namespace, Resource
 from cnaas_nms.api.generic import empty_result
 from cnaas_nms.db.device import Device, DeviceState
 from cnaas_nms.db.session import sqla_session
-from cnaas_nms.db.settings import get_group_regex, get_group_settings, get_groups
+from cnaas_nms.db.settings import get_group, get_group_settings, get_groups
 from cnaas_nms.tools.security import login_required
 from cnaas_nms.version import __api_version__
 
@@ -21,7 +20,7 @@ def groups_populate(group_name: Optional[str] = None) -> dict:
     with sqla_session() as session:  # type: ignore
         devices: List[Device] = session.query(Device).all()
         for dev in devices:
-            groups = get_groups(dev.hostname)
+            groups = get_groups(dev)
             for group in groups:
                 if group in tmpgroups:
                     tmpgroups[group].append(dev.hostname)
@@ -32,24 +31,23 @@ def groups_settings_populate(group_name: Optional[str] = None) -> dict:
     settings, _ = get_group_settings()
 
     if group_name:
-        group_list = [item["group"] for item in settings["groups"] if item["group"]["name"] == group_name]
+        group_list = [group for group in settings["groups"] if group["name"] == group_name]
     else:
-        group_list = [item["group"] for item in settings["groups"]]
+        group_list = settings["groups"]
 
     ret = {}
-    for item in group_list:
-        name = item.pop("name")
-        ret[name] = item
+    for group in group_list:
+        name = group.pop("name")
+        ret[name] = group
 
     return ret
 
 
 def groups_osversion_populate(group_name: str):
     os_versions: dict = {}
-    group_regex = get_group_regex(group_name)
-    if group_regex:
-        group_regex_p = re.compile(group_regex)
-    else:
+
+    group = get_group(group_name)
+    if not group:
         raise ValueError("Could not find group {}".format(group_name))
 
     with sqla_session() as session:  # type: ignore
@@ -59,7 +57,7 @@ def groups_osversion_populate(group_name: str):
         for dev in devices:
             if not dev.os_version:
                 continue
-            if re.match(group_regex_p, dev.hostname):
+            if group.matches(dev):
                 if dev.os_version in os_versions:
                     os_versions[dev.os_version].append(dev.hostname)
                 else:

--- a/src/cnaas_nms/api/groups.py
+++ b/src/cnaas_nms/api/groups.py
@@ -37,8 +37,8 @@ def groups_settings_populate(group_name: Optional[str] = None) -> dict:
 
     ret = {}
     for group in group_list:
-        name = group.pop("name")
-        ret[name] = group
+        ret[group.name] = group.model_dump()
+        del ret[group.name]["name"]
 
     return ret
 

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -140,7 +140,7 @@ class InterfaceApi(Resource):
                         # TODO: maybe this validation should be done via
                         #  pydantic if it gets more complex
                         if not device_settings:
-                            device_settings, _ = get_settings(hostname, dev.device_type)
+                            device_settings, _ = get_settings(dev, dev.device_type)
                         if "vxlan" in if_dict["data"]:
                             if if_dict["data"]["vxlan"] in device_settings["vxlans"]:
                                 intfdata["vxlan"] = if_dict["data"]["vxlan"]

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -49,7 +49,7 @@ class SettingsApi(Resource):
                 return empty_result("error", "Invalid device type specified"), 400
 
         try:
-            settings, settings_origin = get_settings(hostname, device_type, model)
+            settings, settings_origin = get_settings(dev, device_type, model)
         except Exception as e:
             return empty_result("error", "Error getting settings: {}".format(str(e))), 400
 

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -40,6 +40,7 @@ class SettingsApi(Resource):
                 if dev:
                     device_type = dev.device_type
                     model = dev.model
+                    session.expunge(dev)
                 else:
                     return empty_result("error", "Hostname not found in database"), 400
         if "device_type" in args:

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -176,6 +176,19 @@ def test_repository_get(client):
     assert re.match(r"[Cc]ommit", result.json["data"])
 
 
+def test_settings_hostname(client):
+    """
+    Test getting settings with query parameter
+    """
+    result = client.get("/api/v1.0/settings?hostname=eosaccess")
+    assert result.status_code == 200
+    assert result.content_type == "application/json"
+
+    # Not found hostname
+    result = client.get("/api/v1.0/settings?hostname=notfoundaccess")
+    assert result.status_code == 400
+
+
 def test_sync_devices_invalid_input(client):
     # Test invalid hostname
     data = {"hostname": "...", "dry_run": True}
@@ -372,9 +385,9 @@ def test_generate_only_vars(client, testdata, templates_directory):
     result = client.get("/api/v1.0/device/{}/generate_config".format(testdata["interface_device"]))
     assert result.status_code == 200
     assert result.json["status"] == "success"
-    assert (
-        result.json["data"]["config"]["available_variables"]["hostname"] == testdata["interface_device"]
-    ), "hostname variable not found in generate_only variables"
+    assert result.json["data"]["config"]["available_variables"]["hostname"] == testdata["interface_device"], (
+        "hostname variable not found in generate_only variables"
+    )
 
 
 def test_linknet(client):

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -47,12 +47,3 @@ def test_settings_server(testclient: FlaskClient):
     assert result.status_code == 200
     assert result.content_type == "application/json"
     assert "api" in result.json
-
-def test_settings_hostname(testclient: FlaskClient):
-    result = testclient.get("/api/v1.0/settings?hostname=eosaccess")
-    assert result.status_code == 200
-    assert result.content_type == "application/json"
-
-    # Not found hostname
-    result = testclient.get("/api/v1.0/settings?hostname=notfoundaccess")
-    assert result.status_code == 400

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -47,3 +47,12 @@ def test_settings_server(testclient: FlaskClient):
     assert result.status_code == 200
     assert result.content_type == "application/json"
     assert "api" in result.json
+
+def test_settings_hostname(testclient: FlaskClient):
+    result = testclient.get("/api/v1.0/settings?hostname=eosaccess")
+    assert result.status_code == 200
+    assert result.content_type == "application/json"
+
+    # Not found hostname
+    result = testclient.get("/api/v1.0/settings?hostname=notfoundaccess")
+    assert result.status_code == 400

--- a/src/cnaas_nms/db/data/default_groups.yml
+++ b/src/cnaas_nms/db/data/default_groups.yml
@@ -1,6 +1,6 @@
 ---
 groups:
-  - group:
-      name: 'DEFAULT'
-      regex: '.*'
-      group_priority: 1
+  - name: 'DEFAULT'
+    device_filter:
+      hostname: '.*'
+    group_priority: 1

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -202,7 +202,7 @@ def get_peer_with_mirror_interfaces(session, dev: Device) -> Optional[Device]:
         logger.exception("Error while finding peer device for mirrored interfaces")
         return None
 
-    peer_settings, _ = get_settings(peer_device.hostname, peer_device.device_type, peer_device.model)
+    peer_settings, _ = get_settings(peer_device, peer_device.device_type, peer_device.model)
 
     try:
         for intf in expand_interface_settings(peer_settings["interfaces"]):

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -313,7 +313,7 @@ def check_settings_collisions(unique_vlans: bool = True):
                 mgmt_vlans.add(mgmtdom.vlan)
         managed_devices: List[Device] = session.query(Device).filter(Device.state == DeviceState.MANAGED).all()
         for dev in managed_devices:
-            dev_settings, _ = get_settings(dev.hostname, dev.device_type)
+            dev_settings, _ = get_settings(dev, dev.device_type)
             devices_dict[dev.hostname] = dev_settings
 
     logger.debug("Memory size of all device settings: {}".format(sizeof_fmt(json.dumps(devices_dict).__sizeof__())))
@@ -587,12 +587,10 @@ def get_downstream_dependencies(hostname: str, settings: dict) -> dict:
             return settings
         neighbor_devices = dev.get_neighbors(session)
         # Downstream device hostnames
-        ds_hostnames = []
         for neighbor_dev in neighbor_devices:
-            if neighbor_dev.device_type == DeviceType.ACCESS:
-                ds_hostnames.append(neighbor_dev.hostname)
-        for ds_hostname in ds_hostnames:
-            ds_settings, _ = get_settings(ds_hostname, DeviceType.ACCESS)
+            if neighbor_dev.device_type != DeviceType.ACCESS:
+                continue
+            ds_settings, _ = get_settings(neighbor_dev, DeviceType.ACCESS)
             for vxlan_name, vxlan_data in ds_settings["vxlans"].items():
                 if vxlan_name not in settings["vxlans"].keys():
                     settings["vxlans"][vxlan_name] = vxlan_data
@@ -835,16 +833,20 @@ def get_groups(device: Optional[Device] = None) -> List[str]:
     if settings.groups is None:
         return groups
     for group in settings.groups:
-        if device:
-            if not group.matches(device):
-                continue
+        if device and not group.matches(device):
+            continue
         groups.append(group.name)
     return groups
 
 
 def get_group(group_name: str) -> Optional[f_group]:
     """Returns the group object if it's found."""
-    return get_group_settings_asdict().get(group_name, {})
+    settings, _ = get_group_settings()
+    if not settings:
+        return None
+    if settings.groups is None:
+        return None
+    return next((group for group in settings.groups if group.name == group_name), None)
 
 
 def get_group_templates_branch(group_name: str) -> Optional[str]:
@@ -859,7 +861,7 @@ def get_group_settings_asdict() -> Dict[str, Dict[str, Any]]:
     settings, _ = get_group_settings()
     if not settings:
         return {}
-    if not settings.get("groups"):
+    if not settings.groups:
         return {}
     group_dict: Dict[str, Dict[str, Any]] = {}
     for group in settings.groups:

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -801,7 +801,7 @@ def get_settings(
 
 
 @redis_lru_cache
-def get_group_settings() -> Tuple[dict, dict]:
+def get_group_settings() -> Tuple[f_groups, dict]:
     logger = get_logger()
     settings: dict = {}
     settings_origin: dict = {}
@@ -822,7 +822,7 @@ def get_group_settings() -> Tuple[dict, dict]:
     )
     settings["groups"] += default_settings["groups"]
     check_settings_syntax(settings, settings_origin)
-    return f_groups(**settings).model_dump(), settings_origin
+    return f_groups(**settings), settings_origin
 
 
 @redis_lru_cache
@@ -832,16 +832,13 @@ def get_groups(device: Optional[Device] = None) -> List[str]:
     settings, origin = get_group_settings()
     if not settings:
         return groups
-    if not settings.get("groups", None):
+    if settings.groups is None:
         return groups
-    for group in settings["groups"]:
-        # Group must always have a name
-        if "name" not in group:
-            continue
+    for group in settings.groups:
         if device:
             if not group.matches(device):
                 continue
-        groups.append(group["name"])
+        groups.append(group.name)
     return groups
 
 
@@ -865,15 +862,13 @@ def get_group_settings_asdict() -> Dict[str, Dict[str, Any]]:
     if not settings.get("groups"):
         return {}
     group_dict: Dict[str, Dict[str, Any]] = {}
-    for group in settings["groups"]:
-        if "name" not in group:
-            continue
-        group_dict[group["name"]] = group
-        del group_dict[group["name"]]["name"]
+    for group in settings.groups:
+        group_dict[group.name] = group.model_dump()
+        del group_dict[group.name]["name"]
     return group_dict
 
 
-def get_groups_priorities(device: Optional[Device] = None, settings: Optional[dict] = None) -> Dict[str, int]:
+def get_groups_priorities(device: Optional[Device] = None, settings: Optional[f_groups] = None) -> Dict[str, int]:
     """Return dicts with {name: priority} for groups"""
     groups_priorities: dict[str, Any] = {}
 
@@ -881,23 +876,22 @@ def get_groups_priorities(device: Optional[Device] = None, settings: Optional[di
         settings, _ = get_group_settings()
     if not settings:
         return groups_priorities
-    if not settings.get("groups", None):
+    if settings.groups is None:
         return groups_priorities
-    for group in settings["groups"]:
-        # Group must always have a name
-        if "name" not in group:
-            continue
-        if "group_priority" not in group or group["group_priority"] == 0:
+    for group in settings.groups:
+        if not group.group_priority or group.group_priority == 0:
             continue
         if device:
             if not group.matches(device):
                 continue
-        groups_priorities[group["name"]] = group["group_priority"]
+        groups_priorities[group.name] = group.group_priority
 
     return groups_priorities
 
 
-def get_groups_priorities_sorted(device: Optional[Device] = None, settings: Optional[dict] = None) -> Dict[str, int]:
+def get_groups_priorities_sorted(
+    device: Optional[Device] = None, settings: Optional[f_groups] = None
+) -> Dict[str, int]:
     return {
         k: v
         for k, v in sorted(

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -15,7 +15,7 @@ from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.git_worktrees import refresh_templates_worktree
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.db.session import redis_session, sqla_session
-from cnaas_nms.db.settings_fields import f_groups
+from cnaas_nms.db.settings_fields import f_group, f_groups
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.tools.mergedict import merge_dict_origin
 
@@ -319,7 +319,6 @@ def check_settings_collisions(unique_vlans: bool = True):
     logger.debug("Memory size of all device settings: {}".format(sizeof_fmt(json.dumps(devices_dict).__sizeof__())))
 
     check_vlan_collisions(devices_dict, mgmt_vlans, unique_vlans)
-    check_group_priority_collisions()
     check_routing_policies(devices_dict)
 
 
@@ -445,31 +444,6 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], u
                 device_vlan_names[hostname].add(vxlan_data["vlan_name"])
             else:
                 device_vlan_names[hostname] = {vxlan_data["vlan_name"]}
-
-
-def check_group_priority_collisions(settings: Optional[dict] = None):
-    priorities: Dict[int, str] = {}
-    if not settings:
-        settings, _ = get_group_settings()
-    if not settings:
-        return
-    if not settings.get("groups", None):
-        return
-    for group in settings["groups"]:
-        if "name" not in group["group"]:
-            continue
-        if "group_priority" not in group["group"] or group["group"]["group_priority"] == 0:
-            continue
-        if group["group"]["group_priority"] in priorities.keys():
-            raise ValueError(
-                "Groups must have unique group_priority values, "
-                "but group {} and {} both have priority {}".format(
-                    priorities[group["group"]["group_priority"]],
-                    group["group"]["name"],
-                    group["group"]["group_priority"],
-                )
-            )
-        priorities[group["group"]["group_priority"]] = group["group"]["name"]
 
 
 @redis_lru_cache
@@ -627,7 +601,7 @@ def get_downstream_dependencies(hostname: str, settings: dict) -> dict:
 
 @redis_lru_cache
 def get_settings(
-    hostname: Optional[str] = None,
+    device: Optional[Device] = None,
     device_type: Optional[DeviceType] = None,
     device_model: Optional[str] = None,
 ) -> Tuple[dict, dict]:
@@ -653,9 +627,9 @@ def get_settings(
         settings_origin[k] = "default"
 
     # 2. Get settings repo global settings
-    if hostname:
+    if device:
         # Some settings parsing require knowledge of group memberships
-        groups = get_groups(hostname)
+        groups = get_groups(device)
         settings, settings_origin = read_settings(
             local_repo_path,
             ["global", "base_system.yml"],
@@ -686,10 +660,10 @@ def get_settings(
     if device_type:
         get_type = "devicetype {}".format(device_type.name)
         if device_type == DeviceType.UNKNOWN:
-            if hostname is None:
+            if device is None:
                 raise ValueError("It's not possible to get settings for devices with type UNKNOWN")
             else:
-                logger.warning("Device type is UNKNOWN, trying to get settings for hostname {}".format(hostname))
+                logger.warning("Device type is UNKNOWN, trying to get settings for hostname {}".format(device.hostname))
         else:
             settings, settings_origin = read_settings(
                 local_repo_path,
@@ -698,8 +672,8 @@ def get_settings(
                 settings,
                 settings_origin,
             )
-    if hostname:
-        get_type = "hostname {}".format(hostname)
+    if device:
+        get_type = "hostname {}".format(device.hostname)
         settings, settings_origin = read_settings(
             local_repo_path,
             ["global", "routing.yml"],
@@ -715,11 +689,11 @@ def get_settings(
             settings,
             settings_origin,
             groups,
-            hostname,
+            device.hostname,
         )
-        settings = get_downstream_dependencies(hostname, settings)
+        settings = get_downstream_dependencies(device.hostname, settings)
         # 5. Get settings repo group specific settings
-        primary_group = get_device_primary_groups().get(hostname)
+        primary_group = get_device_primary_groups().get(device.hostname)
         if primary_group:
             # add templates worktree
             templates_branch = get_group_templates_branch(primary_group)
@@ -748,25 +722,25 @@ def get_settings(
                     settings_origin,
                 )
         # 6. Get settings repo device specific settings
-        if os.path.isdir(os.path.join(local_repo_path, "devices", hostname)):
+        if os.path.isdir(os.path.join(local_repo_path, "devices", device.hostname)):
             settings, settings_origin = read_settings(
                 local_repo_path,
-                ["devices", hostname, "base_system.yml"],
-                "device->{}->base_system.yml".format(hostname),
+                ["devices", device.hostname, "base_system.yml"],
+                "device->{}->base_system.yml".format(device.hostname),
                 settings,
                 settings_origin,
             )
             settings, settings_origin = read_settings(
                 local_repo_path,
-                ["devices", hostname, "interfaces.yml"],
-                "device->{}->interfaces.yml".format(hostname),
+                ["devices", device.hostname, "interfaces.yml"],
+                "device->{}->interfaces.yml".format(device.hostname),
                 settings,
                 settings_origin,
             )
             settings, settings_origin = read_settings(
                 local_repo_path,
-                ["devices", hostname, "routing.yml"],
-                "device->{}->routing.yml".format(hostname),
+                ["devices", device.hostname, "routing.yml"],
+                "device->{}->routing.yml".format(device.hostname),
                 settings,
                 settings_origin,
                 groups,
@@ -813,7 +787,6 @@ def get_settings(
             settings,
             settings_origin,
             groups,
-            hostname,
         )
     # Verify syntax
     verified_settings = check_settings_syntax(settings, settings_origin)
@@ -853,7 +826,7 @@ def get_group_settings() -> Tuple[dict, dict]:
 
 
 @redis_lru_cache
-def get_groups(hostname: Optional[str] = None) -> List[str]:
+def get_groups(device: Optional[Device] = None) -> List[str]:
     """Return list of names for valid groups."""
     groups: list[str] = []
     settings, origin = get_group_settings()
@@ -862,22 +835,19 @@ def get_groups(hostname: Optional[str] = None) -> List[str]:
     if not settings.get("groups", None):
         return groups
     for group in settings["groups"]:
-        if "name" not in group["group"]:
+        # Group must always have a name
+        if "name" not in group:
             continue
-        if hostname:
-            if "regex" not in group["group"]:
+        if device:
+            if not group.matches(device):
                 continue
-            # TODO: try and catch, report what regex failed
-            if not re.match(group["group"]["regex"], hostname):
-                continue
-        groups.append(group["group"]["name"])
+        groups.append(group["name"])
     return groups
 
 
-def get_group_regex(group_name: str) -> Optional[str]:
-    """Returns a string containing the regex defining the specified
-    group name if it's found."""
-    return get_group_settings_asdict().get(group_name, {}).get("regex")
+def get_group(group_name: str) -> Optional[f_group]:
+    """Returns the group object if it's found."""
+    return get_group_settings_asdict().get(group_name, {})
 
 
 def get_group_templates_branch(group_name: str) -> Optional[str]:
@@ -896,14 +866,14 @@ def get_group_settings_asdict() -> Dict[str, Dict[str, Any]]:
         return {}
     group_dict: Dict[str, Dict[str, Any]] = {}
     for group in settings["groups"]:
-        if "name" not in group["group"]:
+        if "name" not in group:
             continue
-        group_dict[group["group"]["name"]] = group["group"]
-        del group_dict[group["group"]["name"]]["name"]
+        group_dict[group["name"]] = group
+        del group_dict[group["name"]]["name"]
     return group_dict
 
 
-def get_groups_priorities(hostname: Optional[str] = None, settings: Optional[dict] = None) -> Dict[str, int]:
+def get_groups_priorities(device: Optional[Device] = None, settings: Optional[dict] = None) -> Dict[str, int]:
     """Return dicts with {name: priority} for groups"""
     groups_priorities: dict[str, Any] = {}
 
@@ -914,25 +884,24 @@ def get_groups_priorities(hostname: Optional[str] = None, settings: Optional[dic
     if not settings.get("groups", None):
         return groups_priorities
     for group in settings["groups"]:
-        if "name" not in group["group"]:
+        # Group must always have a name
+        if "name" not in group:
             continue
-        if "group_priority" not in group["group"] or group["group"]["group_priority"] == 0:
+        if "group_priority" not in group or group["group_priority"] == 0:
             continue
-        if hostname:
-            if "regex" not in group["group"]:
+        if device:
+            if not group.matches(device):
                 continue
-            # TODO: try and catch, report what regex failed
-            if not re.match(group["group"]["regex"], hostname):
-                continue
-        groups_priorities[group["group"]["name"]] = group["group"]["group_priority"]
+        groups_priorities[group["name"]] = group["group_priority"]
+
     return groups_priorities
 
 
-def get_groups_priorities_sorted(hostname: Optional[str] = None, settings: Optional[dict] = None) -> Dict[str, int]:
+def get_groups_priorities_sorted(device: Optional[Device] = None, settings: Optional[dict] = None) -> Dict[str, int]:
     return {
         k: v
         for k, v in sorted(
-            get_groups_priorities(hostname, settings).items(),
+            get_groups_priorities(device, settings).items(),
             key=lambda item: item[1],  # sort on value(priority)
             reverse=True,
         )
@@ -954,7 +923,7 @@ def parse_device_primary_groups() -> Dict[str, str]:
     with sqla_session() as session:  # type: ignore
         devices: List[Device] = session.query(Device).all()
         for dev in devices:
-            groups = get_groups(dev.hostname)
+            groups = get_groups(dev)
             primary_group: str = find_primary_group(groups, groups_priorities_sorted)
             device_primary_group[dev.hostname] = primary_group
     return device_primary_group
@@ -1034,11 +1003,11 @@ def rebuild_settings_cache() -> None:
             if dev is None or dev.device_type == DeviceType.UNKNOWN:
                 logger.warning(f"Device {hostname} specified in settings/devices but it was not found in database")
                 continue
-            get_settings(hostname, dev.device_type)
+            get_settings(dev, dev.device_type)
     logger.debug("Rebuilding settings cache for device models")
     for devtype_str, device_models in get_model_specific_configfiles(True).items():
         devtype = DeviceType[devtype_str]
         for device_model in device_models:
-            get_settings("nonexisting", devtype, device_model)
+            get_settings(None, devtype, device_model)
     logger.debug("Rechecking settings collisions")
     check_settings_collisions(api_settings.GLOBAL_UNIQUE_VLANS)

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -883,9 +883,8 @@ def get_groups_priorities(device: Optional[Device] = None, settings: Optional[f_
     for group in settings.groups:
         if not group.group_priority or group.group_priority == 0:
             continue
-        if device:
-            if not group.matches(device):
-                continue
+        if device and not group.matches(device):
+            continue
         groups_priorities[group.name] = group.group_priority
 
     return groups_priorities

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -482,7 +482,6 @@ class f_group_device_filter(BaseModel):
         Is a cached property to avoid re-compiling regex patterns
         """
         fields = set(self.__annotations__.keys())
-        # Compile all field regex into a single regex pattern with AND logic
         compiled_patterns = {}
         for field in fields:
             pattern = getattr(self, field, None)
@@ -495,9 +494,9 @@ class f_group_device_filter(BaseModel):
         A function that matches a device based on the regex patterns.
         """
         compiled_patterns = self.compiled_patterns
-        # No patterns defined, match everything
+        # No patterns defined, match nothing
         if not compiled_patterns:
-            True
+            return False
 
         for field, pattern in compiled_patterns.items():
             value = getattr(device, field, None)

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -1,9 +1,20 @@
-from enum import StrEnum, auto
+import re
+import warnings
+from enum import Enum, StrEnum, auto
+from functools import cached_property
 from ipaddress import AddressValueError, IPv4Interface
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Self, Union
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 from pydantic.functional_validators import AfterValidator
+
+from cnaas_nms.db.device import Device
 
 # HOSTNAME_REGEX = r'([a-z0-9-]{1,63}\.?)+'
 IPV4_REGEX = r"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}" r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
@@ -447,11 +458,82 @@ class f_root(BaseModel):
     upgrade_post_waittime: Dict[str, int] = {"default": 600}
 
 
-class f_group_item(BaseModel):
+class f_group_device_filter(BaseModel):
+    hostname: Optional[str] = None
+    device_type: Optional[str] = None
+    model: Optional[str] = None
+    os_version: Optional[str] = None
+    platform: Optional[str] = None
+
+    @field_validator("hostname", "device_type", "model", "os_version", "platform")
+    @classmethod
+    def validate_regex(cls, v):
+        """Validate that the value is a valid regex pattern."""
+        try:
+            # Try compiling regex
+            re.compile(v)
+        except re.error as exc:
+            raise ValueError(f"Invalid regex pattern: {v}") from exc
+        return v
+
+    @cached_property
+    def compiled_patterns(self) -> Dict[str, re.Pattern]:
+        """
+        Is a cached property to avoid re-compiling regex patterns
+        """
+        fields = set(self.__annotations__.keys())
+        # Compile all field regex into a single regex pattern with AND logic
+        compiled_patterns = {}
+        for field in fields:
+            pattern = getattr(self, field, None)
+            if pattern:
+                compiled_patterns.update({field: re.compile(pattern)})
+        return compiled_patterns
+
+    def matches(self, device: Device) -> bool:
+        """
+        A function that matches a device based on the regex patterns.
+        """
+        compiled_patterns = self.compiled_patterns
+        # No patterns defined, match everything
+        if not compiled_patterns:
+            True
+
+        for field, pattern in compiled_patterns.items():
+            value = getattr(device, field, None)
+            if value is None:
+                return False
+            if isinstance(value, Enum):
+                match_value = value.name
+            else:
+                match_value = value
+            if match_value is None:
+                return False  # field missing → no match
+            if not pattern.match(str(match_value)):  # convert to str to be safe
+                return False  # pattern did not match
+        return True  # all matched
+
+
+class f_group(BaseModel):
     name: str = group_name
-    regex: str = ""
+    device_filter: Optional[f_group_device_filter] = None
+    devices: Optional[List[str]] = None
     group_priority: int = group_priority_schema
     templates_branch: Optional[str] = None
+
+    def __init__(self, **data):
+        if "group" in data:
+            warnings.warn(
+                "Old group config style is deprecated and will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            legacy_data = data.pop("group")
+            # Convert legacy group data to new format
+            data["hostname"] = legacy_data.pop("regex")
+            data["group_priority"] = data.pop("group_priority")
+            data["templates_branch"] = data.pop("templates_branch")
+        super().__init__(**data)
 
     @field_validator("group_priority")
     @classmethod
@@ -467,10 +549,49 @@ class f_group_item(BaseModel):
             raise ValueError("templates_branch can only be specified on primary groups")
         return v
 
+    @model_validator(mode="after")
+    def cannot_use_device_filter_with_devices(self: Self) -> Self:
+        device_filter = self.device_filter
+        devices = self.devices
+        if device_filter and devices:
+            raise ValueError("cannot use device_filter together with devices")
 
-class f_group(BaseModel):
-    group: Optional[f_group_item] = None
+        return self
+
+    def matches(self, device: Device) -> bool:
+        """A function to check if a device matches the group filters."""
+        if self.device_filter is not None:
+            # Use the device filter matcher to check if the device matches
+            return self.device_filter.matches(device)
+        elif self.devices is not None:
+            # If no device filter is defined, check if the device is in the devices list
+            return device.hostname in self.devices
+        return False
+
+
+def validate_groups(groups: List[f_group]):
+    """
+    Validate that the provided list of groups have unique names and group priorities.
+    """
+
+    # Validate uniqueness of group names and group priorities
+    unique_fields = ["name", "group_priority"]
+    for unique_field in unique_fields:
+        seen = set()
+        for group in groups:
+            value = getattr(group, unique_field)
+            # Skip validation for group_priority if it's 0
+            if unique_field == "group_priority" and value == 0:
+                continue
+            if value in seen:
+                raise ValueError(
+                    f"Groups must have unique {unique_field} values, "
+                    f"but group {group} has a duplicate {unique_field} value as another group."
+                )
+            seen.add(value)
+
+    return groups
 
 
 class f_groups(BaseModel):
-    groups: Optional[List[f_group]] = None
+    groups: Annotated[Optional[List[f_group]], Field(default_factory=list), AfterValidator(validate_groups)] = None

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -529,9 +529,12 @@ class f_group(BaseModel):
             )
             legacy_data = data.pop("group")
             # Convert legacy group data to new format
-            data["hostname"] = legacy_data.pop("regex")
-            data["group_priority"] = data.pop("group_priority")
-            data["templates_branch"] = data.pop("templates_branch")
+            data["name"] = legacy_data.pop("name")
+            regex = legacy_data.pop("regex")
+            if regex:
+                data["device_filter"] = {"hostname": regex}
+            data["group_priority"] = legacy_data.pop("group_priority", 0)
+            data["templates_branch"] = legacy_data.pop("templates_branch", None)
         super().__init__(**data)
 
     @field_validator("group_priority")

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -501,13 +501,11 @@ class f_group_device_filter(BaseModel):
         for field, pattern in compiled_patterns.items():
             value = getattr(device, field, None)
             if value is None:
-                return False
+                return False  # field missing → no match
             if isinstance(value, Enum):
                 match_value = value.name
             else:
                 match_value = value
-            if match_value is None:
-                return False  # field missing → no match
             if not pattern.match(str(match_value)):  # convert to str to be safe
                 return False  # pattern did not match
         return True  # all matched
@@ -596,4 +594,4 @@ def validate_groups(groups: List[f_group]):
 
 
 class f_groups(BaseModel):
-    groups: Annotated[Optional[List[f_group]], Field(default_factory=list), AfterValidator(validate_groups)] = None
+    groups: Annotated[Optional[List[f_group]], AfterValidator(validate_groups)] = None

--- a/src/cnaas_nms/db/tests/test_groups.py
+++ b/src/cnaas_nms/db/tests/test_groups.py
@@ -13,6 +13,12 @@ class GroupsTest(unittest.TestCase):
         self.eosdist_device = Device(hostname="dist1", platform="eos", device_type=DeviceType.DIST)
         self.iosdist_device = Device(hostname="dist2", platform="ios", device_type=DeviceType.DIST)
 
+    def test_groups_deprecated(self):
+        # Test that the old group format is converted to the new format
+        old_group = f_group(**{"group": {"name": "GROUP", "regex": ".*"}}).model_dump_json()
+        new_group = f_group(name="GROUP", device_filter={"hostname": ".*"}).model_dump_json()
+        self.assertEqual(old_group, new_group)
+
     def test_groups(self):
         # error when device_filter and devices are both set
         with self.assertRaises(ValueError):

--- a/src/cnaas_nms/db/tests/test_groups.py
+++ b/src/cnaas_nms/db/tests/test_groups.py
@@ -1,14 +1,73 @@
 #!/usr/bin/env python3
 
-import os
 import unittest
 
-import pkg_resources
-import yaml
+from cnaas_nms.db.device import Device, DeviceType
+from cnaas_nms.db.settings_fields import f_group
 
 
 class GroupsTest(unittest.TestCase):
     def setUp(self):
-        data_dir = pkg_resources.resource_filename(__name__, "data")
-        with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+        self.group1 = f_group(name="ACCESS_REGEX_HOSTNAME", device_filter={"hostname": "^.*access.*$"})
+        self.group2 = f_group(name="ACCESS_ENUM_TYPE", device_filter={"device_type": "ACCESS"})
+        self.group3 = f_group(name="ACCESS_DIST_REGEX_TYPE", device_filter={"device_type": "ACCESS|DIST|CORE"})
+        self.group4 = f_group(name="EOS_ACCESS", device_filter={"device_type": "ACCESS", "platform": "eos"})
+        self.group5 = f_group(name="IOS_DIST", device_filter={"device_type": "DIST", "platform": "ios"})
+        self.group6 = f_group(name="ALL_DEVICES", devices=["access1", "access2", "dist1", "dist2"])
+
+        self.eosaccess_device = Device(hostname="access1", platform="eos", device_type=DeviceType.ACCESS)
+        self.iosaccess_device = Device(hostname="access2", platform="ios", device_type=DeviceType.ACCESS)
+        self.eosdist_device = Device(hostname="dist1", platform="eos", device_type=DeviceType.DIST)
+        self.iosdist_device = Device(hostname="dist2", platform="ios", device_type=DeviceType.DIST)
+
+    def test_groups(self):
+        # error when device_filter and devices are both set
+        with self.assertRaises(ValueError):
+            f_group(name="INVALID_GROUP", device_filter={"device_type": "ACCESS"}, devices=["access1"])
+
+    def test_groups_device_filter_hostname(self):
+        # Match on hostname
+        self.assertTrue(self.group1.matches(self.eosaccess_device))
+        self.assertFalse(self.group1.matches(self.eosdist_device))
+
+        self.assertTrue(self.group1.matches(self.iosaccess_device))
+        self.assertFalse(self.group1.matches(self.iosdist_device))
+
+    def test_groups_device_filter_device_type(self):
+        # Match on device type enum
+        self.assertTrue(self.group2.matches(self.eosaccess_device))
+        self.assertFalse(self.group2.matches(self.eosdist_device))
+
+        self.assertTrue(self.group2.matches(self.iosaccess_device))
+        self.assertFalse(self.group2.matches(self.iosdist_device))
+
+        # Match on device type regex
+        self.assertTrue(self.group3.matches(self.eosaccess_device))
+        self.assertTrue(self.group3.matches(self.eosdist_device))
+
+        self.assertTrue(self.group3.matches(self.iosaccess_device))
+        self.assertTrue(self.group3.matches(self.iosdist_device))
+
+    def test_groups_device_filter_platform(self):
+        # Match on platform eos + access
+        self.assertTrue(self.group4.matches(self.eosaccess_device))
+        self.assertFalse(self.group4.matches(self.iosaccess_device))
+        self.assertFalse(self.group4.matches(self.eosdist_device))
+        self.assertFalse(self.group4.matches(self.iosdist_device))
+        # Match on platform ios + dist
+        self.assertTrue(self.group5.matches(self.iosdist_device))
+        self.assertFalse(self.group5.matches(self.eosdist_device))
+        self.assertFalse(self.group5.matches(self.eosaccess_device))
+        self.assertFalse(self.group5.matches(self.iosaccess_device))
+
+    def test_groups_device_filter_devices(self):
+        # Match on device list
+        self.assertTrue(self.group6.matches(self.eosaccess_device))
+        self.assertTrue(self.group6.matches(self.iosaccess_device))
+        self.assertTrue(self.group6.matches(self.eosdist_device))
+        self.assertTrue(self.group6.matches(self.iosdist_device))
+
+        # Check that a device not in the group does not match
+        self.assertFalse(
+            self.group6.matches(Device(hostname="unknown", platform="unknown", device_type=DeviceType.ACCESS))
+        )

--- a/src/cnaas_nms/db/tests/test_groups.py
+++ b/src/cnaas_nms/db/tests/test_groups.py
@@ -24,6 +24,10 @@ class GroupsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f_group(name="INVALID_GROUP", device_filter={"device_type": "ACCESS"}, devices=["access1"])
 
+    def test_groups_empty_name(self):
+        with self.assertRaises(ValueError):
+            f_group(name=None)
+
     def test_groups_empty_device_filter(self):
         group = f_group(name="EMPTY_DEVICE_FILTER", device_filter={})
         # Match on empty device filter

--- a/src/cnaas_nms/db/tests/test_groups.py
+++ b/src/cnaas_nms/db/tests/test_groups.py
@@ -8,13 +8,6 @@ from cnaas_nms.db.settings_fields import f_group
 
 class GroupsTest(unittest.TestCase):
     def setUp(self):
-        self.group1 = f_group(name="ACCESS_REGEX_HOSTNAME", device_filter={"hostname": "^.*access.*$"})
-        self.group2 = f_group(name="ACCESS_ENUM_TYPE", device_filter={"device_type": "ACCESS"})
-        self.group3 = f_group(name="ACCESS_DIST_REGEX_TYPE", device_filter={"device_type": "ACCESS|DIST|CORE"})
-        self.group4 = f_group(name="EOS_ACCESS", device_filter={"device_type": "ACCESS", "platform": "eos"})
-        self.group5 = f_group(name="IOS_DIST", device_filter={"device_type": "DIST", "platform": "ios"})
-        self.group6 = f_group(name="ALL_DEVICES", devices=["access1", "access2", "dist1", "dist2"])
-
         self.eosaccess_device = Device(hostname="access1", platform="eos", device_type=DeviceType.ACCESS)
         self.iosaccess_device = Device(hostname="access2", platform="ios", device_type=DeviceType.ACCESS)
         self.eosdist_device = Device(hostname="dist1", platform="eos", device_type=DeviceType.DIST)
@@ -25,49 +18,69 @@ class GroupsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             f_group(name="INVALID_GROUP", device_filter={"device_type": "ACCESS"}, devices=["access1"])
 
-    def test_groups_device_filter_hostname(self):
-        # Match on hostname
-        self.assertTrue(self.group1.matches(self.eosaccess_device))
-        self.assertFalse(self.group1.matches(self.eosdist_device))
+    def test_groups_empty_device_filter(self):
+        group = f_group(name="EMPTY_DEVICE_FILTER", device_filter={})
+        # Match on empty device filter
+        self.assertFalse(group.matches(self.eosaccess_device))
+        self.assertFalse(group.matches(self.iosaccess_device))
+        self.assertFalse(group.matches(self.eosdist_device))
+        self.assertFalse(group.matches(self.iosdist_device))
 
-        self.assertTrue(self.group1.matches(self.iosaccess_device))
-        self.assertFalse(self.group1.matches(self.iosdist_device))
+    def test_groups_empty_devices(self):
+        group = f_group(name="EMPTY_DEVICES", devices=[])
+        # Match on empty device filter
+        self.assertFalse(group.matches(self.eosaccess_device))
+        self.assertFalse(group.matches(self.iosaccess_device))
+        self.assertFalse(group.matches(self.eosdist_device))
+        self.assertFalse(group.matches(self.iosdist_device))
+
+    def test_groups_device_filter_hostname(self):
+        group = f_group(name="ACCESS_REGEX_HOSTNAME", device_filter={"hostname": "^.*access.*$"})
+        # Match on hostname
+        self.assertTrue(group.matches(self.eosaccess_device))
+        self.assertFalse(group.matches(self.eosdist_device))
+
+        self.assertTrue(group.matches(self.iosaccess_device))
+        self.assertFalse(group.matches(self.iosdist_device))
 
     def test_groups_device_filter_device_type(self):
+        group1 = f_group(name="ACCESS_ENUM_TYPE", device_filter={"device_type": "ACCESS"})
+        group2 = f_group(name="ACCESS_DIST_REGEX_TYPE", device_filter={"device_type": "ACCESS|DIST|CORE"})
         # Match on device type enum
-        self.assertTrue(self.group2.matches(self.eosaccess_device))
-        self.assertFalse(self.group2.matches(self.eosdist_device))
+        self.assertTrue(group1.matches(self.eosaccess_device))
+        self.assertFalse(group1.matches(self.eosdist_device))
 
-        self.assertTrue(self.group2.matches(self.iosaccess_device))
-        self.assertFalse(self.group2.matches(self.iosdist_device))
+        self.assertTrue(group1.matches(self.iosaccess_device))
+        self.assertFalse(group1.matches(self.iosdist_device))
 
         # Match on device type regex
-        self.assertTrue(self.group3.matches(self.eosaccess_device))
-        self.assertTrue(self.group3.matches(self.eosdist_device))
+        self.assertTrue(group2.matches(self.eosaccess_device))
+        self.assertTrue(group2.matches(self.eosdist_device))
 
-        self.assertTrue(self.group3.matches(self.iosaccess_device))
-        self.assertTrue(self.group3.matches(self.iosdist_device))
+        self.assertTrue(group2.matches(self.iosaccess_device))
+        self.assertTrue(group2.matches(self.iosdist_device))
 
     def test_groups_device_filter_platform(self):
+        group1 = f_group(name="EOS_ACCESS", device_filter={"device_type": "ACCESS", "platform": "eos"})
+        group2 = f_group(name="IOS_DIST", device_filter={"device_type": "DIST", "platform": "ios"})
         # Match on platform eos + access
-        self.assertTrue(self.group4.matches(self.eosaccess_device))
-        self.assertFalse(self.group4.matches(self.iosaccess_device))
-        self.assertFalse(self.group4.matches(self.eosdist_device))
-        self.assertFalse(self.group4.matches(self.iosdist_device))
+        self.assertTrue(group1.matches(self.eosaccess_device))
+        self.assertFalse(group1.matches(self.iosaccess_device))
+        self.assertFalse(group1.matches(self.eosdist_device))
+        self.assertFalse(group1.matches(self.iosdist_device))
         # Match on platform ios + dist
-        self.assertTrue(self.group5.matches(self.iosdist_device))
-        self.assertFalse(self.group5.matches(self.eosdist_device))
-        self.assertFalse(self.group5.matches(self.eosaccess_device))
-        self.assertFalse(self.group5.matches(self.iosaccess_device))
+        self.assertTrue(group2.matches(self.iosdist_device))
+        self.assertFalse(group2.matches(self.eosdist_device))
+        self.assertFalse(group2.matches(self.eosaccess_device))
+        self.assertFalse(group2.matches(self.iosaccess_device))
 
     def test_groups_device_filter_devices(self):
+        group = f_group(name="ALL_DEVICES", devices=["access1", "access2", "dist1", "dist2"])
         # Match on device list
-        self.assertTrue(self.group6.matches(self.eosaccess_device))
-        self.assertTrue(self.group6.matches(self.iosaccess_device))
-        self.assertTrue(self.group6.matches(self.eosdist_device))
-        self.assertTrue(self.group6.matches(self.iosdist_device))
+        self.assertTrue(group.matches(self.eosaccess_device))
+        self.assertTrue(group.matches(self.iosaccess_device))
+        self.assertTrue(group.matches(self.eosdist_device))
+        self.assertTrue(group.matches(self.iosdist_device))
 
         # Check that a device not in the group does not match
-        self.assertFalse(
-            self.group6.matches(Device(hostname="unknown", platform="unknown", device_type=DeviceType.ACCESS))
-        )
+        self.assertFalse(group.matches(Device(hostname="unknown", platform="unknown", device_type=DeviceType.ACCESS)))

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -14,11 +14,12 @@ from cnaas_nms.db.settings import (
     check_bgp_neighbor_routemaps,
     check_vlan_collisions,
     get_device_primary_groups,
+    get_group_settings,
     get_groups_priorities_sorted,
     get_settings,
     verify_dir_structure,
 )
-from cnaas_nms.db.settings_fields import f_groups
+from cnaas_nms.db.settings_fields import f_group, f_groups
 
 
 class SettingsTests(unittest.TestCase):
@@ -47,7 +48,7 @@ class SettingsTests(unittest.TestCase):
 
     @pytest.mark.integration
     def test_get_settings_device(self):
-        settings, settings_origin = get_settings(device=Device(**self.testdata["testdevice"]), device_type=DeviceType.DIST)
+        settings, settings_origin = get_settings(device=Device(hostname=self.testdata["testdevice"]), device_type=DeviceType.DIST)
         # Assert that all required settings are set
         self.assertTrue(all(k in settings for k in self.required_setting_keys))
 
@@ -194,7 +195,7 @@ class SettingsTests(unittest.TestCase):
                 {"name": "NONE", "group_priority": 0},
             ]
         }
-        result = get_groups_priorities_sorted(settings=group_settings_dict)
+        result = get_groups_priorities_sorted(settings=f_groups(**group_settings_dict))
         # Groups with priority 0 is not evaluated in selecting primary group
         self.assertEqual(list(result.keys()), ["HIGH", "DEFAULT"], "Unexpected ordering of groups sorted by priority")
         self.assertNotEqual(
@@ -275,6 +276,11 @@ class SettingsTests(unittest.TestCase):
         del group_settings_dict["groups"][2]
         f_groups(**group_settings_dict).model_dump()
 
+    def test_group_settings(self):
+        settings, _ = get_group_settings()
+        for group in settings.groups:
+            self.assertEqual(type(group), f_group)
+            assert callable(group.matches)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -6,13 +6,12 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from cnaas_nms.db.device import DeviceType
+from cnaas_nms.db.device import Device, DeviceType
 from cnaas_nms.db.settings import (
     DIR_STRUCTURE,
     VerifyPathException,
     VlanConflictError,
     check_bgp_neighbor_routemaps,
-    check_group_priority_collisions,
     check_vlan_collisions,
     get_device_primary_groups,
     get_groups_priorities_sorted,
@@ -48,7 +47,7 @@ class SettingsTests(unittest.TestCase):
 
     @pytest.mark.integration
     def test_get_settings_device(self):
-        settings, settings_origin = get_settings(hostname=self.testdata["testdevice"], device_type=DeviceType.DIST)
+        settings, settings_origin = get_settings(device=Device(**self.testdata["testdevice"]), device_type=DeviceType.DIST)
         # Assert that all required settings are set
         self.assertTrue(all(k in settings for k in self.required_setting_keys))
 
@@ -190,11 +189,9 @@ class SettingsTests(unittest.TestCase):
     def test_groups_priorities_sorted(self):
         group_settings_dict = {
             "groups": [
-                {
-                    "group": {"name": "DEFAULT", "group_priority": 1},
-                },
-                {"group": {"name": "HIGH", "group_priority": 100}},
-                {"group": {"name": "NONE", "group_priority": 0}},
+                {"name": "DEFAULT", "group_priority": 1},
+                {"name": "HIGH", "group_priority": 100},
+                {"name": "NONE", "group_priority": 0},
             ]
         }
         result = get_groups_priorities_sorted(settings=group_settings_dict)
@@ -213,34 +210,59 @@ class SettingsTests(unittest.TestCase):
     def test_groups_priorities_collission(self):
         group_settings_dict = {
             "groups": [
-                {
-                    "group": {"name": "DEFAULT", "group_priority": 1},
-                },
-                {"group": {"name": "HIGH", "group_priority": 100}},
-                {"group": {"name": "DUPLICATE", "group_priority": 100}},
+                {"name": "DEFAULT", "group_priority": 1},
+                {"name": "HIGH", "group_priority": 100},
+                {"name": "DUPLICATE", "group_priority": 100},
             ]
         }
+
         with self.assertRaises(ValueError, msg="Groups with same priority should raise ValueError"):
-            check_group_priority_collisions(group_settings_dict)
+            f_groups(**group_settings_dict)
         # Remove duplicate entry
         del group_settings_dict["groups"][2]
-        self.assertIsNone(check_group_priority_collisions(group_settings_dict))
+        f_groups(**group_settings_dict)
 
-    def test_groups_templates_braches(self):
+    def test_groups_names_collission(self):
         group_settings_dict = {
             "groups": [
+                {"name": "DEFAULT", "group_priority": 1},
+                {"name": "OTHER_GROUP"},
+                {"name": "DEFAULT"},
+            ]
+        }
+
+        with self.assertRaises(ValueError, msg="Groups with same name should raise ValueError"):
+            f_groups(**group_settings_dict)
+        # Remove duplicate entry
+        del group_settings_dict["groups"][2]
+        f_groups(**group_settings_dict)
+
+    def test_groups_device_filter(self):
+        group_settings_dict = {
+            "groups": [
+                {"name": "DEFAULT", "group_priority": 1},
+                {"name": "GROUP1", "device_filter": {"hostname": "eosdist1$"}},
+                {"name": "ERROR_GROUP", "device_filter": {"hostname": "eosdist1$("}},
+            ]
+        }
+
+        with self.assertRaises(ValueError, msg="Groups with bad regex should raise ValueError"):
+            f_groups(**group_settings_dict)
+        # Remove bad entry
+        del group_settings_dict["groups"][2]
+        f_groups(**group_settings_dict)
+
+    def test_groups_templates_branches(self):
+        group_settings_dict = {
+            "groups": [
+                {"name": "DEFAULT", "group_priority": 1},
                 {
-                    "group": {"name": "DEFAULT", "group_priority": 1},
+                    "name": "TEMPLATE1",
+                    "device_filter": {"hostname": "eosdist1$"},
+                    "group_priority": 100,
+                    "templates_branch": "test1",
                 },
-                {
-                    "group": {
-                        "name": "TEMPLATE1",
-                        "regex": "eosdist1$",
-                        "group_priority": 100,
-                        "templates_branch": "test1",
-                    }
-                },
-                {"group": {"name": "NOT_PRIMARY_GROUP", "templates_branch": "test2"}},
+                {"name": "NOT_PRIMARY_GROUP", "templates_branch": "test2"},
             ]
         }
         with self.assertRaises(

--- a/src/cnaas_nms/devicehandler/firmware.py
+++ b/src/cnaas_nms/devicehandler/firmware.py
@@ -338,114 +338,114 @@ def device_upgrade_task(
         device_type = dev.device_type
         device_model = dev.model
 
-    if filename and filename.startswith("detect_arch-"):
-        dev_settings, _ = get_settings(task.host.name, device_type)
-        if dev_settings and "arista_models_32bit" in dev_settings and dev_settings["arista_models_32bit"] is not None:
-            models_32bit: List[str] = dev_settings["arista_models_32bit"]
-        else:
-            models_32bit = arista_models.models_32bit
-        filename = filename.removeprefix("detect_arch-")
-        if device_model in models_32bit and filename.startswith("EOS64-"):
-            filename = "EOS-" + filename.removeprefix("EOS64-")
-            logger.info(
-                "Detected 32-bit device {}, changing filename to 32-bit version: {}".format(task.host.name, filename)
-            )
-        elif device_model not in models_32bit and filename.startswith("EOS-"):
-            filename = "EOS64-" + filename.removeprefix("EOS-")
-            logger.info(
-                "Detected 64-bit device {}, changing filename to 64-bit version: {}".format(task.host.name, filename)
-            )
-
-    if pre_flight:
-        logger.info("Running pre-flight check on {}".format(task.host.name))
-        try:
-            res = task.run(task=arista_pre_flight_check, job_id=job_id)
-        except Exception as e:
-            logger.exception("Exception while doing pre-flight check: {}".format(str(e)))
-            raise Exception("Pre-flight check failed")
-        else:
-            if res.failed:
-                logger.exception("Pre-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
-                raise
-
-    # If download is true, go ahead and download the firmware
-    if download:
-        if not filename:
-            raise Exception("No filename specified for download")
-        # Download the firmware from the HTTP container.
-        logger.info("Downloading firmware {} on {}".format(filename, task.host.name))
-        try:
-            res = task.run(
-                task=arista_firmware_download, filename=filename, httpd_url=url, device_type=device_type, job_id=job_id
-            )
-        except Exception as e:
-            logger.exception("Exception while downloading firmware: {}".format(str(e)))
-            raise e
-
-    # If download_only is false, continue to activate the newly downloaded
-    # firmware and verify that it if present in the boot-config.
-    already_active = False
-    if activate:
-        if not filename:
-            raise Exception("No filename specified for activate")
-        logger.info("Activating firmware {} on {}".format(filename, task.host.name))
-        try:
-            res = task.run(task=arista_firmware_activate, filename=filename, job_id=job_id)
-        except NornirSubTaskError as e:
-            subtask_result = e.result[0]
-            logger.debug("Exception while activating firmware for {}: {}".format(task.host.name, subtask_result))
-            if subtask_result.exception:
-                if isinstance(subtask_result.exception, FirmwareAlreadyActiveException):
-                    already_active = True
-                    logger.info(
-                        "Firmware already active, skipping reboot and post_flight: {}".format(subtask_result.exception)
-                    )
-                else:
-                    logger.exception(
-                        "Firmware activate subtask exception for {}: {}".format(
-                            task.host.name, str(subtask_result.exception)
-                        )
-                    )
-                    raise e
+        if filename and filename.startswith("detect_arch-"):
+            dev_settings, _ = get_settings(dev, device_type)
+            if dev_settings and "arista_models_32bit" in dev_settings and dev_settings["arista_models_32bit"] is not None:
+                models_32bit: List[str] = dev_settings["arista_models_32bit"]
             else:
-                logger.error("Activate subtask result for {}: {}".format(task.host.name, subtask_result.result))
+                models_32bit = arista_models.models_32bit
+            filename = filename.removeprefix("detect_arch-")
+            if device_model in models_32bit and filename.startswith("EOS64-"):
+                filename = "EOS-" + filename.removeprefix("EOS64-")
+                logger.info(
+                    "Detected 32-bit device {}, changing filename to 32-bit version: {}".format(task.host.name, filename)
+                )
+            elif device_model not in models_32bit and filename.startswith("EOS-"):
+                filename = "EOS64-" + filename.removeprefix("EOS-")
+                logger.info(
+                    "Detected 64-bit device {}, changing filename to 64-bit version: {}".format(task.host.name, filename)
+                )
+
+        if pre_flight:
+            logger.info("Running pre-flight check on {}".format(task.host.name))
+            try:
+                res = task.run(task=arista_pre_flight_check, job_id=job_id)
+            except Exception as e:
+                logger.exception("Exception while doing pre-flight check: {}".format(str(e)))
+                raise Exception("Pre-flight check failed")
+            else:
+                if res.failed:
+                    logger.exception("Pre-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
+                    raise
+
+        # If download is true, go ahead and download the firmware
+        if download:
+            if not filename:
+                raise Exception("No filename specified for download")
+            # Download the firmware from the HTTP container.
+            logger.info("Downloading firmware {} on {}".format(filename, task.host.name))
+            try:
+                res = task.run(
+                    task=arista_firmware_download, filename=filename, httpd_url=url, device_type=device_type, job_id=job_id
+                )
+            except Exception as e:
+                logger.exception("Exception while downloading firmware: {}".format(str(e)))
                 raise e
-        except Exception as e:
-            logger.exception("Exception while activating firmware for {}: {}".format(task.host.name, str(e)))
-            raise e
 
-    # Reboot the device if needed, we will then lose the connection.
-    if reboot and not already_active:
-        logger.info("Rebooting {}".format(task.host.name))
-        try:
-            res = task.run(task=arista_device_reboot, job_id=job_id)
-        except Exception:  # noqa: S110
-            pass
+        # If download_only is false, continue to activate the newly downloaded
+        # firmware and verify that it if present in the boot-config.
+        already_active = False
+        if activate:
+            if not filename:
+                raise Exception("No filename specified for activate")
+            logger.info("Activating firmware {} on {}".format(filename, task.host.name))
+            try:
+                res = task.run(task=arista_firmware_activate, filename=filename, job_id=job_id)
+            except NornirSubTaskError as e:
+                subtask_result = e.result[0]
+                logger.debug("Exception while activating firmware for {}: {}".format(task.host.name, subtask_result))
+                if subtask_result.exception:
+                    if isinstance(subtask_result.exception, FirmwareAlreadyActiveException):
+                        already_active = True
+                        logger.info(
+                            "Firmware already active, skipping reboot and post_flight: {}".format(subtask_result.exception)
+                        )
+                    else:
+                        logger.exception(
+                            "Firmware activate subtask exception for {}: {}".format(
+                                task.host.name, str(subtask_result.exception)
+                            )
+                        )
+                        raise e
+                else:
+                    logger.error("Activate subtask result for {}: {}".format(task.host.name, subtask_result.result))
+                    raise e
+            except Exception as e:
+                logger.exception("Exception while activating firmware for {}: {}".format(task.host.name, str(e)))
+                raise e
 
-    # If post-flight is selected, execute the post-flight task which
-    # will update device facts for the selected devices
-    if post_flight and not already_active:
-        try:
-            dev_settings, _ = get_settings(task.host.name, device_type)
-            res = task.run(
-                task=arista_post_flight_check,
-                post_waittime=post_waittime,
-                scheduled_by=scheduled_by,
-                job_id=job_id,
-                dev_settings=dev_settings,
-                device_model=device_model,
-            )
-        except Exception as e:
-            logger.exception("Failed to run post-flight check: {}".format(str(e)))
-        else:
-            if res.failed:
-                logger.error("Post-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
+        # Reboot the device if needed, we will then lose the connection.
+        if reboot and not already_active:
+            logger.info("Rebooting {}".format(task.host.name))
+            try:
+                res = task.run(task=arista_device_reboot, job_id=job_id)
+            except Exception:  # noqa: S110
+                pass
 
-    if job_id:
-        with redis_session() as db:  # type: ignore
-            db.lpush("finished_devices_" + str(job_id), task.host.name)
+        # If post-flight is selected, execute the post-flight task which
+        # will update device facts for the selected devices
+        if post_flight and not already_active:
+            try:
+                dev_settings, _ = get_settings(dev, device_type)
+                res = task.run(
+                    task=arista_post_flight_check,
+                    post_waittime=post_waittime,
+                    scheduled_by=scheduled_by,
+                    job_id=job_id,
+                    dev_settings=dev_settings,
+                    device_model=device_model,
+                )
+            except Exception as e:
+                logger.exception("Failed to run post-flight check: {}".format(str(e)))
+            else:
+                if res.failed:
+                    logger.error("Post-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
 
-    return "Devices upgraded"
+        if job_id:
+            with redis_session() as db:  # type: ignore
+                db.lpush("finished_devices_" + str(job_id), task.host.name)
+
+        return "Devices upgraded"
 
 
 @job_wrapper

--- a/src/cnaas_nms/devicehandler/firmware.py
+++ b/src/cnaas_nms/devicehandler/firmware.py
@@ -337,115 +337,116 @@ def device_upgrade_task(
             raise Exception("Could not find a device with hostname {}".format(task.host.name))
         device_type = dev.device_type
         device_model = dev.model
+        session.expunge(dev)
 
-        if filename and filename.startswith("detect_arch-"):
-            dev_settings, _ = get_settings(dev, device_type)
-            if dev_settings and "arista_models_32bit" in dev_settings and dev_settings["arista_models_32bit"] is not None:
-                models_32bit: List[str] = dev_settings["arista_models_32bit"]
-            else:
-                models_32bit = arista_models.models_32bit
-            filename = filename.removeprefix("detect_arch-")
-            if device_model in models_32bit and filename.startswith("EOS64-"):
-                filename = "EOS-" + filename.removeprefix("EOS64-")
-                logger.info(
-                    "Detected 32-bit device {}, changing filename to 32-bit version: {}".format(task.host.name, filename)
-                )
-            elif device_model not in models_32bit and filename.startswith("EOS-"):
-                filename = "EOS64-" + filename.removeprefix("EOS-")
-                logger.info(
-                    "Detected 64-bit device {}, changing filename to 64-bit version: {}".format(task.host.name, filename)
-                )
+    if filename and filename.startswith("detect_arch-"):
+        dev_settings, _ = get_settings(dev, device_type)
+        if dev_settings and "arista_models_32bit" in dev_settings and dev_settings["arista_models_32bit"] is not None:
+            models_32bit: List[str] = dev_settings["arista_models_32bit"]
+        else:
+            models_32bit = arista_models.models_32bit
+        filename = filename.removeprefix("detect_arch-")
+        if device_model in models_32bit and filename.startswith("EOS64-"):
+            filename = "EOS-" + filename.removeprefix("EOS64-")
+            logger.info(
+                "Detected 32-bit device {}, changing filename to 32-bit version: {}".format(task.host.name, filename)
+            )
+        elif device_model not in models_32bit and filename.startswith("EOS-"):
+            filename = "EOS64-" + filename.removeprefix("EOS-")
+            logger.info(
+                "Detected 64-bit device {}, changing filename to 64-bit version: {}".format(task.host.name, filename)
+            )
 
-        if pre_flight:
-            logger.info("Running pre-flight check on {}".format(task.host.name))
-            try:
-                res = task.run(task=arista_pre_flight_check, job_id=job_id)
-            except Exception as e:
-                logger.exception("Exception while doing pre-flight check: {}".format(str(e)))
-                raise Exception("Pre-flight check failed")
-            else:
-                if res.failed:
-                    logger.exception("Pre-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
-                    raise
+    if pre_flight:
+        logger.info("Running pre-flight check on {}".format(task.host.name))
+        try:
+            res = task.run(task=arista_pre_flight_check, job_id=job_id)
+        except Exception as e:
+            logger.exception("Exception while doing pre-flight check: {}".format(str(e)))
+            raise Exception("Pre-flight check failed")
+        else:
+            if res.failed:
+                logger.exception("Pre-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
+                raise
 
-        # If download is true, go ahead and download the firmware
-        if download:
-            if not filename:
-                raise Exception("No filename specified for download")
-            # Download the firmware from the HTTP container.
-            logger.info("Downloading firmware {} on {}".format(filename, task.host.name))
-            try:
-                res = task.run(
-                    task=arista_firmware_download, filename=filename, httpd_url=url, device_type=device_type, job_id=job_id
-                )
-            except Exception as e:
-                logger.exception("Exception while downloading firmware: {}".format(str(e)))
-                raise e
+    # If download is true, go ahead and download the firmware
+    if download:
+        if not filename:
+            raise Exception("No filename specified for download")
+        # Download the firmware from the HTTP container.
+        logger.info("Downloading firmware {} on {}".format(filename, task.host.name))
+        try:
+            res = task.run(
+                task=arista_firmware_download, filename=filename, httpd_url=url, device_type=device_type, job_id=job_id
+            )
+        except Exception as e:
+            logger.exception("Exception while downloading firmware: {}".format(str(e)))
+            raise e
 
-        # If download_only is false, continue to activate the newly downloaded
-        # firmware and verify that it if present in the boot-config.
-        already_active = False
-        if activate:
-            if not filename:
-                raise Exception("No filename specified for activate")
-            logger.info("Activating firmware {} on {}".format(filename, task.host.name))
-            try:
-                res = task.run(task=arista_firmware_activate, filename=filename, job_id=job_id)
-            except NornirSubTaskError as e:
-                subtask_result = e.result[0]
-                logger.debug("Exception while activating firmware for {}: {}".format(task.host.name, subtask_result))
-                if subtask_result.exception:
-                    if isinstance(subtask_result.exception, FirmwareAlreadyActiveException):
-                        already_active = True
-                        logger.info(
-                            "Firmware already active, skipping reboot and post_flight: {}".format(subtask_result.exception)
-                        )
-                    else:
-                        logger.exception(
-                            "Firmware activate subtask exception for {}: {}".format(
-                                task.host.name, str(subtask_result.exception)
-                            )
-                        )
-                        raise e
+    # If download_only is false, continue to activate the newly downloaded
+    # firmware and verify that it if present in the boot-config.
+    already_active = False
+    if activate:
+        if not filename:
+            raise Exception("No filename specified for activate")
+        logger.info("Activating firmware {} on {}".format(filename, task.host.name))
+        try:
+            res = task.run(task=arista_firmware_activate, filename=filename, job_id=job_id)
+        except NornirSubTaskError as e:
+            subtask_result = e.result[0]
+            logger.debug("Exception while activating firmware for {}: {}".format(task.host.name, subtask_result))
+            if subtask_result.exception:
+                if isinstance(subtask_result.exception, FirmwareAlreadyActiveException):
+                    already_active = True
+                    logger.info(
+                        "Firmware already active, skipping reboot and post_flight: {}".format(subtask_result.exception)
+                    )
                 else:
-                    logger.error("Activate subtask result for {}: {}".format(task.host.name, subtask_result.result))
+                    logger.exception(
+                        "Firmware activate subtask exception for {}: {}".format(
+                            task.host.name, str(subtask_result.exception)
+                        )
+                    )
                     raise e
-            except Exception as e:
-                logger.exception("Exception while activating firmware for {}: {}".format(task.host.name, str(e)))
-                raise e
-
-        # Reboot the device if needed, we will then lose the connection.
-        if reboot and not already_active:
-            logger.info("Rebooting {}".format(task.host.name))
-            try:
-                res = task.run(task=arista_device_reboot, job_id=job_id)
-            except Exception:  # noqa: S110
-                pass
-
-        # If post-flight is selected, execute the post-flight task which
-        # will update device facts for the selected devices
-        if post_flight and not already_active:
-            try:
-                dev_settings, _ = get_settings(dev, device_type)
-                res = task.run(
-                    task=arista_post_flight_check,
-                    post_waittime=post_waittime,
-                    scheduled_by=scheduled_by,
-                    job_id=job_id,
-                    dev_settings=dev_settings,
-                    device_model=device_model,
-                )
-            except Exception as e:
-                logger.exception("Failed to run post-flight check: {}".format(str(e)))
             else:
-                if res.failed:
-                    logger.error("Post-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
+                logger.error("Activate subtask result for {}: {}".format(task.host.name, subtask_result.result))
+                raise e
+        except Exception as e:
+            logger.exception("Exception while activating firmware for {}: {}".format(task.host.name, str(e)))
+            raise e
 
-        if job_id:
-            with redis_session() as db:  # type: ignore
-                db.lpush("finished_devices_" + str(job_id), task.host.name)
+    # Reboot the device if needed, we will then lose the connection.
+    if reboot and not already_active:
+        logger.info("Rebooting {}".format(task.host.name))
+        try:
+            res = task.run(task=arista_device_reboot, job_id=job_id)
+        except Exception:  # noqa: S110
+            pass
 
-        return "Devices upgraded"
+    # If post-flight is selected, execute the post-flight task which
+    # will update device facts for the selected devices
+    if post_flight and not already_active:
+        try:
+            dev_settings, _ = get_settings(dev, device_type)
+            res = task.run(
+                task=arista_post_flight_check,
+                post_waittime=post_waittime,
+                scheduled_by=scheduled_by,
+                job_id=job_id,
+                dev_settings=dev_settings,
+                device_model=device_model,
+            )
+        except Exception as e:
+            logger.exception("Failed to run post-flight check: {}".format(str(e)))
+        else:
+            if res.failed:
+                logger.error("Post-flight check failed for: {}".format(" ".join(res.failed_hosts.keys())))
+
+    if job_id:
+        with redis_session() as db:  # type: ignore
+            db.lpush("finished_devices_" + str(job_id), task.host.name)
+
+    return "Devices upgraded"
 
 
 @job_wrapper

--- a/src/cnaas_nms/devicehandler/nornir_plugins/cnaas_inventory.py
+++ b/src/cnaas_nms/devicehandler/nornir_plugins/cnaas_inventory.py
@@ -83,7 +83,7 @@ class CnaasInventory:
                 if instance.port and isinstance(instance.port, int):
                     port = instance.port
                 host_groups = ["T_" + instance.device_type.name, "S_" + instance.state.name]
-                for member_group in get_groups(instance.hostname):
+                for member_group in get_groups(instance):
                     host_groups.append(member_group)
 
                 if instance.state in insecure_device_states:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -145,7 +145,7 @@ def populate_device_vars(
     if not isinstance(dev.platform, str):
         raise ValueError("Unknown platform: {}".format(dev.platform))
 
-    settings, settings_origin = get_settings(hostname, devtype, dev.model)
+    settings, settings_origin = get_settings(dev, devtype, dev.model)
 
     if devtype == DeviceType.ACCESS:
         if ztp_hostname:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -323,7 +323,7 @@ def populate_device_vars(
                     # Copy interface settings from mgmtdomain peer device
                     if_dict = {"indexnum": ifindexnum}
                     peer_device = cnaas_nms.db.helper.find_mgmtdomain_peer(session, dev)
-                    peer_settings, _ = get_settings(peer_device.hostname, devtype, peer_device.model)
+                    peer_settings, _ = get_settings(peer_device, devtype, peer_device.model)
                     if "interfaces" in peer_settings and peer_settings["interfaces"]:
                         for peer_intf in peer_settings["interfaces"]:
                             if peer_intf["name"] == intf["name"]:
@@ -345,9 +345,7 @@ def populate_device_vars(
                     fabric_device_variables["interfaces"].append(if_dict)
 
         for local_if, data in fabric_interfaces.items():
-            logger.warn(
-                f"Interface {local_if} on device {hostname} not " "configured as linknet because of wrong ifclass"
-            )
+            logger.warn(f"Interface {local_if} on device {hostname} not configured as linknet because of wrong ifclass")
 
         if not ztp_hostname:
             for mgmtdom in cnaas_nms.db.helper.get_all_mgmtdomains(session, hostname):

--- a/src/cnaas_nms/devicehandler/update.py
+++ b/src/cnaas_nms/devicehandler/update.py
@@ -269,8 +269,8 @@ def update_linknets(
 
         logger.debug(f"Remote device found, device id: {remote_device_inst.id}")
 
-        local_device_settings, _ = get_settings(settings_hostname, devtype, local_device_inst.model)
-        remote_device_settings, _ = get_settings(remote_device_inst.hostname, remote_devtype, remote_device_inst.model)
+        local_device_settings, _ = get_settings(local_device_inst, devtype, local_device_inst.model)
+        remote_device_settings, _ = get_settings(remote_device_inst, remote_devtype, remote_device_inst.model)
 
         local_device_inst_copy = Device(hostname=local_device_inst.hostname, device_type=local_device_inst.device_type)
         local_device_inst_copy.device_type = devtype


### PR DESCRIPTION
My work for issue: #401.

### Changes
- New group model with backwards compatibility
  Can match on the following fields: hostname, device_type, model, os_version and platform
- Can match all fields with regex and the regex is properly validated.
- Updated logic for grouping devices
  Should be faster due to using compiled regex patterns that caches with cached_property
  I have not tested the speed but in theory it should be faster
  Still works with redis-caching.
- Updated all functions that call get_groups or get_settings to send the entire device to be able to match on more fields.
- Added and changed some unittests
- Updated groups api endpoint with the new group layout
- Updated documentation
- Added documentation for a migration-command from old to new group format using yq.


@indy-independence please provide feedback.