### PR TITLE
Feature httpd updates

### DIFF
--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -26,8 +26,17 @@ firmware_model = api.model(
     "firmware_download",
     {
         "url": fields.String(required=True),
-        "sha1": fields.String(description="sha1 checksum, cannot be used together with sha512", required=False),
-        "sha512": fields.String(description="sha512 checksum, cannot be used together with sha1", required=False),
+        "checksum": fields.Nested(
+            api.model(
+                "firmware_checksum",
+                {
+                    "algorithm": fields.String(description="checksum algorithm", required=True),
+                    "checksum": fields.String(description="checksum value", required=True),
+                },
+            ),
+            required=True,
+            description="checksum object containing algorithm and checksum value, if sha1 field is sent instead of checksum object sha1 is assumed as algorithm.",
+        ),
         "verify_tls": fields.Boolean(required=False),
         "filename": fields.String(required=True),
     },
@@ -122,20 +131,18 @@ class FirmwareApi(Resource):
         if "url" not in json_data:
             return empty_result(status="error", data="Missing parameter url")
 
-        if "sha512" not in json_data and "sha1" not in json_data:
-            return empty_result(status="error", data="Missing parameter sha1 or sha512")
-
-        if "sha512" in json_data and "sha1" in json_data:
-            return empty_result(status="error", data="Cannot supply both sha1 and sha512")
+        if "checksum" not in json_data and "sha1" not in json_data:
+            return empty_result(status="error", data="Missing parameter checksum")
 
         if "verify_tls" not in json_data:
             return empty_result(status="error", data="Missing parameter verify_tls")
 
         kwargs["url"] = json_data["url"]
-        if "sha512" in json_data:
-            kwargs["sha512"] = json_data["sha512"]
-        else:
-            kwargs["sha1"] = json_data["sha1"]
+
+        # If sha1 is sent override checksum object and assume sha1 as algorithm.
+        if "sha1" in json_data:
+            kwargs["checksum"] = {"algorithm": "sha1", "checksum": json_data["sha1"]}
+
         kwargs["verify_tls"] = json_data["verify_tls"]
 
         scheduler: Scheduler = Scheduler()

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -139,9 +139,12 @@ class FirmwareApi(Resource):
 
         kwargs["url"] = json_data["url"]
 
-        # If sha1 is sent override checksum object and assume sha1 as algorithm.
+        # If sha1 is sent use backwards compatible sha1, otherwise use checksum object
+        # Will be transformed to a checksum object in HTTPD
         if "sha1" in json_data:
-            kwargs["checksum"] = {"algorithm": "sha1", "checksum": json_data["sha1"]}
+            kwargs["sha1"] = json_data["sha1"]
+        else:
+            kwargs["checksum"] = json_data["checksum"]
 
         kwargs["verify_tls"] = json_data["verify_tls"]
 

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -61,7 +61,7 @@ firmware_upgrade_model = api.model(
 
 
 @job_wrapper
-def get_firmware(**kwargs: dict) -> str:
+def download_firmware(**kwargs: dict) -> str:
     try:
         res = requests.post(api_settings.HTTPD_URL, json=kwargs, verify=api_settings.VERIFY_TLS)
         json_data = json.loads(res.content)
@@ -71,52 +71,6 @@ def get_firmware(**kwargs: dict) -> str:
     if json_data["status"] == "error":
         return json_data["message"]
     return "File downloaded from: " + str(kwargs["url"])
-
-
-@job_wrapper
-def get_firmware_chksum(**kwargs: dict) -> str:
-    try:
-        url = api_settings.HTTPD_URL + "/" + str(kwargs["filename"])
-        res = requests.get(url, verify=api_settings.VERIFY_TLS)
-        json_data = json.loads(res.content)
-    except Exception as e:
-        logger.exception(f"Exception while getting checksum: {e}")
-        return "Failed to get checksum for " + str(kwargs["filename"])
-    if json_data["status"] == "error":
-        return json_data["message"]
-    file_data = json_data["data"]["file"]
-    if "sha512" in file_data:
-        return file_data["sha512"]
-    else:
-        return file_data["sha1"]
-
-
-@job_wrapper
-def remove_file(**kwargs: dict) -> str:
-    try:
-        url = api_settings.HTTPD_URL + "/" + str(kwargs["filename"])
-        res = requests.delete(url, verify=api_settings.VERIFY_TLS)
-        json_data = json.loads(res.content)
-    except Exception as e:
-        logger.exception(f"Exception when removing firmware: {e}")
-        return "Failed to remove file"
-    if json_data["status"] == "error":
-        return "Failed to remove file " + str(kwargs["filename"])
-    return "File " + str(kwargs["filename"]) + " removed"
-
-
-@job_wrapper
-def set_default_file(**kwargs: dict) -> str:
-    try:
-        url = api_settings.HTTPD_URL + "/" + str(kwargs["filename"]) + "/set-default"
-        res = requests.post(url, verify=api_settings.VERIFY_TLS)
-        json_data = json.loads(res.content)
-    except Exception as e:
-        logger.exception(f"Exception when settings default image: {e}")
-        return "Failed to set default image"
-    if json_data["status"] == "error":
-        return "Failed to set default image: " + str(kwargs["filename"]) + ", " + json_data["message"]
-    return "File " + str(kwargs["filename"]) + " set as default image."
 
 
 class FirmwareApi(Resource):
@@ -150,7 +104,7 @@ class FirmwareApi(Resource):
 
         scheduler: Scheduler = Scheduler()
         job_id = scheduler.add_onetime_job(
-            "cnaas_nms.api.firmware:get_firmware", when=1, scheduled_by=get_identity(), kwargs=kwargs
+            "cnaas_nms.api.firmware:download_firmware", when=1, scheduled_by=get_identity(), kwargs=kwargs
         )
         res = empty_result(data="Scheduled job to download firmware")
         res["job_id"] = job_id
@@ -164,55 +118,54 @@ class FirmwareApi(Resource):
             res = requests.get(api_settings.HTTPD_URL, verify=api_settings.VERIFY_TLS)
             json_data = json.loads(res.content)["data"]
         except Exception as e:
-            logger.exception(f"Exception when getting images: {e}")
+            logger.exception(f"Exception when getting files: {e}")
             return empty_result(status="error", data="Could not get files"), 404
-        return empty_result(status="success", data=json_data)
+        # httpd returns the correct format so we can skip formatting here
+        # this will potentially return any error caught in httpd as well
+        return json_data
 
 
 class FirmwareImageApi(Resource):
     @login_required
     def get(self, filename: str) -> dict:
         """Get information about a single firmware"""
-        scheduler: Scheduler = Scheduler()
-        job_id = scheduler.add_onetime_job(
-            "cnaas_nms.api.firmware:get_firmware_chksum",
-            when=1,
-            scheduled_by=get_identity(),
-            kwargs={"filename": filename},
-        )
-        res = empty_result(data="Scheduled job get firmware information")
-        res["job_id"] = job_id
-
-        return res
+        try:
+            res = requests.get(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
+            json_data = json.loads(res.content)["data"]
+        except Exception as e:
+            logger.exception(f"Exception when getting file: {e}")
+            return empty_result(status="error", data="Could not get file"), 404
+        # httpd returns the correct format so we can skip formatting here
+        # this will potentially return any error caught in httpd as well
+        return json_data
 
     @login_required
     def delete(self, filename: str) -> dict:
         """Remove firmware"""
-        scheduler: Scheduler = Scheduler()
-        job_id = scheduler.add_onetime_job(
-            "cnaas_nms.api.firmware:remove_file", when=1, scheduled_by=get_identity(), kwargs={"filename": filename}
-        )
-        res = empty_result(data="Scheduled job to remove firmware")
-        res["job_id"] = job_id
-
-        return res
+        try:
+            res = requests.delete(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
+            json_data = json.loads(res.content)["data"]
+        except Exception as e:
+            logger.exception(f"Exception when deleting file: {e}")
+            return empty_result(status="error", data="Could not delete file"), 404
+        # httpd returns the correct format so we can skip formatting here
+        # this will potentially return any error caught in httpd as well
+        return json_data
 
 
 class FirmwareSetDefaultApi(Resource):
     @login_required
     def post(self, filename: str) -> dict:
         """Set a firmware as the default image"""
-        scheduler: Scheduler = Scheduler()
-        job_id = scheduler.add_onetime_job(
-            "cnaas_nms.api.firmware:set_default_file",
-            when=1,
-            scheduled_by=get_identity(),
-            kwargs={"filename": filename},
-        )
-        res = empty_result(data="Scheduled job to set default firmware")
-        res["job_id"] = job_id
-
-        return res
+        try:
+            res = requests.post(f"{api_settings.HTTPD_URL}/{filename}/set-default", verify=api_settings.VERIFY_TLS)
+            json_data = json.loads(res.content)["data"]
+        except Exception as e:
+            logger.exception(f"Exception when setting file as default: {e}")
+            return empty_result(status="error", data="Could not set file as default"), 404
+        # httpd returns the correct format so we can skip formatting here
+        # this will potentially return any error caught in httpd as well
+        return json_data
 
 
 class FirmwareUpgradeApi(Resource):
@@ -229,7 +182,7 @@ class FirmwareUpgradeApi(Resource):
 
         if "url" not in json_data and url == "":
             return empty_result(
-                status="error", data="No external address configured for " 'HTTPD, please specify one with "url"'
+                status="error", data='No external address configured for HTTPD, please specify one with "url"'
             )
 
         if "url" not in json_data:

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -120,14 +120,12 @@ class FirmwareApi(Resource):
         except Exception as e:
             logger.exception(f"Exception when getting files: {e}")
             return empty_result(status="error", data="Could not get files"), 404
-        # httpd returns the correct format so we can skip formatting here
-        # this will potentially return any error caught in httpd as well
-        return json_data
+        return empty_result(status="success", data=json_data)
 
 
 class FirmwareImageApi(Resource):
     @login_required
-    def get(self, filename: str) -> dict:
+    def get(self, filename: str) -> dict[str, Any] | tuple[dict[str, Any], int]:
         """Get information about a single firmware"""
         try:
             res = requests.get(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
@@ -135,12 +133,10 @@ class FirmwareImageApi(Resource):
         except Exception as e:
             logger.exception(f"Exception when getting file: {e}")
             return empty_result(status="error", data="Could not get file"), 404
-        # httpd returns the correct format so we can skip formatting here
-        # this will potentially return any error caught in httpd as well
-        return json_data
+        return empty_result(status="success", data=json_data)
 
     @login_required
-    def delete(self, filename: str) -> dict:
+    def delete(self, filename: str) -> dict[str, Any] | tuple[dict[str, Any], int]:
         """Remove firmware"""
         try:
             res = requests.delete(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
@@ -148,14 +144,12 @@ class FirmwareImageApi(Resource):
         except Exception as e:
             logger.exception(f"Exception when deleting file: {e}")
             return empty_result(status="error", data="Could not delete file"), 404
-        # httpd returns the correct format so we can skip formatting here
-        # this will potentially return any error caught in httpd as well
-        return json_data
+        return empty_result(status="success", data=json_data)
 
 
 class FirmwareSetDefaultApi(Resource):
     @login_required
-    def post(self, filename: str) -> dict:
+    def post(self, filename: str) -> dict[str, Any] | tuple[dict[str, Any], int]:
         """Set a firmware as the default image"""
         try:
             res = requests.post(f"{api_settings.HTTPD_URL}/{filename}/set-default", verify=api_settings.VERIFY_TLS)
@@ -163,9 +157,7 @@ class FirmwareSetDefaultApi(Resource):
         except Exception as e:
             logger.exception(f"Exception when setting file as default: {e}")
             return empty_result(status="error", data="Could not set file as default"), 404
-        # httpd returns the correct format so we can skip formatting here
-        # this will potentially return any error caught in httpd as well
-        return json_data
+        return empty_result(status="success", data=json_data)
 
 
 class FirmwareUpgradeApi(Resource):

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -26,8 +26,8 @@ firmware_model = api.model(
     "firmware_download",
     {
         "url": fields.String(required=True),
-        "sha1": fields.String(description='sha1 checksum, cannot be used together with sha512', required=False),
-        "sha512": fields.String(description='sha512 checksum, cannot be used together with sha1',required=False),
+        "sha1": fields.String(description="sha1 checksum, cannot be used together with sha512", required=False),
+        "sha512": fields.String(description="sha512 checksum, cannot be used together with sha1", required=False),
         "verify_tls": fields.Boolean(required=False),
         "filename": fields.String(required=True),
     },
@@ -94,6 +94,20 @@ def remove_file(**kwargs: dict) -> str:
     if json_data["status"] == "error":
         return "Failed to remove file " + str(kwargs["filename"])
     return "File " + str(kwargs["filename"]) + " removed"
+
+
+@job_wrapper
+def set_default_file(**kwargs: dict) -> str:
+    try:
+        url = api_settings.HTTPD_URL + "/" + str(kwargs["filename"]) + "/set-default"
+        res = requests.post(url, verify=api_settings.VERIFY_TLS)
+        json_data = json.loads(res.content)
+    except Exception as e:
+        logger.exception(f"Exception when settings default image: {e}")
+        return "Failed to set default image"
+    if json_data["status"] == "error":
+        return "Failed to set default image: " + str(kwargs["filename"]) + ", " + json_data["message"]
+    return "File " + str(kwargs["filename"]) + " set as default image."
 
 
 class FirmwareApi(Resource):
@@ -166,6 +180,23 @@ class FirmwareImageApi(Resource):
             "cnaas_nms.api.firmware:remove_file", when=1, scheduled_by=get_identity(), kwargs={"filename": filename}
         )
         res = empty_result(data="Scheduled job to remove firmware")
+        res["job_id"] = job_id
+
+        return res
+
+
+class FirmwareSetDefaultApi(Resource):
+    @login_required
+    def post(self, filename: str) -> dict:
+        """Set a firmware as the default image"""
+        scheduler: Scheduler = Scheduler()
+        job_id = scheduler.add_onetime_job(
+            "cnaas_nms.api.firmware:set_default_file",
+            when=1,
+            scheduled_by=get_identity(),
+            kwargs={"filename": filename},
+        )
+        res = empty_result(data="Scheduled job to set default firmware")
         res["job_id"] = job_id
 
         return res
@@ -300,4 +331,5 @@ class FirmwareUpgradeApi(Resource):
 # Firmware
 api.add_resource(FirmwareApi, "")
 api.add_resource(FirmwareImageApi, "/<string:filename>")
+api.add_resource(FirmwareSetDefaultApi, "/<string:filename>/set-default")
 api.add_resource(FirmwareUpgradeApi, "/upgrade")

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -125,6 +125,9 @@ class FirmwareApi(Resource):
         if "sha512" not in json_data and "sha1" not in json_data:
             return empty_result(status="error", data="Missing parameter sha1 or sha512")
 
+        if "sha512" in json_data and "sha1" in json_data:
+            return empty_result(status="error", data="Cannot supply both sha1 and sha512")
+
         if "verify_tls" not in json_data:
             return empty_result(status="error", data="Missing parameter verify_tls")
 

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -26,7 +26,8 @@ firmware_model = api.model(
     "firmware_download",
     {
         "url": fields.String(required=True),
-        "sha1": fields.String(required=True),
+        "sha1": fields.String(description='sha1 checksum, cannot be used together with sha512', required=False),
+        "sha512": fields.String(description='sha512 checksum, cannot be used together with sha1',required=False),
         "verify_tls": fields.Boolean(required=False),
         "filename": fields.String(required=True),
     },
@@ -70,11 +71,15 @@ def get_firmware_chksum(**kwargs: dict) -> str:
         res = requests.get(url, verify=api_settings.VERIFY_TLS)
         json_data = json.loads(res.content)
     except Exception as e:
-        logger.exception(f"Exceptionb while getting checksum: {e}")
+        logger.exception(f"Exception while getting checksum: {e}")
         return "Failed to get checksum for " + str(kwargs["filename"])
     if json_data["status"] == "error":
         return json_data["message"]
-    return json_data["data"]["file"]["sha1"]
+    file_data = json_data["data"]["file"]
+    if "sha512" in file_data:
+        return file_data["sha512"]
+    else:
+        return file_data["sha1"]
 
 
 @job_wrapper
@@ -103,14 +108,17 @@ class FirmwareApi(Resource):
         if "url" not in json_data:
             return empty_result(status="error", data="Missing parameter url")
 
-        if "sha1" not in json_data:
-            return empty_result(status="error", data="Missing parameter sha1")
+        if "sha512" not in json_data and "sha1" not in json_data:
+            return empty_result(status="error", data="Missing parameter sha1 or sha512")
 
         if "verify_tls" not in json_data:
             return empty_result(status="error", data="Missing parameter verify_tls")
 
         kwargs["url"] = json_data["url"]
-        kwargs["sha1"] = json_data["sha1"]
+        if "sha512" in json_data:
+            kwargs["sha512"] = json_data["sha512"]
+        else:
+            kwargs["sha1"] = json_data["sha1"]
         kwargs["verify_tls"] = json_data["verify_tls"]
 
         scheduler: Scheduler = Scheduler()

--- a/src/cnaas_nms/api/firmware.py
+++ b/src/cnaas_nms/api/firmware.py
@@ -61,7 +61,7 @@ firmware_upgrade_model = api.model(
 
 
 @job_wrapper
-def download_firmware(**kwargs: dict) -> str:
+def download_firmware_to_nms(**kwargs: dict) -> str:
     try:
         res = requests.post(api_settings.HTTPD_URL, json=kwargs, verify=api_settings.VERIFY_TLS)
         json_data = json.loads(res.content)
@@ -104,7 +104,7 @@ class FirmwareApi(Resource):
 
         scheduler: Scheduler = Scheduler()
         job_id = scheduler.add_onetime_job(
-            "cnaas_nms.api.firmware:download_firmware", when=1, scheduled_by=get_identity(), kwargs=kwargs
+            "cnaas_nms.api.firmware:download_firmware_to_nms", when=1, scheduled_by=get_identity(), kwargs=kwargs
         )
         res = empty_result(data="Scheduled job to download firmware")
         res["job_id"] = job_id


### PR DESCRIPTION
Changes needed to support the new functions in HTTPd: https://github.com/SUNET/cnaas-httpd/pull/3.
- Added dynamic checksum algorithm support with backwards compability to sha1.
- Added /set-default endpoint to nms.
- Should be backwards-compatible with older versions of httpd.
Will just fail if /set-default is called or sha512 is supplied.