### PR TITLE
Feature: File glob mapping.yml dependencies

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -18,12 +18,15 @@ might be a definition of templates for an access switch specified like this:
     ACCESS:
         entrypoint: access.j2
         dependencies:
+            - access*.j2
             - managed-full.j2
 
 
 This indicates that the starting point for the template of access switches for this platform
 is deffined in the Jinja2 template file called "access.j2". Additionally, this template file
-will depend on things defined in a file called "managed-full.j2".
+will depend on things defined in files "access*.j2" and "managed-full.j2".
+The dependencies can use glob patterns, so "access*.j2" will match any file starting with "access"
+and ending with ".j2".
 
 The template files themselves are written using the Jinja2 templating language. Variables
 that are exposed from CNaaS includes:

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import fnmatch
 import json
 import os
 import shutil
@@ -347,6 +348,18 @@ def _refresh_repo_task(local_repo_path, remote_repo_path) -> Tuple[str, Set[str]
     return ret, changed_files
 
 
+def _is_device_type_update_required(updated_templates: set[str], dependencies: List[str], platform: str) -> bool:
+    """
+    Checks if any of the updated templates matches any of the platform dependencies.
+    Support for glob patterns in dependencies with fnmatch.
+    """
+    for updated_template in updated_templates:
+        for dependency in dependencies:
+            if fnmatch.fnmatch(updated_template, os.path.join(platform, dependency)):
+                return True
+    return False
+
+
 def template_syncstatus(updated_templates: set) -> Set[Tuple[DeviceType, str]]:
     """Determine what device types have become unsynchronized because
     of updated template files."""
@@ -373,7 +386,6 @@ def template_syncstatus(updated_templates: set) -> Set[Tuple[DeviceType, str]]:
         devtype: DeviceType
         for devtype in DeviceType:
             if devtype.name in mapping:
-                update_required = False
                 try:
                     dependencies = list([mapping[devtype.name]["entrypoint"]])
                     if "dependencies" in mapping[devtype.name] and isinstance(
@@ -391,11 +403,7 @@ def template_syncstatus(updated_templates: set) -> Set[Tuple[DeviceType, str]]:
                             devtype.name, str(e)
                         )
                     )
-
-                for dependency in dependencies:
-                    if os.path.join(platform, dependency) in updated_templates:
-                        update_required = True
-                if update_required:
+                if _is_device_type_update_required(updated_templates, dependencies, platform):
                     logger.info("Template for device type {} has been updated".format(devtype.name))
                     unsynced_devtypes.add((devtype, platform))
 

--- a/src/cnaas_nms/db/tests/test_git.py
+++ b/src/cnaas_nms/db/tests/test_git.py
@@ -4,7 +4,13 @@ from typing import Set, Tuple
 import pytest
 
 from cnaas_nms.db.device import DeviceType
-from cnaas_nms.db.git import RepoType, repo_checkout_working, repo_save_working_commit, template_syncstatus
+from cnaas_nms.db.git import (
+    RepoType,
+    _is_device_type_update_required,
+    repo_checkout_working,
+    repo_save_working_commit,
+    template_syncstatus,
+)
 from cnaas_nms.db.session import redis_session
 
 
@@ -31,6 +37,15 @@ class GitTests(unittest.TestCase):
             self.assertEqual(type(devtype[0]), DeviceType)
             self.assertEqual(type(devtype[1]), str)
         self.assertTrue((DeviceType.ACCESS, "eos") in devtypes)
+
+    def test_is_device_type_update_required(self):
+        self.assertTrue(_is_device_type_update_required({"eos/base.j2"}, ["base.j2"], "eos"))
+        self.assertTrue(_is_device_type_update_required({"eos/access.j2"}, ["access*.j2"], "eos"))
+        self.assertFalse(_is_device_type_update_required({"ios/base.j2"}, ["**.j2"], "eos"))
+        self.assertTrue(_is_device_type_update_required({"eos/acls/some-acl.eacl"}, ["acls/*.eacl"], "eos"))
+        self.assertFalse(_is_device_type_update_required({"eos/dist-base.j2"}, ["access*.j2"], "eos"))
+        self.assertFalse(_is_device_type_update_required({"eos/core-base.j2"}, ["dist*.j2"], "eos"))
+        self.assertFalse(_is_device_type_update_required({"junos/access-base.j2"}, ["access-*.j2"], "eos"))
 
     def test_savecommit(self):
         self.assertFalse(


### PR DESCRIPTION
Adds feature from #424.

- Uses [fnmatch](https://docs.python.org/3/library/fnmatch.html) to match with glob patterns in mapping.yml dependencies.
- Refactored code and added: _is_device_type_update_required to be able to return through 2 nested for-loops.
- Added tests
- Updated docs
- Optional [PR](https://github.com/SUNET/cnaas-integrationtest-templates/pull/1) in repo: cnaas-integrationtest-templates
- Ran full integration-tests successfully
- Should be run once end to end in norpan with a git commit on a template file to further confirm it working.