### PR TITLE
Feature.replace access switch

### DIFF
--- a/docs/apiref/devices.rst
+++ b/docs/apiref/devices.rst
@@ -344,6 +344,14 @@ To initialize a pair of ACCESS devices as an MLAG pair:
 
 For MLAG pairs the devices must be able to dectect it's peer via LLDP neighbors and compatible uplink devices for initialization to finish.
 
+If you want to replace an existing switch new a new device that is in DISCOVERED state, use the following API call on the new device in DISCOVERED state:
+
+::
+
+   curl https://localhost/api/v1.0/device_init/46 -d '{"hostname": "a1", "device_type": "ACCESS", "replace_hostname": true}' -X POST -H "Content-Type: application/json"
+
+See more details about switch replacement under Howto :ref:`switch_replacement`
+
 Update facts
 ------------
 

--- a/docs/howto/index.rst
+++ b/docs/howto/index.rst
@@ -159,3 +159,22 @@ neighbors and in this case init will continue even if no LLDP neighbors were
 detected. This is also very risky since you can't verify that interfaces
 are connected correctly before sending configuration and possibly losing
 connectivity to the device.
+
+.. _switch_replacement:
+
+Replacement of access switch
+----------------------------
+
+To replace a broken switch with a new one, first disconnect the old switch from
+the network and connect the new switch using the same interfaces. Wait for the
+new switch to boot up and reach the DISCOVERED state in NMS device list.
+Change the old switch to state UNMANAGED, and then perform a device_init on the
+new switch and specify the existing hostname and add argument replace_hostname
+with value true.
+
+It's also possible to replace with a switch of another model, as long as the new
+model has the same interface name scheme and at least as many interfaces as the
+old one. Eg replacing a switch with interfaces Ethernet1-24 with a switch with
+interfaces Ethernet1-48 should work, but going From Ethernet1-48 to Ethernet1-24
+or Ethernet1-24 to GigabitEthernet1/0/1-24 you will loose interface
+configurations.

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import datetime
 import json
+from copy import deepcopy
 from typing import Any, List, Optional
 
 from flask import make_response, request
@@ -100,7 +100,14 @@ device_model = device_api.model(
 )
 
 device_init_model = device_init_api.model(
-    "device_init", {"hostname": fields.String(required=False), "device_type": fields.String(required=False)}
+    "device_init",
+    {
+        "hostname": fields.String(required=False),
+        "device_type": fields.String(required=False),
+        "replace_hostname": fields.Boolean(
+            required=False, description="This device id should replace old device with specified hostname"
+        ),
+    },
 )
 
 device_initcheck_model = device_initcheck_api.model(
@@ -327,8 +334,10 @@ class DeviceByIdApi(Resource):
                 name_change_ok = old_settings == new_settings
 
             if is_name_change_request and not name_change_ok:
-                msg = f"Configuration after name change for {current_hostname} would not be the same."\
+                msg = (
+                    f"Configuration after name change for {current_hostname} would not be the same."
                     f" Please check device specific configuration for {current_hostname} and {new_hostname}"
+                )
                 return empty_result(status="error", data=[msg]), 400
 
             errors = dev.device_update(**json_data)
@@ -342,9 +351,9 @@ class DeviceByIdApi(Resource):
                     rebuild_settings_cache()
 
                     # Update interfaces where this device was a neighbor and make the unsynched
-                    interfaces = session.query(Interface).filter(
-                        Interface.data["neighbor"].astext == current_hostname
-                    ).all()
+                    interfaces = (
+                        session.query(Interface).filter(Interface.data["neighbor"].astext == current_hostname).all()
+                    )
                     for intf in interfaces:
                         intf.data["neighbor"] = new_hostname
                         neigh_dev = session.query(Device).filter(Device.id == intf.device_id).one()
@@ -356,7 +365,8 @@ class DeviceByIdApi(Resource):
                     add_sync_event(new_hostname, "device_name_change", by=get_identity())
 
                     logger.info(
-                        f"Updated {len(interfaces)} interfaces from neighbor '{current_hostname}' to '{new_hostname}'")
+                        f"Updated {len(interfaces)} interfaces from neighbor '{current_hostname}' to '{new_hostname}'"
+                    )
 
                 except SettingsSyntaxError as e:
                     msg = "Error in settings repo configuration: {}".format(e)
@@ -571,6 +581,9 @@ class DeviceInitApi(Resource):
                 )
         else:
             parsed_args["neighbors"] = None
+
+        if "replace_hostname" in json_data and json_data["replace_hostname"] is not None:
+            parsed_args["replace_hostname"] = json_data["replace_hostname"]
 
         return parsed_args
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -105,7 +105,9 @@ device_init_model = device_init_api.model(
         "hostname": fields.String(required=False),
         "device_type": fields.String(required=False),
         "replace_hostname": fields.Boolean(
-            required=False, description="This device id should replace old device with specified hostname"
+            required=False,
+            description="This device id should replace old device with specified hostname",
+            default=False,
         ),
     },
 )

--- a/src/cnaas_nms/devicehandler/get.py
+++ b/src/cnaas_nms/devicehandler/get.py
@@ -251,9 +251,16 @@ def get_interfaces_names(hostname: str) -> List[str]:
         return list(getfacts_task.result["interfaces"].keys())
 
 
+def sort_interfaces(name):
+    def toint(text):
+        return int(text) if text.isdigit() else text
+
+    return [toint(c) for c in re.split(r"(\d+)", name)]
+
+
 def filter_interfaces(iflist: List[str], platform=None, include=None) -> List[str]:
     # TODO: include pattern matching from external configurable file
-    ret = []
+    ret: List[str] = []
     junos_phy_r = r"^(ge|xe|et|mge)-([0-9]+\/)+[0-9]+$"
     ios_phy_r = r"^[a-zA-Z]+Ethernet.*"
     iosxr_phy_r = r"^[a-zA-Z]*E(thernet)?[0-9].*"
@@ -271,7 +278,7 @@ def filter_interfaces(iflist: List[str], platform=None, include=None) -> List[st
             else:
                 if intf.startswith("Ethernet"):
                     ret.append(intf)
-    return ret
+    return sorted(ret, key=sort_interfaces)
 
 
 def get_interfacedb_ifs(session, hostname: str) -> List[str]:

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -521,7 +521,8 @@ def init_access_device_step1(
             # update linknets using LLDP data
             linknets_all += update_linknets(session, dev.hostname, DeviceType.ACCESS, dry_run=True)
             linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
-            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
+            if not replace_dev:
+                update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
 
         try:
@@ -562,6 +563,7 @@ def init_access_device_step1(
             session.commit()
             del dev
             dev = replace_dev
+            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             device_id = dev.id
             dev.ztp_mac = new_ztp_mac
             dev.serial = new_serial

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -563,7 +563,6 @@ def init_access_device_step1(
             session.commit()
             del dev
             dev = replace_dev
-            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             device_id = dev.id
             dev.ztp_mac = new_ztp_mac
             dev.serial = new_serial
@@ -581,6 +580,7 @@ def init_access_device_step1(
             if secondary_mgmt_ip:
                 reserved_ip = ReservedIP(device=dev, ip=secondary_mgmt_ip, ip_version=secondary_mgmt_ip.version)
                 session.add(reserved_ip)
+            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             session.commit()
 
         try:

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -418,6 +418,7 @@ def init_access_device_step1(
     mlag_peer_id: Optional[int] = None,
     mlag_peer_new_hostname: Optional[str] = None,
     uplink_hostnames_arg: Optional[List[str]] = [],
+    replace_hostname: Optional[bool] = None,
     job_id: Optional[int] = None,
     scheduled_by: str = "",
 ) -> NornirJobResult:
@@ -457,6 +458,14 @@ def init_access_device_step1(
                 )
             else:
                 raise e
+        # Pre checks for device being replaced
+        if replace_hostname:
+            replace_dev: Optional[Device] = session.query(Device).filter(Device.hostname == new_hostname).one_or_none()
+            if not replace_dev:
+                raise DeviceStateError(f"Device {new_hostname} not found")
+            if replace_dev.state != DeviceState.UNMANAGED:
+                raise DeviceStateError(f"Device {new_hostname} not in UNMANAGED state")
+
         linknets_all = dev.get_linknets_as_dict(session)
         mlag_peer_dev: Optional[Device] = None
 
@@ -549,27 +558,64 @@ def init_access_device_step1(
             session.rollback()
             raise e
 
+        secondary_mgmt_ip = None
+        # old hostname
+        if replace_dev:
+            new_ztp_mac = dev.ztp_mac
+            new_serial = dev.serial
+            new_model = dev.model
+            new_dhcp_ip = dev.dhcp_ip
+            logger.info(
+                f"Replacing device {new_hostname}, "
+                + f"serial: {dev.serial} -> {new_serial}, model: {dev.model} -> {new_model}"
+            )
+            logger.info(
+                f"Replacing device {new_hostname}, " + f"removing device ID {dev.id} and keeping {replace_dev.id}"
+            )
+            session.delete(dev)
+            session.commit()
+            del dev
+            dev = replace_dev
+            device_id = dev.id
+            dev.ztp_mac = new_ztp_mac
+            dev.serial = new_serial
+            dev.model = new_model
+            dev.dhcp_ip = new_dhcp_ip
+            dev.state = DeviceState.DISCOVERED
+            mgmt_ip = dev.management_ip
+            secondary_mgmt_ip = dev.secondary_management_ip
+            dev.management_ip = None
+            dev.secondary_management_ip = None
+            dev.confhash = None
+            if mgmt_ip:
+                reserved_ip = ReservedIP(device=dev, ip=mgmt_ip, ip_version=mgmt_ip.version)
+                session.add(reserved_ip)
+            if secondary_mgmt_ip:
+                reserved_ip = ReservedIP(device=dev, ip=secondary_mgmt_ip, ip_version=secondary_mgmt_ip.version)
+                session.add(reserved_ip)
+            session.commit()
+
         # TODO: check compatability, same dist pair and same ports on dists
         mgmtdomain = cnaas_nms.db.helper.find_mgmtdomain(session, uplink_hostnames)
         if not mgmtdomain:
             raise Exception(
                 "Could not find appropriate management domain for uplink peer devices: {}".format(uplink_hostnames)
             )
-        # Select a new management IP for the device
-        ReservedIP.clean_reservations(session, device=dev)
-        session.commit()
-        mgmt_ip = mgmtdomain.find_free_primary_mgmt_ip(session)
         if not mgmt_ip:
-            raise Exception(
-                "Could not find free primary management IP for management domain {}/{}".format(
-                    mgmtdomain.id, mgmtdomain.description
+            # Select a new management IP for the device
+            ReservedIP.clean_reservations(session, device=dev)
+            session.commit()
+            mgmt_ip = mgmtdomain.find_free_primary_mgmt_ip(session)
+            if not mgmt_ip:
+                raise Exception(
+                    "Could not find free primary management IP for management domain {}/{}".format(
+                        mgmtdomain.id, mgmtdomain.description
+                    )
                 )
-            )
-        reserved_ip = ReservedIP(device=dev, ip=mgmt_ip, ip_version=mgmt_ip.version)
-        session.add(reserved_ip)
+            reserved_ip = ReservedIP(device=dev, ip=mgmt_ip, ip_version=mgmt_ip.version)
+            session.add(reserved_ip)
 
-        secondary_mgmt_ip = None
-        if mgmtdomain.is_dual_stack:
+        if mgmtdomain.is_dual_stack and not secondary_mgmt_ip:
             secondary_mgmt_ip = mgmtdomain.find_free_secondary_mgmt_ip(session)
             if not secondary_mgmt_ip:
                 raise Exception(
@@ -671,13 +717,14 @@ def init_access_device_step1(
 
     # Plugin hook, allocated IP
     try:
-        pmh = PluginManagerHandler()
-        pmh.pm.hook.allocated_ipv4(
-            vrf="mgmt",
-            ipv4_address=str(mgmt_ip),
-            ipv4_network=str(mgmt_gw_ipif.network),
-            hostname=hostname,
-        )
+        if mgmt_ip.version == 4:
+            pmh = PluginManagerHandler()
+            pmh.pm.hook.allocated_ipv4(
+                vrf="mgmt",
+                ipv4_address=str(mgmt_ip),
+                ipv4_network=str(mgmt_gw_ipif.network),
+                hostname=hostname,
+            )
     except Exception as e:
         logger.exception("Error while running plugin hooks for allocated_ipv4: {}".format(str(e)))
 

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -544,20 +544,6 @@ def init_access_device_step1(
             session.rollback()
             raise e
 
-        try:
-            update_linknets(
-                session,
-                dev.hostname,
-                DeviceType.ACCESS,
-                mlag_peer_dev=mlag_peer_dev,
-                dry_run=False,
-            )
-            if mlag_peer_dev:
-                update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=False)
-        except Exception as e:
-            session.rollback()
-            raise e
-
         secondary_mgmt_ip = None
         # old hostname
         if replace_dev:
@@ -567,7 +553,7 @@ def init_access_device_step1(
             new_dhcp_ip = dev.dhcp_ip
             logger.info(
                 f"Replacing device {new_hostname}, "
-                + f"serial: {dev.serial} -> {new_serial}, model: {dev.model} -> {new_model}"
+                + f"serial: {replace_dev.serial} -> {new_serial}, model: {replace_dev.model} -> {new_model}"
             )
             logger.info(
                 f"Replacing device {new_hostname}, " + f"removing device ID {dev.id} and keeping {replace_dev.id}"
@@ -594,6 +580,20 @@ def init_access_device_step1(
                 reserved_ip = ReservedIP(device=dev, ip=secondary_mgmt_ip, ip_version=secondary_mgmt_ip.version)
                 session.add(reserved_ip)
             session.commit()
+
+        try:
+            update_linknets(
+                session,
+                dev.hostname,
+                DeviceType.ACCESS,
+                mlag_peer_dev=mlag_peer_dev,
+                dry_run=False,
+            )
+            if mlag_peer_dev:
+                update_linknets(session, mlag_peer_dev.hostname, DeviceType.ACCESS, dry_run=False)
+        except Exception as e:
+            session.rollback()
+            raise e
 
         # TODO: check compatability, same dist pair and same ports on dists
         mgmtdomain = cnaas_nms.db.helper.find_mgmtdomain(session, uplink_hostnames)

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -521,8 +521,7 @@ def init_access_device_step1(
             # update linknets using LLDP data
             linknets_all += update_linknets(session, dev.hostname, DeviceType.ACCESS, dry_run=True)
             linknets = Linknet.deduplicate_linknet_dicts(linknets_all)
-            if not replace_dev:
-                update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
+            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             uplink_hostnames = dev.get_uplink_peer_hostnames(session)
 
         try:
@@ -552,6 +551,8 @@ def init_access_device_step1(
             new_serial = dev.serial
             new_model = dev.model
             new_dhcp_ip = dev.dhcp_ip
+            ztp_hostname = dev.hostname
+            ztp_device_id = dev.id
             logger.info(
                 f"Replacing device {new_hostname}, "
                 + f"serial: {replace_dev.serial} -> {new_serial}, model: {replace_dev.model} -> {new_model}"
@@ -567,6 +568,7 @@ def init_access_device_step1(
             dev.ztp_mac = new_ztp_mac
             dev.serial = new_serial
             dev.model = new_model
+            dev.hostname = ztp_hostname
             dev.dhcp_ip = new_dhcp_ip
             dev.state = DeviceState.DISCOVERED
             mgmt_ip = dev.management_ip
@@ -580,8 +582,14 @@ def init_access_device_step1(
             if secondary_mgmt_ip:
                 reserved_ip = ReservedIP(device=dev, ip=secondary_mgmt_ip, ip_version=secondary_mgmt_ip.version)
                 session.add(reserved_ip)
-            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
             session.commit()
+            # go through linknets and update neighbor id from ztp device_id to old device_id
+            for linknet in linknets:  # type: ignore
+                if linknet["device_a_id"] == ztp_device_id:
+                    linknet["device_a_id"] = dev.id
+                if linknet["device_b_id"] == ztp_device_id:
+                    linknet["device_b_id"] = dev.id
+            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
 
         try:
             update_linknets(

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -728,11 +728,17 @@ def init_access_device_step1(
     # Plugin hook, allocated IP
     try:
         if mgmt_ip.version == 4:
+            ipv4_addr = mgmt_ip
+            ipv4_net = mgmt_gw_ipif.network
+        elif secondary_mgmt_ip and secondary_mgmt_ip.version == 4:
+            ipv4_addr = secondary_mgmt_ip
+            ipv4_net = secondary_mgmt_gw_ipif.network
+        if ipv4_addr and ipv4_net:
             pmh = PluginManagerHandler()
             pmh.pm.hook.allocated_ipv4(
                 vrf="mgmt",
-                ipv4_address=str(mgmt_ip),
-                ipv4_network=str(mgmt_gw_ipif.network),
+                ipv4_address=str(ipv4_addr),
+                ipv4_network=str(ipv4_net),
                 hostname=hostname,
             )
     except Exception as e:

--- a/src/cnaas_nms/devicehandler/update.py
+++ b/src/cnaas_nms/devicehandler/update.py
@@ -64,6 +64,8 @@ def update_interfacedb_worker(
     if not phy_interfaces:
         raise Exception("Could not find any physical interfaces for device {}".format(dev.hostname))
 
+    log_new_interfaces = []
+    log_updated_interfaces = []
     for intf_name in phy_interfaces:
         intf: Interface = (
             session.query(Interface).filter(Interface.device == dev).filter(Interface.name == intf_name).one_or_none()
@@ -77,7 +79,6 @@ def update_interfacedb_worker(
             intf = Interface()
         if not new_intf and not replace:
             continue
-        logger.debug("New/updated physical interface found on device {}: {}".format(dev.hostname, intf_name))
         if intf_name in uplinks.keys():
             intf.configtype = InterfaceConfigType.ACCESS_UPLINK
             intf.data = {"neighbor": uplinks[intf_name]}
@@ -90,7 +91,18 @@ def update_interfacedb_worker(
         intf.device = dev
         if new_intf:
             session.add(intf)
+            log_new_interfaces.append(intf_name)
+        else:
+            log_updated_interfaces.append(intf_name)
         ret.append(intf.as_dict())
+    if log_new_interfaces:
+        logger.debug(
+            "New physical interfaces found on device {}: {}".format(dev.hostname, ", ".join(log_new_interfaces))
+        )
+    if log_updated_interfaces:
+        logger.debug(
+            "Updated physical interfaces on device {}: {}".format(dev.hostname, ", ".join(log_updated_interfaces))
+        )
 
     # Remove interfaces that no longer exist on device
     for unmatched_intf in unmatched_iflist:
@@ -253,8 +265,8 @@ def update_linknets(
     )
 
     for idx, (local_if, data) in enumerate(neighbors.items()):
-        remote_hostname = data[0]['hostname']
-        remote_if = canonical_interface_name(data[0]['port'])
+        remote_hostname = data[0]["hostname"]
+        remote_if = canonical_interface_name(data[0]["port"])
         logger.debug(f"Local: {local_if}, remote: {remote_hostname} {remote_if}")
         remote_device_inst: Device = session.query(Device).filter(Device.hostname == remote_hostname).one_or_none()
         if not remote_device_inst:


### PR DESCRIPTION
Option to replace a (dead) switch with a new one and keep old device_id, linknets, interface config etc but use new hardware installed via ZTP