### PR TITLE
interfaces_export API 

### DIFF
--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -1,7 +1,8 @@
+import datetime
 from typing import Any, List, Optional
 
-from flask import request
-from flask_restx import Namespace, Resource, fields
+from flask import make_response, request
+from flask_restx import Namespace, Resource, fields, inputs, reqparse
 
 from cnaas_nms.api.generic import empty_result
 from cnaas_nms.db.device import Device
@@ -61,6 +62,11 @@ interfaces_model = api.model(
         "interfaces": fields.Nested(interfacename_model, required=True),
     },
 )
+
+export_parser = reqparse.RequestParser()
+export_parser.add_argument("include_uplinks", type=inputs.boolean, default=False, location="args")
+export_parser.add_argument("include_downlinks", type=inputs.boolean, default=True, location="args")
+export_parser.add_argument("include_descriptions", type=inputs.boolean, default=True, location="args")
 
 
 class InterfaceApi(Resource):
@@ -295,6 +301,40 @@ class InterfaceApi(Resource):
             return empty_result(status="success", data={"updated": data})
 
 
+class InterfaceExportApi(Resource):
+    @login_required
+    @api.expect(export_parser)
+    def get(self, hostname):
+        """Export all interfaces for local download"""
+        args = export_parser.parse_args()
+        result: dict[str, dict] = {"interfaces": {}}
+        with sqla_session() as session:  # type: ignore
+            dev = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+            if not dev:
+                return empty_result("error", "Device not found"), 404
+            intfs = session.query(Interface).filter(Interface.device == dev).all()
+            intf: Interface
+            for intf in intfs:
+                session.expunge(intf)  # don't modify the database
+                if not args["include_uplinks"] and intf.configtype == InterfaceConfigType.ACCESS_UPLINK:
+                    continue
+                if not args["include_downlinks"] and intf.configtype == InterfaceConfigType.ACCESS_DOWNLINK:
+                    continue
+                ifdict = intf.as_dict()
+                del ifdict["name"]
+                del ifdict["device_id"]
+                if not args["include_descriptions"]:
+                    if "data" in ifdict and ifdict["data"] and "description" in ifdict["data"]:
+                        del ifdict["data"]["description"]
+                result["interfaces"][intf.name] = ifdict
+
+        response = make_response(result)
+        response.headers["Content-type"] = "application/json"
+        timestamp_str: str = datetime.datetime.isoformat(datetime.datetime.now(), timespec="seconds")
+        response.headers["Content-Disposition"] = f"attachment; filename={hostname}-interfaces-{timestamp_str}.json"
+        return response
+
+
 class InterfaceStatusApi(Resource):
     @login_required
     def get(self, hostname):
@@ -333,4 +373,5 @@ class InterfaceStatusApi(Resource):
 
 
 api.add_resource(InterfaceApi, "/<string:hostname>/interfaces")
+api.add_resource(InterfaceExportApi, "/<string:hostname>/interfaces_export")
 api.add_resource(InterfaceStatusApi, "/<string:hostname>/interface_status")

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -162,6 +162,59 @@ class DeviceTests(unittest.TestCase):
                 session.delete(updated)
                 session.commit()
 
+    def test_interface_export(self):
+        from cnaas_nms.db.interface import Interface, InterfaceConfigType
+
+        with sqla_session() as session:
+            intf1 = Interface(
+                device_id=self.device_id,
+                name="Ethernet1",
+                configtype=InterfaceConfigType.ACCESS_AUTO,
+                data={"description": "testdesc"},
+            )
+            session.add(intf1)
+            intf2 = Interface(
+                device_id=self.device_id,
+                name="Ethernet2",
+                configtype=InterfaceConfigType.ACCESS_UPLINK,
+                data={"neighbor": "testneigh"},
+            )
+            session.add(intf2)
+            intf3 = Interface(
+                device_id=self.device_id,
+                name="Ethernet3",
+                configtype=InterfaceConfigType.ACCESS_DOWNLINK,
+            )
+            session.add(intf3)
+            session.commit()
+
+            # Make a query with most things excluded
+            response = self.client.get(
+                f"/api/v1.0/device/{self.hostname}/interfaces_export",
+                query_string={"include_downlinks": False, "include_descriptions": False},
+            )
+            # example output: {'interfaces': {'Ethernet1': {'configtype': 'ACCESS_AUTO', 'data': {'description': 'testdesc'}}}}
+            for interface in response.json["interfaces"]:
+                self.assertNotEqual(response.json["interfaces"][interface]["configtype"], "ACCESS_UPLINK")
+            for interface in response.json["interfaces"]:
+                self.assertNotEqual(response.json["interfaces"][interface]["configtype"], "ACCESS_DOWNLINK")
+            for interface in response.json["interfaces"]:
+                self.assertNotIn("description", response.json["interfaces"][interface]["data"])
+
+            # Make a query with everything included
+            response = self.client.get(
+                f"/api/v1.0/device/{self.hostname}/interfaces_export",
+                query_string={"include_uplinks": True},
+            )
+            for interface in response.json["interfaces"]:
+                self.assertIn(interface, ["Ethernet1", "Ethernet2", "Ethernet3"])
+            self.assertIn("description", response.json["interfaces"]["Ethernet1"]["data"])
+
+            session.delete(intf1)
+            session.delete(intf2)
+            session.delete(intf3)
+            session.commit()
+
     def test_rename_device_updates_neighbor(self):
         with sqla_session() as session:
             neighbor_device = Device(


### PR DESCRIPTION
add interfaces_export API that can be used for exporting interface configuration from one device and then possibly imported on another device without modifications