### PR TITLE
Added raise and log jinja functions

### DIFF
--- a/src/cnaas_nms/devicehandler/nornir_helper.py
+++ b/src/cnaas_nms/devicehandler/nornir_helper.py
@@ -14,7 +14,7 @@ from nornir.core.task import AggregatedResult, MultiResult
 
 from cnaas_nms.devicehandler.nornir_plugins.cnaas_inventory import CnaasInventory
 from cnaas_nms.scheduler.jobresult import JobResult
-from cnaas_nms.tools import jinja_filters
+from cnaas_nms.tools import jinja_filters, jinja_functions
 
 
 @dataclass
@@ -39,6 +39,7 @@ def get_jinja_env(path):
         loader=FileSystemLoader(path),
         cache_size=0,
     )
+    jinja_env.globals.update(jinja_functions.FUNCTIONS)
     jinja_env.filters.update(jinja_filters.FILTERS)
     jinja_env.filters.update(jinja2_convenience_function())
     return jinja_env

--- a/src/cnaas_nms/tools/generate_esi.py
+++ b/src/cnaas_nms/tools/generate_esi.py
@@ -61,13 +61,24 @@ def load_jinja_filters():
 
         ret = jinja_filters.FILTERS
     except ModuleNotFoundError as e:
-        print("jinja_filters.py could not be loaded from PYTHONPATH, proceeding without filters: " f"{e}")
+        print(f"jinja_filters.py could not be loaded from PYTHONPATH, proceeding without filters: {e}")
     try:
         from netutils.utils import jinja2_convenience_function
 
         ret = {**ret, **jinja2_convenience_function()}
     except ModuleNotFoundError as e:
-        print("netutils could not be loaded from PYTHONPATH, proceeding without filters: " f"{e}")
+        print(f"netutils could not be loaded from PYTHONPATH, proceeding without filters: {e}")
+    return ret
+
+
+def load_jinja_functions():
+    ret = {}
+    try:
+        import jinja_functions
+
+        ret = jinja_functions.FUNCTIONS
+    except ModuleNotFoundError as e:
+        print(f"jinja_functions.py could not be loaded from PYTHONPATH, proceeding without functions: {e}")
     return ret
 
 
@@ -82,6 +93,8 @@ def render_template(platform, device_type, variables):
     )
     jfilters = load_jinja_filters()
     jinjaenv.filters.update(jfilters)
+    jfunctions = load_jinja_functions()
+    jinjaenv.globals.update(jfunctions)
     template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))
     rendered = template.render(**template_vars)

--- a/src/cnaas_nms/tools/jinja_functions.py
+++ b/src/cnaas_nms/tools/jinja_functions.py
@@ -1,0 +1,68 @@
+"""Jinja functions for use in configuration templates"""
+
+import logging
+from typing import Callable, Optional
+
+from jinja2.exceptions import TemplateError
+
+from cnaas_nms.tools.log import get_logger
+
+# This global dict can be used to update the Jinja environment global functions to include all
+# registered template functions
+FUNCTIONS = {}
+
+
+def template_function(name: Optional[str] = None) -> Callable:
+    """Registers a template function in the FUNCTIONS dict.
+
+    Args:
+        name: Optional alternative name to register the function as
+    """
+
+    def decorator(func):
+        name_ = name if name else func.__name__
+        FUNCTIONS[name_] = func
+        return func
+
+    return decorator
+
+
+@template_function("raise")
+def raise_helper(msg: str) -> None:
+    """
+    Raises TemplateError in templates.
+
+    Args:
+        msg: The exception message.
+
+    Usage:
+        {{ raise("some exception") }}
+    """
+    raise TemplateError(msg)
+
+
+@template_function()
+def log(msg: str, level: str = "INFO", module_override: str = "render_template") -> str:
+    """
+    Log a message in templates.
+
+    Usage:
+        {{ log("some info log") }}
+        {{ log("some specific warning log", "WARNING", "dist_render") }}
+
+    Args:
+        msg: Log message.
+        level: Log level, CRITICAL, ERROR, WARNING, INFO, DEBUG.
+        module_override: Override module in log-message. Defaults to render_template.
+
+    Returns:
+        Empty string, ""
+    """
+    logger = get_logger()
+    lvl: int | None = getattr(logging, str(level).upper(), None)
+    if not lvl or not isinstance(lvl, int):
+        logger.error(f"{level} is not a valid log level, defaulting to INFO.")
+        lvl = logging.INFO
+
+    logger.log(lvl, msg, extra={"module_override": module_override})
+    return ""

--- a/src/cnaas_nms/tools/log.py
+++ b/src/cnaas_nms/tools/log.py
@@ -7,12 +7,20 @@ from cnaas_nms.tools.event import add_event
 
 
 class WebsocketHandler(logging.StreamHandler):
-    def __init__(self):
-        logging.StreamHandler.__init__(self)
-
     def emit(self, record):
+        # Override module if module_override is set
+        record.module = getattr(record, "module_override", record.module)
+
         msg = self.format(record)
         add_event(msg, level=record.levelname)
+
+
+class StdoutHandler(logging.StreamHandler):
+    def emit(self, record):
+        # Override module if module_override is set
+        record.module = getattr(record, "module_override", record.module)
+
+        super().emit(record)
 
 
 def get_logger():
@@ -23,7 +31,7 @@ def get_logger():
                 "[%(asctime)s] %(levelname)s in %(module)s job #{}: %(message)s".format(thread_data.job_id)
             )
             # stdout logging
-            stdout_handler = logging.StreamHandler()
+            stdout_handler = StdoutHandler()
             stdout_handler.setFormatter(formatter)
             logger.addHandler(stdout_handler)
             # websocket logging
@@ -37,7 +45,7 @@ def get_logger():
         if not logger.handlers:
             formatter = logging.Formatter("[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
             # stdout logging
-            stdout_handler = logging.StreamHandler()
+            stdout_handler = StdoutHandler()
             stdout_handler.setFormatter(formatter)
             logger.addHandler(stdout_handler)
             # websocket logging

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -61,13 +61,24 @@ def load_jinja_filters():
 
         ret = jinja_filters.FILTERS
     except ModuleNotFoundError as e:
-        print("jinja_filters.py could not be loaded from PYTHONPATH, proceeding without filters: " f"{e}")
+        print(f"jinja_filters.py could not be loaded from PYTHONPATH, proceeding without filters: {e}")
     try:
         from netutils.utils import jinja2_convenience_function
 
         ret = {**ret, **jinja2_convenience_function()}
     except ModuleNotFoundError as e:
-        print("netutils could not be loaded from PYTHONPATH, proceeding without filters: " f"{e}")
+        print(f"netutils could not be loaded from PYTHONPATH, proceeding without filters: {e}")
+    return ret
+
+
+def load_jinja_functions():
+    ret = {}
+    try:
+        import jinja_functions
+
+        ret = jinja_functions.FUNCTIONS
+    except ModuleNotFoundError as e:
+        print(f"jinja_functions.py could not be loaded from PYTHONPATH, proceeding without functions: {e}")
     return ret
 
 
@@ -82,6 +93,8 @@ def render_template(platform, device_type, variables):
     )
     jfilters = load_jinja_filters()
     jinjaenv.filters.update(jfilters)
+    jfunctions = load_jinja_functions()
+    jinjaenv.globals.update(jfunctions)
     print("Jinja filters added: {}".format([*jfilters]))
     template_vars = {**variables, **get_environment_secrets()}
     template = jinjaenv.get_template(get_entrypoint(platform, device_type))

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -1,0 +1,91 @@
+import unittest
+
+from jinja2 import Environment
+from jinja2.exceptions import TemplateError
+
+from cnaas_nms.tools.jinja_functions import (
+    log,
+    raise_helper,
+)
+
+
+class FailTests(unittest.TestCase):
+    def test_fail_exception(self):
+        with self.assertRaises(TemplateError) as cm:
+            raise_helper("this raises TemplateError")
+        cm.msg == "this raises TemplateError"
+
+    def test_fail_in_jinja(self):
+        env = Environment()
+        env.globals["raise"] = raise_helper
+
+        template = env.from_string('{{ raise("some exception") }}')
+
+        with self.assertRaises(TemplateError) as cm:
+            template.render()
+        cm.msg == "some exception"
+
+
+class LogTests(unittest.TestCase):
+    def test_log_filter(self):
+        with self.assertLogs("cnaas-nms", "INFO") as cm:
+            log("this is a info-log")
+            log("this is also a info-log", "info")
+        assert len(cm.records) == 2
+        assert cm.records[0].msg == "this is a info-log"
+        assert cm.records[0].levelname == "INFO"
+
+        with self.assertLogs("cnaas-nms", "WARNING") as cm:
+            log("this is a warning-log", "WARNING")
+        assert len(cm.records) == 1
+        assert cm.records[0].msg == "this is a warning-log"
+        assert cm.records[0].levelname == "WARNING"
+
+        with self.assertLogs("cnaas-nms", "CRITICAL") as cm:
+            log("this is a critical-log", "CRITICAL")
+        assert len(cm.records) == 1
+        assert cm.records[0].msg == "this is a critical-log"
+        assert cm.records[0].levelname == "CRITICAL"
+
+        with self.assertLogs("cnaas-nms", "ERROR") as cm:
+            log("this is a error-log", "ERROR")
+        assert len(cm.records) == 1
+        assert cm.records[0].msg == "this is a error-log"
+        assert cm.records[0].levelname == "ERROR"
+
+    def test_log_incorrect_level(self):
+        """Sending an invalid level logs with error and info"""
+        with self.assertLogs("cnaas-nms", "INFO") as cm:
+            log("this turns into a info-log", "INVALID_LEVEL")
+        assert len(cm.records) == 2
+        assert cm.records[0].msg == "INVALID_LEVEL is not a valid log level, defaulting to INFO."
+        assert cm.records[0].levelname == "ERROR"
+        assert cm.records[1].msg == "this turns into a info-log"
+        assert cm.records[1].levelname == "INFO"
+
+    def test_log_module_override(self):
+        with self.assertLogs("cnaas-nms", "INFO") as cm:
+            log("this is a custom info-log", module_override="info_log")
+        # module_override is set to info_log.
+        assert cm.records[0].module_override == "info_log"
+        assert cm.records[0].levelname == "INFO"
+
+
+def test_log_in_jinja(caplog):
+    """
+    Test logging within a jinja2 template.
+    Uses pytest so we can use caplog fixture
+    """
+    env = Environment()
+    env.globals["log"] = log
+
+    template = env.from_string('{{ log("test message", "INFO") }}')
+
+    render = template.render()
+
+    assert "test message" in caplog.text
+    assert render == ""
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -25,6 +25,26 @@ class RaiseTests(unittest.TestCase):
             template.render()
         assert cm.exception.message == "some exception"
 
+    def test_raise_in_jinja_if_else(self):
+        """Raise exception only when caught in jinja if/else"""
+        env = Environment(autoescape=True)
+        env.globals["raise"] = raise_helper
+
+        template = env.from_string(
+            """
+                {%- if host == "d1" -%}
+                 {{ raise("d1 is not valid") }}
+                {%- else -%}
+                some text
+                {%- endif -%}
+            """
+        )
+
+        with self.assertRaises(TemplateError) as cm:
+            template.render(host="d1")
+        assert cm.exception.message == "d1 is not valid"
+        assert "some text" == template.render(host="a1")
+
 
 def test_log_info(caplog):
     with caplog.at_level("INFO", logger="cnaas-nms"):
@@ -100,6 +120,29 @@ def test_log_in_jinja(caplog):
 
     assert "test message" in caplog.text
     assert render == ""
+
+
+def test_log_in_jinja_if_else(caplog):
+    """Log only when caught in if/else"""
+    env = Environment(autoescape=True)
+    env.globals["log"] = log
+
+    template = env.from_string(
+        """
+            {%- if host == "d1" -%}
+             {{ log("d1 is not valid") }}
+            {%- else -%}
+            some text
+            {%- endif -%}
+        """
+    )
+
+    render1 = template.render(host="d1")
+    render2 = template.render(host="a1")
+    assert len(caplog.records) == 1
+    assert "d1 is not valid" == caplog.records[0].message
+    assert render1 == ""
+    assert render2 == "some text"
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -13,7 +13,7 @@ class FailTests(unittest.TestCase):
     def test_fail_exception(self):
         with self.assertRaises(TemplateError) as cm:
             raise_helper("this raises TemplateError")
-        cm.msg == "this raises TemplateError"
+        assert cm.exception.message == "this raises TemplateError"
 
     def test_fail_in_jinja(self):
         env = Environment()
@@ -23,7 +23,7 @@ class FailTests(unittest.TestCase):
 
         with self.assertRaises(TemplateError) as cm:
             template.render()
-        cm.msg == "some exception"
+        assert cm.exception.message == "some exception"
 
 
 class LogTests(unittest.TestCase):

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -16,7 +16,7 @@ class FailTests(unittest.TestCase):
         assert cm.exception.message == "this raises TemplateError"
 
     def test_fail_in_jinja(self):
-        env = Environment()
+        env = Environment(autoescape=True)
         env.globals["raise"] = raise_helper
 
         template = env.from_string('{{ raise("some exception") }}')
@@ -76,7 +76,7 @@ def test_log_in_jinja(caplog):
     Test logging within a jinja2 template.
     Uses pytest so we can use caplog fixture
     """
-    env = Environment()
+    env = Environment(autoescape=True)
     env.globals["log"] = log
 
     template = env.from_string('{{ log("test message", "INFO") }}')

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -26,49 +26,64 @@ class FailTests(unittest.TestCase):
         assert cm.exception.message == "some exception"
 
 
-class LogTests(unittest.TestCase):
-    def test_log_filter(self):
-        with self.assertLogs("cnaas-nms", "INFO") as cm:
-            log("this is a info-log")
-            log("this is also a info-log", "info")
-        assert len(cm.records) == 2
-        assert cm.records[0].msg == "this is a info-log"
-        assert cm.records[0].levelname == "INFO"
+def test_log_info(caplog):
+    with caplog.at_level("INFO", logger="cnaas-nms"):
+        log("this is a info-log")
+        log("this is also a info-log", "info")
 
-        with self.assertLogs("cnaas-nms", "WARNING") as cm:
-            log("this is a warning-log", "WARNING")
-        assert len(cm.records) == 1
-        assert cm.records[0].msg == "this is a warning-log"
-        assert cm.records[0].levelname == "WARNING"
+    assert len(caplog.records) == 2
+    assert caplog.records[0].msg == "this is a info-log"
+    assert caplog.records[0].levelname == "INFO"
 
-        with self.assertLogs("cnaas-nms", "CRITICAL") as cm:
-            log("this is a critical-log", "CRITICAL")
-        assert len(cm.records) == 1
-        assert cm.records[0].msg == "this is a critical-log"
-        assert cm.records[0].levelname == "CRITICAL"
 
-        with self.assertLogs("cnaas-nms", "ERROR") as cm:
-            log("this is a error-log", "ERROR")
-        assert len(cm.records) == 1
-        assert cm.records[0].msg == "this is a error-log"
-        assert cm.records[0].levelname == "ERROR"
+def test_log_warning(caplog):
+    with caplog.at_level("WARNING", logger="cnaas-nms"):
+        log("this is a warning-log", "WARNING")
 
-    def test_log_incorrect_level(self):
-        """Sending an invalid level logs with error and info"""
-        with self.assertLogs("cnaas-nms", "INFO") as cm:
-            log("this turns into a info-log", "INVALID_LEVEL")
-        assert len(cm.records) == 2
-        assert cm.records[0].msg == "INVALID_LEVEL is not a valid log level, defaulting to INFO."
-        assert cm.records[0].levelname == "ERROR"
-        assert cm.records[1].msg == "this turns into a info-log"
-        assert cm.records[1].levelname == "INFO"
+    assert len(caplog.records) == 1
+    assert caplog.records[0].msg == "this is a warning-log"
+    assert caplog.records[0].levelname == "WARNING"
 
-    def test_log_module_override(self):
-        with self.assertLogs("cnaas-nms", "INFO") as cm:
-            log("this is a custom info-log", module_override="info_log")
-        # module_override is set to info_log.
-        assert cm.records[0].module_override == "info_log"
-        assert cm.records[0].levelname == "INFO"
+
+def test_log_critical(caplog):
+    with caplog.at_level("CRITICAL", logger="cnaas-nms"):
+        log("this is a critical-log", "CRITICAL")
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].msg == "this is a critical-log"
+    assert caplog.records[0].levelname == "CRITICAL"
+
+
+def test_log_error(caplog):
+    with caplog.at_level("ERROR", logger="cnaas-nms"):
+        log("this is a error-log", "ERROR")
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].msg == "this is a error-log"
+    assert caplog.records[0].levelname == "ERROR"
+
+
+def test_log_incorrect_level(caplog):
+    """Sending an invalid level logs with error and info"""
+    with caplog.at_level("INFO", logger="cnaas-nms"):
+        log("this turns into a info-log", "INVALID_LEVEL")
+
+    # Expect two logs: error + defaulted info
+    assert len(caplog.records) == 2
+    assert caplog.records[0].msg == "INVALID_LEVEL is not a valid log level, defaulting to INFO."
+    assert caplog.records[0].levelname == "ERROR"
+    assert caplog.records[1].msg == "this turns into a info-log"
+    assert caplog.records[1].levelname == "INFO"
+
+
+def test_log_module_override(caplog):
+    with caplog.at_level("INFO", logger="cnaas-nms"):
+        log("this is a custom info-log", module_override="info_log")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert getattr(record, "module_override", None) == "info_log"
+    assert record.levelname == "INFO"
 
 
 def test_log_in_jinja(caplog):

--- a/src/cnaas_nms/tools/tests/test_jinja_functions.py
+++ b/src/cnaas_nms/tools/tests/test_jinja_functions.py
@@ -9,13 +9,13 @@ from cnaas_nms.tools.jinja_functions import (
 )
 
 
-class FailTests(unittest.TestCase):
-    def test_fail_exception(self):
+class RaiseTests(unittest.TestCase):
+    def test_raise_helper(self):
         with self.assertRaises(TemplateError) as cm:
             raise_helper("this raises TemplateError")
         assert cm.exception.message == "this raises TemplateError"
 
-    def test_fail_in_jinja(self):
+    def test_raise_in_jinja(self):
         env = Environment(autoescape=True)
         env.globals["raise"] = raise_helper
 


### PR DESCRIPTION
Work on: #448 

# Features added
- Added two jinja functions, raise and log as separate functions.
- Update logger to be able to send 'module_override' to customize module in log output.

# Functions

## raise
Raises TemplateError with a custom message.
### Usage
```jinja
{{ raise("some exception message") }}
```
### Exception example
```python3
Traceback (most recent call last):
  File "/opt/cnaas/venv/lib/python3.11/site-packages/nornir/core/task.py", line 98, in start
    r = self.task(self, **self.params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cnaas/venv/lib/python3.11/site-packages/nornir_jinja2/plugins/tasks/template_file.py", line 43, in template_file
    text = t.render(host=task.host, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cnaas/venv/lib/python3.11/site-packages/jinja2/environment.py", line 1295, in render
    self.environment.handle_exception()
  File "/opt/cnaas/venv/lib/python3.11/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/opt/cnaas/templates/eos/dist.j2", line 3, in top-level template code
    {% include 'base.j2' %}
  File "/opt/cnaas/templates/eos/base.j2", line 2, in top-level template code
    {{ raise("some exception") }}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/cnaas/venv/cnaas-nms/src/cnaas_nms/tools/jinja_functions.py", line 41, in raise_helper
    raise TemplateError(msg)
jinja2.exceptions.TemplateError: some exception
```

## log
Logs some message with optional log level and module_override to customize log output.

### Usage 
```
{{ log("this is a log from inside a template") }}
{{ log("this is a custom log", "DEBUG", "dist_render") }}
```
Logs this:
```
[2025-11-29 10:07:25,486] INFO in render_template job #2861: this is a log from inside a template
[2025-11-29 10:07:25,516] DEBUG in dist_render job #2861: this is a custom log
```