### PR TITLE
Use an older way of enabling http2 until nginx have been upgraded

### DIFF
--- a/docker/api/config/nginx_app.conf
+++ b/docker/api/config/nginx_app.conf
@@ -1,6 +1,7 @@
 server {
-    listen 1443 ssl;
-    http2 on;
+    listen 1443 ssl http2;
+    # TODO, when upgrading to newer version of nginx
+    # http2 on;
     server_name cnaas;
     client_max_body_size 200M;
 


### PR DESCRIPTION
Uses another compatible way of enabling http2 support on the current nginx version.
Need to do alot of work to make the code and docker container compatible with Debian Trixie and Python 3.13.