### PR TITLE
File-specific pydantic validation

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -71,14 +71,23 @@ override the settings_fields module which defines the allowed setting "fields".
 The settings_fields module uses pydantic to define allowed data types in a model.
 It's possible to just extend the existing model or to redefine it altogether.
 
-Example settingns_fields.py module to extend existing model::
+Example settings_fields.py module to extend existing model
+
+.. code-block:: python3
 
   from typing import List
 
   from cnaas_nms.db import settings_fields as orig_fields
 
-  class f_root(orig_fields.f_root):
+  class f_base_system(orig_fields.f_base_system):
       my_new_field: List[str] = []
+
+Models that can be overridden:
+  - f_access_lists
+  - f_base_system
+  - f_interfaces
+  - f_routing
+  - f_vxlans
 
 Save it as settings_fields.py in src/cnaas_nms/plugins or use environment
 variables to define a custom name: :ref:`configuration_environment_ref`

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -116,7 +116,7 @@ class SettingsModelFilenameApi(Resource):
         if not_valid_keys:
             return empty_result(
                 status="error",
-                data=f"Key{'s' if len(not_valid_keys) > 1 else ''}: '{', '.join(not_valid_keys)}' cannot be used in this file and will be filtered, please move them to the correct settings file.'",
+                data=f"Key{'s' if len(not_valid_keys) > 1 else ''}: '{', '.join(sorted(not_valid_keys))}' cannot be used in this file and will be filtered, please move them to the correct settings file.",
             ), 400
         return validate_json_to_model(json_data)
 

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -10,22 +10,37 @@ from cnaas_nms.db.device import Device, DeviceType
 from cnaas_nms.db.helper import json_dumper
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.settings import (
+    FILE_MODEL_MAP,
     AccessListGenerationError,
     SettingsSyntaxError,
     check_settings_syntax,
-    check_system_access_lists,
+    f_root,
     get_generated_access_lists,
     get_settings,
-    get_settings_root,
 )
 from cnaas_nms.tools.mergedict import merge_dict_origin
 from cnaas_nms.tools.security import login_required
 from cnaas_nms.version import __api_version__
 
-settings_root_model = get_settings_root()
-
-
 api = Namespace("settings", description="Settings", prefix="/api/{}".format(__api_version__))
+
+
+def validate_json_to_model(json_data):
+    """Validate json_data by using check_settings_syntax"""
+    syntax_dict, syntax_dict_origin = merge_dict_origin({}, json_data, {}, "API POST data")
+    try:
+        ret = check_settings_syntax(syntax_dict, syntax_dict_origin)
+        if "access_lists" in syntax_dict:
+            # Try to generate all access_lists and return any errors
+            ret_copy = ret.copy()
+            ret_copy["system_access_lists"] = list(ret_copy.get("access_lists", {}).keys())
+            get_generated_access_lists(platform="eos", settings=ret_copy)
+    except SettingsSyntaxError as e:
+        return empty_result(status="error", data=str(e)), 400
+    except AccessListGenerationError as e:
+        return empty_result(status="error", data=str(e)), 400
+    else:
+        return empty_result(status="success", data=ret)
 
 
 class SettingsApi(Resource):
@@ -67,28 +82,43 @@ class SettingsApi(Resource):
 
 class SettingsModelApi(Resource):
     def get(self):
-        response = make_response(settings_root_model.model_json_schema())
+        response = make_response(f_root.model_json_schema())
         response.headers["Content-Type"] = "application/json"
         return response
 
     def post(self):
         json_data = request.get_json()
-        syntax_dict, syntax_dict_origin = merge_dict_origin({}, json_data, {}, "API POST data")
-        try:
-            ret = check_settings_syntax(syntax_dict, syntax_dict_origin)
-            if "access_lists" in syntax_dict:
-                # Try to generate all access_lists and return any errors
-                ret_copy = ret.copy()
-                ret_copy["system_access_lists"] = list(ret_copy.get("access_lists", {}).keys())
-                get_generated_access_lists(platform="eos", settings=ret_copy)
-            if "access_lists" in syntax_dict and "system_access_lists" in syntax_dict:
-                check_system_access_lists(syntax_dict)
-        except SettingsSyntaxError as e:
-            return empty_result(status="error", data=str(e)), 400
-        except AccessListGenerationError as e:
-            return empty_result(status="error", data=str(e)), 400
-        else:
-            return empty_result(status="success", data=ret)
+        return validate_json_to_model(json_data)
+
+
+class SettingsModelFilenameApi(Resource):
+    def get(
+        self,
+        filename: str,
+    ):
+        f_model = FILE_MODEL_MAP.get(filename)
+        if not f_model:
+            return empty_result(status="error", data=f"Filename: '{filename}' does not map to any model."), 400
+        response = make_response(f_model.model_json_schema())
+        response.headers["Content-Type"] = "application/json"
+        return response
+
+    def post(self, filename: str):
+        json_data = request.get_json()
+        f_model = FILE_MODEL_MAP.get(filename)
+        if not f_model:
+            return empty_result(status="error", data=f"Filename: '{filename}' does not map to any model."), 400
+
+        # Find out if there are any keys not meant to go in this file.
+        filtered_keys = set(f_model.model_construct(**json_data).model_dump(exclude_unset=True).keys())
+        json_data_keys = set(json_data.keys())
+        not_valid_keys = json_data_keys - filtered_keys
+        if not_valid_keys:
+            return empty_result(
+                status="error",
+                data=f"Key{'s' if len(not_valid_keys) > 1 else ''}: '{', '.join(not_valid_keys)}' cannot be used in this file and will be filtered, please move them to the correct settings file.'",
+            ), 400
+        return validate_json_to_model(json_data)
 
 
 class SettingsServerApI(Resource):
@@ -102,4 +132,5 @@ class SettingsServerApI(Resource):
 
 api.add_resource(SettingsApi, "")
 api.add_resource(SettingsModelApi, "/model")
+api.add_resource(SettingsModelFilenameApi, "/model/<string:filename>")
 api.add_resource(SettingsServerApI, "/server")

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -7,6 +7,7 @@ from flask.testing import FlaskClient
 
 from cnaas_nms.api import app
 from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
+from cnaas_nms.db.settings import FILE_MODEL_MAP
 
 
 @pytest.fixture
@@ -35,28 +36,6 @@ def test_valid_setting(testclient: FlaskClient):
     assert result.status_code == 200
 
 
-@pytest.mark.integration
-def test_invalid_system_access_list_setting(testclient: FlaskClient):
-    # System ACL not in access_lists.
-    settings_data = {
-        "system_access_lists": ["ACLTEST2"],
-        "access_lists": {"ACLTEST": {"terms": [{"name": "term_name", "action": "accept"}]}},
-    }
-    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
-    assert result.status_code == 400
-
-
-@pytest.mark.integration
-def test_valid_system_access_list_setting(testclient: FlaskClient):
-    # System ACL in access_lists.
-    settings_data = {
-        "system_access_lists": ["ACLTEST"],
-        "access_lists": {"ACLTEST": {"terms": [{"name": "term_name", "action": "accept"}]}},
-    }
-    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
-    assert result.status_code == 200
-
-
 def test_invalid_access_list_setting(testclient: FlaskClient):
     settings_data = {
         "access_lists": {"ACLTEST": {"terms": [{"action": "accept"}]}},
@@ -79,6 +58,35 @@ def test_settings_model(testclient: FlaskClient):
     assert result.status_code == 200
     assert result.content_type == "application/json"
     assert "$defs" in result.json
+
+
+def test_settings_model_name_good_filenames(testclient: FlaskClient):
+    for filename in FILE_MODEL_MAP.keys():
+        result = testclient.get(f"/api/v1.0/settings/model/{filename}")
+        assert result.status_code == 200
+        assert result.content_type == "application/json"
+        assert "$defs" in result.json
+
+
+def test_settings_model_name_bad_filename(testclient: FlaskClient):
+    result = testclient.get("/api/v1.0/settings/model/some_other_file.yml")
+    assert result.status_code == 400
+    assert result.content_type == "application/json"
+
+
+def test_settings_model_base_system_valid_setting(testclient: FlaskClient):
+    settings_data = {"ntp_servers": [{"host": "10.0.0.50"}]}  # noqa: S1313
+    result = testclient.post("/api/v1.0/settings/model/base_system.yml", json=settings_data)
+    assert result.status_code == 200
+
+
+def test_settings_model_base_system_invalid_setting(testclient: FlaskClient):
+    settings_data = {
+        "ntp_server": [{"host": "10.0.0.50"}],  # noqa: S1313
+        "some_other_invalid_setting": [{"a": "b"}],
+    }
+    result = testclient.post("/api/v1.0/settings/model/base_system.yml", json=settings_data)
+    assert result.status_code == 400
 
 
 def test_settings_server(testclient: FlaskClient):

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -5,7 +5,7 @@ import os
 import re
 import types
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union, overload
 
 import yaml
 from absl import logging as absl_logging
@@ -15,7 +15,7 @@ from aerleon.lib import naming
 from aerleon.lib.policy_builder import PolicyDict, PolicyFilter, PolicyFilterTermsOnly, TermsList
 from aerleon.lib.yaml import PolicyTypeError
 from netutils.lib_mapper import AERLEON_LIB_MAPPER_REVERSE, NAPALM_LIB_MAPPER
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from redis import StrictRedis
 from redis_lru import RedisLRU
 from sqlalchemy import inspect
@@ -26,28 +26,80 @@ from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.git_worktrees import refresh_templates_worktree
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.db.session import redis_session, sqla_session
-from cnaas_nms.db.settings_fields import f_access_list, f_group, f_group_device_filter, f_groups
+from cnaas_nms.db.settings_fields import (
+    f_access_list,
+    f_group,
+    f_group_device_filter,
+    f_groups,
+)
+from cnaas_nms.db.settings_fields import (
+    f_access_lists as f_access_lists_model,
+)
+from cnaas_nms.db.settings_fields import (
+    f_base_system as f_base_system_model,
+)
+from cnaas_nms.db.settings_fields import (
+    f_interfaces as f_interfaces_model,
+)
+from cnaas_nms.db.settings_fields import (
+    f_routing as f_routing_model,
+)
+from cnaas_nms.db.settings_fields import f_vxlans as f_vxlans_model
 from cnaas_nms.tools.log import CaptureHandler, get_logger
 from cnaas_nms.tools.mergedict import merge_dict_origin
 
 
-def get_settings_root():
+@overload
+def get_settings_model(model: Literal["f_access_lists"]) -> type[f_access_lists_model]: ...
+@overload
+def get_settings_model(model: Literal["f_base_system"]) -> type[f_base_system_model]: ...
+@overload
+def get_settings_model(model: Literal["f_interfaces"]) -> type[f_interfaces_model]: ...
+@overload
+def get_settings_model(model: Literal["f_routing"]) -> type[f_routing_model]: ...
+@overload
+def get_settings_model(model: Literal["f_vxlans"]) -> type[f_vxlans_model]: ...
+def get_settings_model(
+    model: str,
+) -> type[BaseModel]:
     logger = get_logger()
+
+    valid_models = ["f_access_lists", "f_base_system", "f_interfaces", "f_routing", "f_vxlans"]
+
+    if model not in valid_models:
+        logger.error(f"Model: '{model}' is not valid, valid options: {valid_models}")
+        raise ModuleNotFoundError(name=model)
+
     try:
         settings_fields_path = os.getenv("PLUGIN_SETTINGS_FIELDS_MODULE", "cnaas_nms.plugins.settings_fields")
         settings_fields = importlib.import_module(settings_fields_path)
-        f_root_ret = settings_fields.f_root
+        f_setting_ret = getattr(settings_fields, model)
         logger.debug("Loaded settings_fields module from plugin: {}".format(settings_fields_path))
     except ModuleNotFoundError:
-        f_root_ret = importlib.import_module("cnaas_nms.db.settings_fields").f_root
+        f_setting_ret = getattr(importlib.import_module("cnaas_nms.db.settings_fields"), model)
         logger.debug("Loaded settings_fields module from bundled cnaas-nms")
     except Exception as e:
         logger.error("Unable to load plugin module for settings_fields: {}".format(e))
-        f_root_ret = importlib.import_module("cnaas_nms.db.settings_fields").f_root
-    return f_root_ret
+        f_setting_ret = getattr(importlib.import_module("cnaas_nms.db.settings_fields"), model)
+    return f_setting_ret
 
 
-f_root = get_settings_root()
+f_access_lists = get_settings_model("f_access_lists")
+f_base_system = get_settings_model("f_base_system")
+f_interfaces = get_settings_model("f_interfaces")
+f_routing = get_settings_model("f_routing")
+f_vxlans = get_settings_model("f_vxlans")
+
+
+class f_root(
+    f_access_lists,  # type: ignore
+    f_base_system,  # type: ignore
+    f_interfaces,  # type: ignore
+    f_routing,  # type: ignore
+    f_vxlans,  # type: ignore
+):
+    pass
+
 
 redis_client = StrictRedis(
     host=app_settings.REDIS_HOSTNAME,
@@ -136,6 +188,15 @@ DIR_STRUCTURE: dict[str, Any] = {
     "access": {"base_system.yml": "file"},
     "devices": {Device: DIR_STRUCTURE_HOST},
     "groups": {"group": DIR_STRUCTURE_HOST},
+}
+
+FILE_MODEL_MAP: dict[str, type[BaseModel]] = {
+    "access_lists.yml": f_access_lists,
+    "base_system.yml": f_base_system,
+    "groups.yml": f_groups,
+    "interfaces.yml": f_interfaces,
+    "routing.yml": f_routing,
+    "vxlans.yml": f_vxlans,
 }
 
 MODEL_IF_REGEX = re.compile(r"^interfaces_(.*)\.yml$")
@@ -548,14 +609,28 @@ def read_settings(
         merged_settings, merged_settings_origin
     """
     logger = get_logger()
-    filename = get_setting_filename(local_repo_path, path)
-    yamldata = read_settings_file(filename)
+    filepath = get_setting_filename(local_repo_path, path)
+    filename = path[-1]
+    yamldata = read_settings_file(filepath)
     if not yamldata:
         return merged_settings, merged_settings_origin
     elif not isinstance(yamldata, dict):
-        logger.info("Invalid yaml file ignored: {}".format(filename))
+        logger.info("Invalid yaml file ignored: {}".format(filepath))
         return merged_settings, merged_settings_origin
-    settings_from_file: dict = yamldata
+    # Filter yamldata with the associated pydantic model and log any fields not meant in this file.
+    # Defaults to f_root if the filename does not map to any specific model.
+    f_model = FILE_MODEL_MAP.get(filename, f_root)
+    # Check if there is any fields not meant to go in this file.
+    for key in yamldata:
+        if key not in f_model.model_fields:
+            logger.error(
+                f"""Key '{key}' in file: '{filename}' is not a valid key for this file.
+                Valid keys are: {", ".join(f_model.model_fields.keys())}.
+                This key will be ignored, please move this setting to the correct file.
+                """
+            )
+    # Filter dict
+    settings_from_file: dict = f_model.model_construct(**yamldata).model_dump(exclude_unset=True)
     if groups or hostname:
         syntax_dict, syntax_dict_origin = merge_dict_origin({}, settings_from_file, {}, origin)
         check_settings_syntax(syntax_dict, syntax_dict_origin)

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -68,7 +68,7 @@ def get_settings_model(
 
     if model not in valid_models:
         logger.error(f"Model: '{model}' is not valid, valid options: {valid_models}")
-        raise ModuleNotFoundError(name=model)
+        raise ValueError(f"Invalid model '{model}'. Valid options are: {valid_models}")
 
     try:
         settings_fields_path = os.getenv("PLUGIN_SETTINGS_FIELDS_MODULE", "cnaas_nms.plugins.settings_fields")

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -621,14 +621,16 @@ def read_settings(
     # Defaults to f_root if the filename does not map to any specific model.
     f_model = FILE_MODEL_MAP.get(filename, f_root)
     # Check if there is any fields not meant to go in this file.
-    for key in yamldata:
-        if key not in f_model.model_fields:
-            logger.error(
-                f"""Key '{key}' in file: '{filename}' is not a valid key for this file.
-                Valid keys are: {", ".join(f_model.model_fields.keys())}.
-                This key will be ignored, please move this setting to the correct file.
-                """
-            )
+    invalid_keys = [key for key in yamldata if key not in f_model.model_fields]
+    if invalid_keys:
+        logger.error(
+            "Invalid key(s) %s in settings file '%s' (path '%s'). Valid keys: %s. "
+            "These keys will be ignored; please move these settings to the correct file.",
+            ", ".join(sorted(invalid_keys)),
+            filename,
+            filepath,
+            ", ".join(sorted(f_model.model_fields.keys())),
+        )
     # Filter dict
     settings_from_file: dict = f_model.model_construct(**yamldata).model_dump(exclude_unset=True)
     if groups or hostname:

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -504,77 +504,6 @@ class f_access_list(BaseModel):
 f_access_list.model_rebuild()
 
 
-class f_root(BaseModel):
-    ntp_servers: List[f_ntp_server] = []
-    radius_servers: List[f_radius_server] = []
-    syslog_servers: List[f_syslog_server] = []
-    snmp_servers: List[f_snmp_server] = []
-    dns_servers: List[f_dns_server] = []
-    flow_collectors: List[f_flow_collector] = []
-    dhcp_relays: Optional[List[f_dhcp_relay]] = None
-    interfaces: List[f_interface] = []
-    vrfs: List[f_vrf] = []
-    vxlans: Dict[str, f_vxlan] = {}
-    underlay: Optional[f_underlay] = None
-    evpn_peers: List[f_evpn_peer] = []
-    extroute_static: Optional[f_extroute_static] = None
-    extroute_ospfv3: Optional[f_extroute_ospfv3] = None
-    extroute_bgp: Optional[f_extroute_bgp] = None
-    internal_vlans: Optional[f_internal_vlans] = None
-    dot1x_fail_vlan: Optional[int] = vlan_id_schema_optional
-    cli_prepend_str: str = ""
-    cli_append_str: str = ""
-    organization_name: str = ""
-    domain_name: Optional[str] = domain_name_schema
-    users: List[f_user] = []
-    dot1x_multi_host: bool = False
-    poe_reboot_maintain: bool = False
-    prefix_sets: Dict[str, f_prefixset] = {}
-    routing_policies: Dict[str, f_routingpolicy] = {}
-    external_routing_policies: List[str] = []
-    interface_tag_options: Dict[str, f_interface_tag] = {}
-    port_template_options: Dict[str, f_port_template] = {}
-    vxlan_vni_range: Optional[Annotated[str, AfterValidator(vni_range_required_check)]] = None
-    arista_models_32bit: Optional[List[str]] = None
-    upgrade_post_waittime: Dict[str, int] = {"default": 600}
-    network_definitions: Dict[str, List[Union[f_network_definition | f_network_definition_include]]] = {}
-    service_definitions: Dict[str, List[Union[f_service_definition | f_service_definition_include]]] = {}
-    access_lists: Dict[access_list_name, f_access_list] = {}
-    system_access_lists: List[access_list_name] = []
-
-    @field_validator("access_lists", mode="after")
-    @classmethod
-    def validate_access_lists_includes(
-        cls, access_lists: Dict[access_list_name, f_access_list]
-    ) -> Dict[access_list_name, f_access_list]:
-        """Raise an error if some term include is not pointing to a valid access_list"""
-        acl_names = access_lists.keys()
-        for access_list in access_lists.values():
-            for term in access_list.terms:
-                include_acl = term.get("include")
-                if include_acl and include_acl not in acl_names:
-                    raise ValueError(f"Included access-list: {include_acl} must be defined.")
-        return access_lists
-
-    @field_validator("access_lists", mode="after")
-    @classmethod
-    def validate_access_lists_included_terms(
-        cls, access_lists: Dict[access_list_name, f_access_list]
-    ) -> Dict[access_list_name, f_access_list]:
-        """Validates an access-list + included access-lists have unique term-names"""
-        for access_list in access_lists.values():
-            all_term_names = [t.get("name") for t in access_list.terms if t.get("name")]
-            for term in access_list.terms:
-                include_acl = term.get("include")
-
-                if include_acl and isinstance(include_acl, str):
-                    all_term_names.extend([t.get("name") for t in access_lists[include_acl].terms if t.get("name")])
-
-            if len(all_term_names) != len(set(all_term_names)):
-                raise ValueError("All term names in an access-list + included access-lists must be unique.")
-        return access_lists
-
-
 class f_group_device_filter(BaseModel):
     hostname: Optional[str] = None
     device_type: Optional[str] = None
@@ -711,3 +640,89 @@ def validate_groups(groups: List[f_group]):
 
 class f_groups(BaseModel):
     groups: Annotated[Optional[List[f_group]], AfterValidator(validate_groups)] = None
+
+
+class f_access_lists(BaseModel):
+    network_definitions: Dict[str, List[Union[f_network_definition | f_network_definition_include]]] = {}
+    service_definitions: Dict[str, List[Union[f_service_definition | f_service_definition_include]]] = {}
+    access_lists: Dict[access_list_name, f_access_list] = {}
+
+    @field_validator("access_lists", mode="after")
+    @classmethod
+    def validate_access_lists_includes(
+        cls, access_lists: Dict[access_list_name, f_access_list]
+    ) -> Dict[access_list_name, f_access_list]:
+        """Raise an error if some term include is not pointing to a valid access_list"""
+        acl_names = access_lists.keys()
+        for access_list in access_lists.values():
+            for term in access_list.terms:
+                include_acl = term.get("include")
+                if include_acl and include_acl not in acl_names:
+                    raise ValueError(f"Included access-list: {include_acl} must be defined.")
+        return access_lists
+
+    @field_validator("access_lists", mode="after")
+    @classmethod
+    def validate_access_lists_included_terms(
+        cls, access_lists: Dict[access_list_name, f_access_list]
+    ) -> Dict[access_list_name, f_access_list]:
+        """Validates an access-list + included access-lists have unique term-names"""
+        for access_list in access_lists.values():
+            all_term_names = [t.get("name") for t in access_list.terms if t.get("name")]
+            for term in access_list.terms:
+                include_acl = term.get("include")
+
+                if include_acl and isinstance(include_acl, str):
+                    all_term_names.extend([t.get("name") for t in access_lists[include_acl].terms if t.get("name")])
+
+            if len(all_term_names) != len(set(all_term_names)):
+                raise ValueError("All term names in an access-list + included access-lists must be unique.")
+        return access_lists
+
+
+class f_base_system(BaseModel):
+    ntp_servers: List[f_ntp_server] = []
+    radius_servers: List[f_radius_server] = []
+    syslog_servers: List[f_syslog_server] = []
+    snmp_servers: List[f_snmp_server] = []
+    dns_servers: List[f_dns_server] = []
+    flow_collectors: List[f_flow_collector] = []
+    dhcp_relays: Optional[List[f_dhcp_relay]] = None
+    internal_vlans: Optional[f_internal_vlans] = None
+    dot1x_fail_vlan: Optional[int] = vlan_id_schema_optional
+    cli_prepend_str: str = ""
+    cli_append_str: str = ""
+    organization_name: str = ""
+    domain_name: Optional[str] = domain_name_schema
+    users: List[f_user] = []
+    dot1x_multi_host: bool = False
+    poe_reboot_maintain: bool = False
+    interface_tag_options: Dict[str, f_interface_tag] = {}
+    port_template_options: Dict[str, f_port_template] = {}
+    vxlan_vni_range: Optional[Annotated[str, AfterValidator(vni_range_required_check)]] = None
+    arista_models_32bit: Optional[List[str]] = None
+    upgrade_post_waittime: Dict[str, int] = {"default": 600}
+    system_access_lists: List[access_list_name] = []
+    # This is defined both in f_base_system and f_routing
+    external_routing_policies: List[str] = []
+
+
+class f_interfaces(BaseModel):
+    interfaces: List[f_interface] = []
+
+
+class f_routing(BaseModel):
+    vrfs: List[f_vrf] = []
+    underlay: Optional[f_underlay] = None
+    evpn_peers: List[f_evpn_peer] = []
+    extroute_static: Optional[f_extroute_static] = None
+    extroute_ospfv3: Optional[f_extroute_ospfv3] = None
+    extroute_bgp: Optional[f_extroute_bgp] = None
+    prefix_sets: Dict[str, f_prefixset] = {}
+    routing_policies: Dict[str, f_routingpolicy] = {}
+    # This is defined both in f_base_system and f_routing
+    external_routing_policies: List[str] = []
+
+
+class f_vxlans(BaseModel):
+    vxlans: Dict[str, f_vxlan] = {}

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -19,6 +19,7 @@ from cnaas_nms.db.settings import (
     check_bgp_neighbor_routemaps,
     check_system_access_lists,
     check_vlan_collisions,
+    f_root,
     get_device_primary_groups,
     get_generated_access_lists,
     get_group_settings,
@@ -27,7 +28,7 @@ from cnaas_nms.db.settings import (
     rebuild_settings_cache,
     verify_dir_structure,
 )
-from cnaas_nms.db.settings_fields import f_group, f_groups, f_root
+from cnaas_nms.db.settings_fields import f_group, f_groups
 
 
 class SettingsTests(unittest.TestCase):


### PR DESCRIPTION
## Whats done
Separated f_root into individual models each pointing to its own file in the settings repo.
Added validation that each file only contains keys found in the associated pydantic model.
Added SettingsModelNameApi for validating specific files.
Added/Updated tests.

### New API endpoint
The new api endpoint makes it possible providing code completions using a json_schema specific to files.
Add this to your settings-repository to enable.
.vscode/settings.json
```json
{
    "yaml.schemas": {
        "https://cnaas-nms/api/v1.0/settings/model/access_lists.yml": "global/access_lists.yml",
        "https://cnaas-nms/api/v1.0/settings/model/base_system.yml": "**/base_system.yml",
        "https://cnaas-nms/api/v1.0/settings/model/groups.yml": "global/groups.yml",
        "https://cnaas-nms/api/v1.0/settings/model/interfaces.yml": "**/interfaces.yml",
        "https://cnaas-nms/api/v1.0/settings/model/routing.yml": "**/routing.yml",
        "https://cnaas-nms/api/v1.0/settings/model/vxlans.yml": "global/vxlans.yml",
    }
}
```

## Breaking changes
Breaks any f_root override-plugins.
Plugins need to be remade to point to the correct pydantic model so validation still works.
Otherwise the custom keys will be filtered away for that specific file.

If for example a plugin extended something in the file: base_system.yml it now needs to extend f_base_system instead of f_root.

Breaks current settings repositories where keys are misplaced between files. Should be easy enough to move them to the correct place.