### PR TITLE
Update aerleon version

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -296,7 +296,7 @@ Access list examples
       terms:
        - name: "allow-all-established"
          protocol: [tcp, udp]
-         option: ["established"]
+         option: "established"
          action: "accept"
 
 groups.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dynamic = [ "version" ]
 [dependency-groups]
 # dependencies are listed as a dependency-group since cnaas-nms itself is NOT a package
 dependencies = [
-  "aerleon==1.13.0",
+  "aerleon==1.14.1",
   "alembic==1.15.2",
   "apscheduler==3.11",
   "async-timeout>=4.0.2",

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -369,6 +369,38 @@ class SettingsTests(unittest.TestCase):
             device = Device(hostname=self.testdata["testdevice"], platform=platform)
             get_generated_access_lists(device)
 
+    def test_acl_option(self):
+        """Test validate and generate access list option"""
+        settings = {
+            "access_lists": {
+                "TEST_ACL_ESTABLISHED": {
+                    "terms": [
+                        {
+                            "name": "permit-established",
+                            "protocol": ["tcp", "udp"],
+                            "option": "established",
+                            "action": "accept",
+                        }
+                    ]
+                },
+                "TEST_ACL_TCP_ESTABLISHED": {
+                    "terms": [
+                        {
+                            "name": "permit-tcp-established",
+                            "protocol": ["tcp"],
+                            "option": "tcp-established",
+                            "action": "accept",
+                        }
+                    ]
+                },
+            },
+            "system_access_lists": ["TEST_ACL_ESTABLISHED", "TEST_ACL_TCP_ESTABLISHED"],
+        }
+        # Validate and generate
+        f_root(**settings)
+        acls = get_generated_access_lists(platform="eos", settings=settings)
+        self.assertEqual(len(acls.keys()), 2)
+
     def test_acl_invalid_definition(self):
         """Test invalid network definitions"""
         settings = {


### PR DESCRIPTION
New version of Aerleon that fixes some types and a CVE found in a dependency for the aerleon package, https://github.com/aerleon/aerleon/releases/tag/1.14.1.
Fixes validating option. Can now be `str | list[str]`.
Added a simple test validating option syntax.