### PR TITLE
Bugfix reuse ztp mac

### DIFF
--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -1011,6 +1011,7 @@ def init_device_step2(
         set_facts(dev, facts)
         management_ip = dev.management_ip
         dev.dhcp_ip = None
+        dev.ztp_mac = None
         dev.last_seen = datetime.datetime.utcnow()  # type: ignore
 
     # Plugin hook: new managed device

--- a/src/cnaas_nms/tools/dhcp_hook.py
+++ b/src/cnaas_nms/tools/dhcp_hook.py
@@ -139,7 +139,7 @@ def main() -> Optional[int]:
                     )
             else:
                 data = {"ztp_mac": None}
-                r = requests.post(
+                r = requests.put(
                     f"{base_url}/api/v1.0/device/{dev_id}",
                     json=data,
                     verify=verify_tls,

--- a/src/cnaas_nms/tools/dhcp_hook.py
+++ b/src/cnaas_nms/tools/dhcp_hook.py
@@ -138,9 +138,18 @@ def main() -> Optional[int]:
                         )
                     )
             else:
-                logger.error(
-                    "Device with ztp_mac {} in state {} unexpectedly booted via DHCP ({})".format(
-                        ztp_mac, dev_dict["state"], dhcp_ip
+                data = {"ztp_mac": None}
+                r = requests.post(
+                    f"{base_url}/api/v1.0/device/{dev_id}",
+                    json=data,
+                    verify=verify_tls,
+                    headers={"Authorization": "Bearer " + token},
+                )
+
+                logger.info(
+                    ("Device with ztp_mac {} booted via DHCP, MAC previously belonged to device {}, "
+                    "unassigning MAC from old device (status {})").format(
+                        ztp_mac, dev_dict["hostname"], r.status_code
                     )
                 )
 


### PR DESCRIPTION
don't store ztp_mac after device finished initialization, it can cause problems if trying to reuse hardware after a device replacement