### PR TITLE
Dependency cleanup

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,35 @@
+name: Build documentation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docs:
+    name: Build Sphinx docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install --group docs
+
+      - name: Build docs
+        run: |
+          cd docs
+          make html
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build/html/
+          retention-days: 7

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,13 +10,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_create_environment:
+      # pip 25.1+ required for --group flag (PEP 735)
+      - pip install --upgrade pip
+      - pip install --group docs
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
-# We recommend specifying your dependencies to enable reproducible builds:
-# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -18,26 +18,23 @@ Planned features:
 
 ## Dependencies
 
-Dependencies are specified in `[dependency-groups]` in _pyproject.toml_. The are currently three groups:
-
-- `dependencies`
-- `dev`
-- `docs`
-
-Dependencies from each group can be installed with:
+Runtime dependencies are specified in `[project].dependencies` in _pyproject.toml_.
+Development dependencies are in `[dependency-groups]` with two groups: `dev` and `docs`.
 
 ```sh
-pip install --group <group>
+pip install .             # runtime dependencies
+pip install --group dev   # test/lint tools (pytest, mypy, ruff, etc.)
+pip install --group docs  # documentation tools (sphinx)
 ```
 
-**Note**: requires pip 25.1 or later.
+**Note**: `--group` requires pip 25.1 or later.
 
 ## Requirements
 
 Docker and docker compose or:
 
-1. Python 3.11 or later
-2. `pip install --group dependencies` (requires pip 25.1 or later)
+1. python3.11 or later
+2. `pip install .` (and `pip install --group dev` for development)
 3. SQL database, Redis
 
 ## Installation
@@ -50,8 +47,8 @@ Install docker with docker compose and run: `docker compose -f docker/docker-com
 
 Install locally by creating a virtualenv and activate the environment, then:
 
-```sh
-python3 -m pip install --group dependencies
+```
+python3 -m pip install .
 cp etc/db_config.yml.sample /etc/cnaas-nms/db_config.yml
 ```
 

--- a/docker/api/cnaas-setup.sh
+++ b/docker/api/cnaas-setup.sh
@@ -27,7 +27,8 @@ python3 -m pip install --no-cache-dir uwsgi
 python3 -m pip install --no-cache-dir uwsgi gevent
 # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
 python3 -m pip install "cython<3.0.0" wheel && python3 -m pip install --no-build-isolation pyyaml==6.0
-python3 -m pip install --no-cache-dir --group dependencies
+python3 -m pip install --no-cache-dir .
+python3 -m pip install --no-cache-dir --group dev
 
 # Temp bugfix for napalm issue #2166
 cd /opt/cnaas/venv/lib/python3.11/site-packages

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-Sphinx==3.3.1
-docutils<0.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ dev = [
   "types-pytz==2025.2.0.20250326",
   "types-requests==2.32.0.20250328",
 ]
+docs = [
+  "sphinx==3.3.1",
+  "docutils<0.18",
+]
 
 [project.readme]
 file = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,16 +17,12 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dynamic = [ "version" ]
-
-[dependency-groups]
-# dependencies are listed as a dependency-group since cnaas-nms itself is NOT a package
 dependencies = [
   "aerleon==1.14.1",
   "alembic==1.15.2",
   "apscheduler==3.11",
   "async-timeout>=4.0.2",
   "authlib==1.6.4",
-  "coverage==7.8",
   "flask==3.1",
   "flask-cors==6.0.0",
   "flask-jwt-extended==4.7.1",
@@ -36,8 +32,6 @@ dependencies = [
   "gitpython==3.1.44",
   "greenlet==3.2.1",
   "markupsafe==3.0.2",
-  "mypy==1.15",
-  "mypy-extensions==1.1",
   "napalm==5.0",
   "netmiko==4.5",
   "nornir==3.5",
@@ -45,39 +39,36 @@ dependencies = [
   "nornir-napalm==0.5",
   "nornir-netmiko==1.0.1",
   "nornir-utils==0.2",
-  "nose==1.3.7",
   "pluggy==1.5",
   "portalocker==3.1.1",
   "psycopg2-binary==2.9.10",
   "pydantic==2.11.3",
   "pydantic-settings==2.9.1",
-  "pytest==8.3.5",
-  "pytest-cov==6.1.1",
-  "pytest-docker==3.2.2",
-  "pytest-env==1.1.5",
   "python-jose==3.4",
   "pytz==2025.2",
   "pyyaml==6.0.3",
   "redis==5.2.1",
   "redis-lru==0.1",
   "requests==2.32.3",
-  "sphinx==8.2.3",
   "sqlalchemy==2.0.40",
   "sqlalchemy-utils==0.41.2",
-  "types-pytz==2025.2.0.20250326",
-  "types-requests==2.32.0.20250328",
   "werkzeug==3.1.3",
 ]
+
+[dependency-groups]
 dev = [
-  "pytest >=8.1.1,<9",
-  "ruff",
+  "coverage==7.8",
+  "mypy==1.15",
+  "mypy-extensions==1.1",
+  "nose==1.3.7",
   "pre-commit",
-  "mypy",
-  "mypy-extensions",
-]
-docs = [
-  "Sphinx==3.3.1",
-  "docutils<0.18",
+  "pytest==8.3.5",
+  "pytest-cov==6.1.1",
+  "pytest-docker==3.2.2",
+  "pytest-env==1.1.5",
+  "ruff",
+  "types-pytz==2025.2.0.20250326",
+  "types-requests==2.32.0.20250328",
 ]
 
 [project.readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,7 @@ dev = [
   "types-requests==2.32.0.20250328",
 ]
 docs = [
-  "sphinx==3.3.1",
-  "docutils<0.18",
+  "sphinx==7.4.7",
 ]
 
 [project.readme]


### PR DESCRIPTION
- Remove duplicate dependencies in `pyproject.toml`
- Move dependencies into the right groups
- Bump sphinx and add a workflow to validate it still works after the bump
