### PR TITLE
feat: enhance Swagger UI auth with validation and persistence

### DIFF
--- a/docker/api/swaggeruirequestintercept.patch
+++ b/docker/api/swaggeruirequestintercept.patch
@@ -4,10 +4,10 @@
                  {%- endif %}
                  validatorUrl: "{{ config.SWAGGER_VALIDATOR_URL }}" || null,
                  dom_id: "#swagger-ui",
-+                // Auto-add Bearer token from localStorage if not already set
++                // Auto-add Bearer token from sessionStorage if not already set
 +                requestInterceptor: (req) => {
 +                    if (!('Authorization' in req.headers)) {
-+                        const token = localStorage.getItem('token');
++                        const token = sessionStorage.getItem('token');
 +                        if (token) {
 +                            req.headers['Authorization'] = 'Bearer ' + token;
 +                        }
@@ -50,7 +50,7 @@
 +                                        }
 +
 +                                        // Save for persistence and show success
-+                                        localStorage.setItem('token', rawToken);
++                                        sessionStorage.setItem('token', rawToken);
 +                                        setTimeout(() => {
 +                                            const wrapper = document.querySelector('.auth-container .wrapper');
 +                                            if (wrapper && !wrapper.querySelector('.token-validated-msg')) {
@@ -64,7 +64,7 @@
 +                                        return oriAction(payload);
 +                                    },
 +                                    logout: (oriAction) => (payload) => {
-+                                        localStorage.removeItem('token');
++                                        sessionStorage.removeItem('token');
 +                                        return oriAction(payload);
 +                                    }
 +                                }
@@ -78,8 +78,8 @@
                  docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
              })
 
-+            // Restore auth from localStorage on page load
-+            const savedToken = localStorage.getItem('token');
++            // Restore auth from sessionStorage on page load
++            const savedToken = sessionStorage.getItem('token');
 +            if (savedToken) {
 +                ui.authActions.authorize({
 +                    apikey: {

--- a/docker/api/swaggeruirequestintercept.patch
+++ b/docker/api/swaggeruirequestintercept.patch
@@ -1,12 +1,95 @@
-diff --git a/flask_restx/templates/swagger-ui.html b/flask_restx/templates/swagger-ui.html
-index b233e01..d0c6f2a 100644
 --- a/flask_restx/templates/swagger-ui.html
 +++ b/flask_restx/templates/swagger-ui.html
-@@ -56,6 +56,7 @@
+@@ -56,12 +56,72 @@
                  {%- endif %}
                  validatorUrl: "{{ config.SWAGGER_VALIDATOR_URL }}" || null,
                  dom_id: "#swagger-ui",
-+                requestInterceptor: (req) => { if (!('Authorization' in req.headers)) { req.headers['Authorization'] = `Bearer ${localStorage.getItem("token")}`; } return req; },
++                // Auto-add Bearer token from localStorage if not already set
++                requestInterceptor: (req) => {
++                    if (!('Authorization' in req.headers)) {
++                        const token = localStorage.getItem('token');
++                        if (token) {
++                            req.headers['Authorization'] = 'Bearer ' + token;
++                        }
++                    }
++                    return req;
++                },
                  presets: [
                      SwaggerUIBundle.presets.apis,
                      SwaggerUIStandalonePreset.slice(1) // No Topbar
+                 ],
+                 plugins: [
+-                    SwaggerUIBundle.plugins.DownloadUrl
++                    SwaggerUIBundle.plugins.DownloadUrl,
++                    // Token validation plugin - validates JWT before authorizing
++                    {
++                        statePlugins: {
++                            auth: {
++                                wrapActions: {
++                                    authorize: (oriAction) => async (payload) => {
++                                        const authData = Object.values(payload)[0];
++                                        if (!authData?.value) return oriAction(payload);
++
++                                        // Normalize token format
++                                        const rawToken = authData.value.replace(/^Bearer\s+/i, '');
++                                        const bearerToken = 'Bearer ' + rawToken;
++
++                                        // Validate against backend
++                                        try {
++                                            const resp = await fetch('/api/v1.0/auth/identity', {
++                                                headers: { 'Authorization': bearerToken }
++                                            });
++                                            if (!resp.ok) {
++                                                const data = await resp.json();
++                                                alert('Token validation failed: ' + (data.message || 'Invalid token'));
++                                                return;
++                                            }
++                                        } catch (e) {
++                                            alert('Token validation failed: Network error');
++                                            return;
++                                        }
++
++                                        // Save for persistence and show success
++                                        localStorage.setItem('token', rawToken);
++                                        setTimeout(() => {
++                                            const wrapper = document.querySelector('.auth-container .wrapper');
++                                            if (wrapper && !wrapper.querySelector('.token-validated-msg')) {
++                                                const msg = document.createElement('div');
++                                                msg.className = 'token-validated-msg';
++                                                msg.style.cssText = 'background:#49cc90;color:white;padding:8px 12px;border-radius:4px;margin:10px 0;font-weight:bold;';
++                                                msg.textContent = 'Token validated successfully';
++                                                wrapper.insertBefore(msg, wrapper.firstChild);
++                                            }
++                                        }, 100);
++                                        return oriAction(payload);
++                                    },
++                                    logout: (oriAction) => (payload) => {
++                                        localStorage.removeItem('token');
++                                        return oriAction(payload);
++                                    }
++                                }
++                            }
++                        }
++                    }
+                 ],
+                 {% if config.SWAGGER_SUPPORTED_SUBMIT_METHODS is defined -%}
+                   supportedSubmitMethods: {{ config.SWAGGER_SUPPORTED_SUBMIT_METHODS | tojson}},
+@@ -71,6 +131,18 @@
+                 docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
+             })
+
++            // Restore auth from localStorage on page load
++            const savedToken = localStorage.getItem('token');
++            if (savedToken) {
++                ui.authActions.authorize({
++                    apikey: {
++                        name: 'apikey',
++                        schema: { type: 'apiKey', in: 'header', name: 'Authorization' },
++                        value: 'Bearer ' + savedToken
++                    }
++                });
++            }
++
+             {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
+             ui.initOAuth({
+                 clientId: "{{ config.SWAGGER_UI_OAUTH_CLIENT_ID }}",

--- a/docker/api/swaggeruirequestintercept.patch
+++ b/docker/api/swaggeruirequestintercept.patch
@@ -21,7 +21,7 @@
                  plugins: [
 -                    SwaggerUIBundle.plugins.DownloadUrl
 +                    SwaggerUIBundle.plugins.DownloadUrl,
-+                    // Token validation plugin - validates JWT before authorizing
++                    // Auth plugin - checks credentials via backend identity endpoint
 +                    {
 +                        statePlugins: {
 +                            auth: {
@@ -34,18 +34,19 @@
 +                                        const rawToken = authData.value.replace(/^Bearer\s+/i, '');
 +                                        const bearerToken = 'Bearer ' + rawToken;
 +
-+                                        // Validate against backend
++                                        // Check authorization against backend
 +                                        try {
 +                                            const resp = await fetch('/api/v1.0/auth/identity', {
 +                                                headers: { 'Authorization': bearerToken }
 +                                            });
 +                                            if (!resp.ok) {
 +                                                const data = await resp.json();
-+                                                alert('Token validation failed: ' + (data.message || 'Invalid token'));
++                                                alert('Authorization check failed: ' + (data.message || 'Invalid token'));
 +                                                return;
 +                                            }
++                                            var identity = await resp.json();
 +                                        } catch (e) {
-+                                            alert('Token validation failed: Network error');
++                                            alert('Authorization check failed: Network error');
 +                                            return;
 +                                        }
 +
@@ -53,11 +54,11 @@
 +                                        sessionStorage.setItem('token', rawToken);
 +                                        setTimeout(() => {
 +                                            const wrapper = document.querySelector('.auth-container .wrapper');
-+                                            if (wrapper && !wrapper.querySelector('.token-validated-msg')) {
++                                            if (wrapper && !wrapper.querySelector('.auth-status-msg')) {
 +                                                const msg = document.createElement('div');
-+                                                msg.className = 'token-validated-msg';
++                                                msg.className = 'auth-status-msg';
 +                                                msg.style.cssText = 'background:#49cc90;color:white;padding:8px 12px;border-radius:4px;margin:10px 0;font-weight:bold;';
-+                                                msg.textContent = 'Token validated successfully';
++                                                msg.textContent = 'Authenticated as ' + identity;
 +                                                wrapper.insertBefore(msg, wrapper.firstChild);
 +                                            }
 +                                        }, 100);

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -51,7 +51,7 @@ authorizations = {
         "type": "apiKey",
         "in": "header",
         "name": "Authorization",
-        "description": "Type 'Bearer <your JWT token here>' to authenticate, or leave empty to use token from WebUI login.",
+        "description": "Enter your JWT token (Bearer prefix is optional). Leave empty to use token from WebUI login.",
     }
 }
 


### PR DESCRIPTION
- Validate JWT tokens against /auth/identity before accepting
- Normalize Bearer prefix client-side (users can paste raw tokens)
- Persist tokens in localStorage across page reloads
- Show success message on valid authorization
- Clear token on logout

 
[Screencast from 2026-02-24 15-09-54.webm](https://github.com/user-attachments/assets/0a19d78d-5c69-4c14-8ac2-55cc63776eb1)

