### PR TITLE
Add FastAPI foundation and convert system, groups, plugins endpoints

### DIFF
--- a/FASTAPI_MIGRATION_PLAN.md
+++ b/FASTAPI_MIGRATION_PLAN.md
@@ -96,7 +96,7 @@ def get_devices(user: str = Depends(get_current_user)):
 
 ---
 
-### PR 3: Linknet + Management Domain
+### PR 3: Linknet + Management Domain ✅
 
 Already use Pydantic (`f_linknet`, `f_mgmtdomain`) — cleanest conversions.
 

--- a/FASTAPI_MIGRATION_PLAN.md
+++ b/FASTAPI_MIGRATION_PLAN.md
@@ -1,0 +1,210 @@
+# FastAPI Migration Plan for CNaaS-NMS
+
+## Context
+
+CNaaS-NMS currently uses Flask 3.1.3 + Flask-RESTX 1.3 for its REST API, with Flask-SocketIO for WebSockets, Flask-JWT-Extended for JWT auth, and gevent/uWSGI for production. The goal is to migrate to FastAPI while:
+- Keeping the API 100% backwards compatible (same URLs, response format, auth)
+- Using Pydantic 2.10+ for request/response validation (already on 2.11.3)
+- Adding unit tests before refactoring areas with low coverage
+
+The codebase already uses Pydantic for validation in several places (settings_fields, stackmembers, linknet, mgmtdomain, permissions, app_settings). Flask-RESTX `fields` models are only used for Swagger docs, not validation — actual validation is mostly inline.
+
+## Key Choices
+
+- **First pass**: PR 1 (foundation) + PR 2 (simple endpoints) combined
+- **ASGI server**: gunicorn + uvicorn workers for production
+- **Transition**: Dual-stack — Flask stays running, FastAPI built in `api/routers/`, final PR switches over
+
+## Migration Strategy: Incremental, PR-by-PR
+
+Each PR is independently deployable. New FastAPI routers coexist with Flask until the final switchover.
+
+---
+
+### PR 1: Foundation + Simple Endpoints + Test Safety Net ✅
+
+**Goal**: FastAPI app skeleton, shared infrastructure, unit tests for untested utilities, AND the 3 simplest endpoints (system, groups, plugins).
+
+#### New files:
+- `src/cnaas_nms/api/fastapi_app.py` — FastAPI app factory with:
+  - CORS middleware (same config as Flask: `origins="*"`, exposed headers `X-Total-Count`, `Link`, etc.)
+  - Exception handlers matching `CnaasApi.handle_error()` in `api/app.py:59-96`
+  - Custom JSON response class handling IP address serialization (replacing `api/json.py` CNaaSJSONEncoder)
+  - Request logging middleware (replacing `app.py:222-263` `@app.after_request`)
+  - OpenAPI docs at `/api/doc/`
+
+- `src/cnaas_nms/api/dependencies.py` — FastAPI dependencies:
+  - `get_current_user` — unified JWT/OIDC auth dependency (replaces `tools/security.py` `login_required` decorator). Reuses `MyBearerTokenValidator` which is framework-agnostic.
+  - `PaginationParams` — dataclass with `page: int = 1, per_page: int = 50`
+
+- `src/cnaas_nms/api/response.py` — Standard response helpers:
+  - `empty_result()` — same signature as `generic.py:167-173`, framework-agnostic
+  - `CnaasJSONResponse` — JSONResponse subclass with IP serialization
+
+- `src/cnaas_nms/api/filtering.py` — Framework-agnostic versions of:
+  - `build_filter(f_class, query, args, per_page, page)` — same as `generic.py:102-164` but takes explicit params instead of `flask.request`
+  - `pagination_headers(total_count, args, per_page, page, base_url)` — same as `generic.py:59-99`
+
+- `src/cnaas_nms/api/tests/fastapi_client.py` — TestClient wrapper with JWT injection (equivalent to `api/tests/app_wrapper.py`)
+
+#### New test files:
+- `src/cnaas_nms/api/tests/test_generic.py` — Unit tests for `empty_result`, `build_filter`, `pagination_headers`, `parse_pydantic_error`, `update_sqla_object`
+- `src/cnaas_nms/api/tests/test_fastapi_foundation.py` — Tests for CORS, error handlers, auth dependency
+
+#### Modified files:
+- `pyproject.toml` — Add: `fastapi`, `uvicorn[standard]`, `python-socketio[asyncio]`, `httpx` (for TestClient). Keep Flask deps during transition.
+
+#### Key decisions:
+- Endpoints remain `def` (sync, not `async def`) — SQLAlchemy sessions are synchronous, FastAPI runs sync handlers in thread pool automatically
+- `generic.py` functions that depend on `flask.request` get parallel framework-agnostic versions in `filtering.py`; old ones stay until Flask is removed
+
+---
+
+#### Simple endpoint files (included in PR 1):
+- `src/cnaas_nms/api/routers/system.py` — 2 endpoints: `GET /system/version`, `POST /system/shutdown`
+- `src/cnaas_nms/api/routers/groups.py` — 3 endpoints: `GET /groups`, `GET /groups/{group_name}`, `GET /groups/{group_name}/os_version`
+- `src/cnaas_nms/api/routers/plugins.py` — 2 endpoints: `GET /plugins`, `PUT /plugins`
+- `src/cnaas_nms/api/models/common_models.py` — `PluginAction(action: str)`, `RepositoryAction(action: str)`
+
+#### Pattern (Flask-RESTX Resource → FastAPI router):
+```python
+# Before (Flask-RESTX)
+class DevicesApi(Resource):
+    @login_required
+    def get(self):
+        return empty_result(...)
+api.add_resource(DevicesApi, "/devices")
+
+# After (FastAPI)
+router = APIRouter(tags=["devices"])
+@router.get("/devices")
+def get_devices(user: str = Depends(get_current_user)):
+    return empty_result(...)
+```
+
+---
+
+### PR 2: Repository, Settings, Jobs
+
+#### New files:
+- `src/cnaas_nms/api/routers/repository.py` — `GET/PUT /repository/{repo}`
+- `src/cnaas_nms/api/routers/settings.py` — `GET /settings`, `GET /settings/model`, `POST /settings/model`
+- `src/cnaas_nms/api/routers/jobs.py` — `GET /jobs`, `GET/PUT /job/{job_id}`, `GET/DELETE /joblocks`
+- `src/cnaas_nms/api/models/job_models.py` — `JobAction(action: str, abort_reason: Optional[str])`
+
+#### Key: Jobs endpoints use `build_filter` + pagination with `X-Total-Count`/`Link` headers — uses the new `filtering.py` functions with `Response` parameter injection.
+
+---
+
+### PR 3: Linknet + Management Domain
+
+Already use Pydantic (`f_linknet`, `f_mgmtdomain`) — cleanest conversions.
+
+#### New files:
+- `src/cnaas_nms/api/routers/linknet.py` — CRUD for `/linknets`, `/linknet/{id}`
+- `src/cnaas_nms/api/routers/mgmtdomain.py` — CRUD for `/mgmtdomains`, `/mgmtdomain/{id}`
+- Pydantic models reuse existing `f_linknet`, `f_mgmtdomain` from their respective files
+
+---
+
+### PR 4: Interface + Firmware
+
+#### New files:
+- `src/cnaas_nms/api/routers/interface.py` — `GET/PUT /device/{hostname}/interfaces`
+- `src/cnaas_nms/api/routers/firmware.py` — firmware endpoints
+- `src/cnaas_nms/api/models/interface_models.py` — Replace 200 lines of manual type-checking in `interface.py:100-300` with Pydantic models
+- `src/cnaas_nms/api/models/firmware_models.py`
+
+---
+
+### PR 5-6: Device Endpoints (split in two)
+
+**PR 5 — Read-only**: `GET /device/{id}`, `GET /devices`, `GET /device/{hostname}/generate_config`, running_config, previous_config, LLDP neighbors, sync history
+
+**PR 6 — Write**: `POST /devices`, `PUT /device/{id}`, `DELETE /device/{id}`, device_init, device_syncto, device_discover, device_update_facts, device_update_interfaces, device_cert, apply_config, stackmembers
+
+#### New files:
+- `src/cnaas_nms/api/routers/device.py` (or split into `device_read.py` / `device_write.py`)
+- `src/cnaas_nms/api/models/device_models.py` — Pydantic models replacing Flask-RESTX field definitions at `device.py:82-238`
+
+---
+
+### PR 7: Auth/OIDC Endpoints
+
+Most complex due to deep Flask integration. Switch from `authlib.integrations.flask_client` to `authlib.integrations.starlette_client`.
+
+#### New files:
+- `src/cnaas_nms/api/routers/auth.py`
+
+#### Modified:
+- `tools/security.py` — Add FastAPI-compatible auth functions alongside Flask ones (both coexist during transition)
+
+---
+
+### PR 8: WebSocket Migration
+
+Replace Flask-SocketIO with `python-socketio` ASGI mode.
+
+#### New files:
+- `src/cnaas_nms/api/socketio_app.py` — `AsyncServer` with same connect/events handlers
+
+#### Modified:
+- `run.py` — Mount SocketIO ASGI app onto FastAPI app
+- Redis polling thread stays same but calls new `sio.emit()`
+
+---
+
+### PR 9: Final Switchover + Cleanup
+
+#### Modified:
+- `run.py` — Replace gevent/Flask-SocketIO startup with gunicorn+uvicorn
+- `pyproject.toml` — Remove flask, flask-restx, flask-socketio, flask-jwt-extended, flask-cors, gevent, greenlet
+- Docker configs — Switch from uWSGI to gunicorn with uvicorn workers
+
+#### Deleted:
+- Old Flask `api/app.py`, old Flask route files (after verifying all tests pass against FastAPI)
+
+---
+
+## Backwards Compatibility Checklist (every PR)
+
+- [ ] Same URL paths (`/api/v1.0/...`)
+- [ ] Same response envelope: `{"status": "success/error", "data/message": ...}`
+- [ ] Same HTTP status codes for same conditions
+- [ ] Same query params: `filter[field][op]`, `per_page`, `page`, `sort`
+- [ ] Same response headers: `X-Total-Count`, `Link`
+- [ ] Same auth: `Authorization: Bearer <jwt>` header
+- [ ] Same WebSocket protocol: `connect` with `?jwt=`, `events` with room data
+- [ ] IP addresses serialize to strings
+
+## Key Architectural Decisions
+
+1. **Sync endpoints, not async** — SQLAlchemy sessions are sync; FastAPI runs `def` handlers in thread pool. No need to convert to async SQLAlchemy.
+2. **No gevent** — FastAPI uses uvicorn (asyncio). Remove gevent monkey patching at final switchover.
+3. **`sqla_session()` unchanged** — Context manager pattern works fine from sync FastAPI handlers.
+4. **Coexistence during transition** — Both Flask and FastAPI apps can exist; tests run against FastAPI from PR 1 onwards.
+
+## Critical Files
+
+| File | Role | Action |
+|------|------|--------|
+| `api/app.py` (264 lines) | Flask app setup, error handling, CORS, JWT, SocketIO, namespaces, logging | Replicate in `fastapi_app.py`, delete at end |
+| `api/generic.py` (213 lines) | `empty_result`, `build_filter`, pagination — used by every endpoint | Create framework-agnostic versions in `filtering.py` + `response.py` |
+| `tools/security.py` (150 lines) | `login_required`, JWT/OIDC auth | Add FastAPI dependency; `MyBearerTokenValidator` is reusable |
+| `api/device.py` (1414 lines) | Largest API file, 20 Resource classes | Split across PR 5-6 |
+| `run.py` (178 lines) | App entry point, gevent, websocket thread | Switch to gunicorn+uvicorn in PR 9 |
+| `pyproject.toml` | Dependencies | Add FastAPI deps in PR 1, remove Flask deps in PR 9 |
+
+## Verification Plan
+
+For each PR:
+1. Run existing unit tests: `pytest src/ -m "not integration and not equipment"`
+2. Run integration tests against FastAPI app: `pytest src/ -m integration`
+3. Manual smoke test: start app, hit key endpoints with curl, verify response format
+4. Compare OpenAPI spec output between Flask-RESTX and FastAPI docs
+
+Final verification (PR 9):
+1. Full test suite passes
+2. Docker build and deployment works with uvicorn
+3. WebSocket connections work
+4. JWT and OIDC auth flows work end-to-end

--- a/FASTAPI_MIGRATION_PLAN.md
+++ b/FASTAPI_MIGRATION_PLAN.md
@@ -84,7 +84,7 @@ def get_devices(user: str = Depends(get_current_user)):
 
 ---
 
-### PR 2: Repository, Settings, Jobs
+### PR 2: Repository, Settings, Jobs ✅
 
 #### New files:
 - `src/cnaas_nms/api/routers/repository.py` — `GET/PUT /repository/{repo}`

--- a/FASTAPI_MIGRATION_PLAN.md
+++ b/FASTAPI_MIGRATION_PLAN.md
@@ -107,7 +107,7 @@ Already use Pydantic (`f_linknet`, `f_mgmtdomain`) — cleanest conversions.
 
 ---
 
-### PR 4: Interface + Firmware
+### PR 4: Interface + Firmware ✅
 
 #### New files:
 - `src/cnaas_nms/api/routers/interface.py` — `GET/PUT /device/{hostname}/interfaces`

--- a/FASTAPI_MIGRATION_PLAN.md
+++ b/FASTAPI_MIGRATION_PLAN.md
@@ -117,7 +117,7 @@ Already use Pydantic (`f_linknet`, `f_mgmtdomain`) — cleanest conversions.
 
 ---
 
-### PR 5-6: Device Endpoints (split in two)
+### PR 5-6: Device Endpoints (split in two) ✅
 
 **PR 5 — Read-only**: `GET /device/{id}`, `GET /devices`, `GET /device/{hostname}/generate_config`, running_config, previous_config, LLDP neighbors, sync history
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "apscheduler==3.11",
   "async-timeout>=4.0.2",
   "authlib==1.6.6",
+  "fastapi>=0.115",
   "flask==3.1.3",
   "flask-cors==6.0.0",
   "flask-jwt-extended==4.7.1",
@@ -53,6 +54,7 @@ dependencies = [
   "requests==2.32.4",
   "sqlalchemy==2.0.40",
   "sqlalchemy-utils==0.41.2",
+  "uvicorn[standard]>=0.30",
   "werkzeug==3.1.6",
 ]
 
@@ -65,6 +67,7 @@ dev = [
   "mypy-extensions==1.1",
   "nose==1.3.7",
   "pre-commit",
+  "httpx>=0.27",
   "pytest==8.3.5",
   "pytest-cov==6.1.1",
   "pytest-docker==3.2.2",

--- a/src/cnaas_nms/api/dependencies.py
+++ b/src/cnaas_nms/api/dependencies.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from cnaas_nms.app_settings import api_settings, auth_settings

--- a/src/cnaas_nms/api/dependencies.py
+++ b/src/cnaas_nms/api/dependencies.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass, field
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from cnaas_nms.app_settings import api_settings, auth_settings
+from cnaas_nms.tools.log import get_logger
+
+logger = get_logger()
+
+# Optional bearer — allows endpoints to work when JWT is disabled
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+) -> str:
+    """FastAPI dependency that validates JWT/OIDC tokens and returns the username.
+
+    Mirrors the behaviour of tools/security.py login_required + get_identity.
+    """
+    # If neither JWT nor OIDC is enabled, everyone is "admin"
+    if not api_settings.JWT_ENABLED and not auth_settings.OIDC_ENABLED:
+        return "admin"
+
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="JWT token missing")
+
+    token_string = credentials.credentials
+
+    if auth_settings.OIDC_ENABLED:
+        from cnaas_nms.tools.oidc.oidc_client_call import get_oauth_token_info
+        from cnaas_nms.tools.security import MyBearerTokenValidator
+
+        validator = MyBearerTokenValidator()
+        token = validator.authenticate_token(token_string)
+        token_info = get_oauth_token_info(token)
+        if auth_settings.OIDC_USERNAME_ATTRIBUTE in token_info:
+            return token_info[auth_settings.OIDC_USERNAME_ATTRIBUTE]
+        elif "client_id" in token_info:
+            return token_info["client_id"]
+        else:
+            raise HTTPException(status_code=401, detail="Could not determine user identity from token")
+    else:
+        # JWT mode — decode with ES256 public key
+        from flask_jwt_extended import decode_token
+
+        try:
+            decoded = decode_token(token_string)
+            return decoded.get("sub", "unknown")
+        except Exception as e:
+            raise HTTPException(status_code=401, detail=f"Invalid JWT token: {e}")
+
+
+@dataclass
+class PaginationParams:
+    """Query parameters for paginated endpoints."""
+
+    page: int = 1
+    per_page: int = 50
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.per_page <= 1000:
+            raise HTTPException(status_code=400, detail="per_page must be between 1 and 1000")
+        self.page = max(1, self.page)
+
+    @property
+    def limit(self) -> int:
+        return self.per_page
+
+    @property
+    def offset(self) -> int:
+        return (self.page - 1) * self.per_page

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -5,7 +5,7 @@ from flask_jwt_extended.exceptions import InvalidHeaderError, NoAuthorizationErr
 from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidKeyError, InvalidSignatureError, InvalidTokenError
 
 from cnaas_nms.api.response import CnaasJSONResponse
-from cnaas_nms.api.routers import groups, jobs, plugins, repository, settings, system
+from cnaas_nms.api.routers import groups, jobs, linknet, mgmtdomain, plugins, repository, settings, system
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.version import __api_version__
 
@@ -150,3 +150,5 @@ app.include_router(plugins.router, prefix=api_prefix)
 app.include_router(repository.router, prefix=api_prefix)
 app.include_router(settings.router, prefix=api_prefix)
 app.include_router(jobs.router, prefix=api_prefix)
+app.include_router(linknet.router, prefix=api_prefix)
+app.include_router(mgmtdomain.router, prefix=api_prefix)

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -5,7 +5,18 @@ from flask_jwt_extended.exceptions import InvalidHeaderError, NoAuthorizationErr
 from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidKeyError, InvalidSignatureError, InvalidTokenError
 
 from cnaas_nms.api.response import CnaasJSONResponse
-from cnaas_nms.api.routers import groups, jobs, linknet, mgmtdomain, plugins, repository, settings, system
+from cnaas_nms.api.routers import (
+    firmware,
+    groups,
+    interface,
+    jobs,
+    linknet,
+    mgmtdomain,
+    plugins,
+    repository,
+    settings,
+    system,
+)
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.version import __api_version__
 
@@ -152,3 +163,5 @@ app.include_router(settings.router, prefix=api_prefix)
 app.include_router(jobs.router, prefix=api_prefix)
 app.include_router(linknet.router, prefix=api_prefix)
 app.include_router(mgmtdomain.router, prefix=api_prefix)
+app.include_router(interface.router, prefix=api_prefix)
+app.include_router(firmware.router, prefix=api_prefix)

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -5,7 +5,7 @@ from flask_jwt_extended.exceptions import InvalidHeaderError, NoAuthorizationErr
 from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidKeyError, InvalidSignatureError, InvalidTokenError
 
 from cnaas_nms.api.response import CnaasJSONResponse
-from cnaas_nms.api.routers import groups, plugins, system
+from cnaas_nms.api.routers import groups, jobs, plugins, repository, settings, system
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.version import __api_version__
 
@@ -155,3 +155,6 @@ api_prefix = "/api/{}".format(__api_version__)
 app.include_router(system.router, prefix=api_prefix)
 app.include_router(groups.router, prefix=api_prefix)
 app.include_router(plugins.router, prefix=api_prefix)
+app.include_router(repository.router, prefix=api_prefix)
+app.include_router(settings.router, prefix=api_prefix)
+app.include_router(jobs.router, prefix=api_prefix)

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -57,9 +57,7 @@ async def expired_sig_handler(request: Request, exc: ExpiredSignatureError) -> C
 
 @app.exception_handler(InvalidKeyError)
 async def invalid_key_handler(request: Request, exc: InvalidKeyError) -> CnaasJSONResponse:
-    return CnaasJSONResponse(
-        status_code=401, content={"status": "error", "data": "Invalid keys {}".format(exc)}
-    )
+    return CnaasJSONResponse(status_code=401, content={"status": "error", "data": "Invalid keys {}".format(exc)})
 
 
 @app.exception_handler(InvalidTokenError)
@@ -72,9 +70,7 @@ async def invalid_token_handler(request: Request, exc: InvalidTokenError) -> Cna
 
 @app.exception_handler(InvalidSignatureError)
 async def invalid_sig_handler(request: Request, exc: InvalidSignatureError) -> CnaasJSONResponse:
-    return CnaasJSONResponse(
-        status_code=401, content={"status": "error", "message": "Invalid token signature"}
-    )
+    return CnaasJSONResponse(status_code=401, content={"status": "error", "message": "Invalid token signature"})
 
 
 @app.exception_handler(InvalidHeaderError)
@@ -87,16 +83,12 @@ async def invalid_header_handler(request: Request, exc: InvalidHeaderError) -> C
 
 @app.exception_handler(MissingAuthorizationError)
 async def missing_auth_handler(request: Request, exc: MissingAuthorizationError) -> CnaasJSONResponse:
-    return CnaasJSONResponse(
-        status_code=401, content={"status": "error", "message": "JWT token missing?"}
-    )
+    return CnaasJSONResponse(status_code=401, content={"status": "error", "message": "JWT token missing?"})
 
 
 @app.exception_handler(NoAuthorizationError)
 async def no_auth_handler(request: Request, exc: NoAuthorizationError) -> CnaasJSONResponse:
-    return CnaasJSONResponse(
-        status_code=401, content={"status": "error", "message": "JWT token missing?"}
-    )
+    return CnaasJSONResponse(status_code=401, content={"status": "error", "message": "JWT token missing?"})
 
 
 @app.exception_handler(ConnectionError)

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -1,0 +1,157 @@
+from authlib.oauth2.rfc6749 import MissingAuthorizationError
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from flask_jwt_extended.exceptions import InvalidHeaderError, NoAuthorizationError
+from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidKeyError, InvalidSignatureError, InvalidTokenError
+
+from cnaas_nms.api.response import CnaasJSONResponse
+from cnaas_nms.api.routers import groups, plugins, system
+from cnaas_nms.tools.log import get_logger
+from cnaas_nms.version import __api_version__
+
+logger = get_logger()
+
+
+app = FastAPI(
+    title="CNaaS NMS API",
+    version=__api_version__,
+    docs_url="/api/doc/",
+    openapi_url="/api/openapi.json",
+    default_response_class=CnaasJSONResponse,
+)
+
+# CORS — same config as Flask app
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+    expose_headers=["Content-Type", "Authorization", "X-Total-Count", "Link", "Set-Cookie", "Cookie"],
+)
+
+
+# --- Exception handlers matching CnaasApi.handle_error() in api/app.py ---
+
+
+@app.exception_handler(DecodeError)
+async def decode_error_handler(request: Request, exc: DecodeError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(status_code=401, content={"status": "error", "message": "Could not decode JWT token"})
+
+
+@app.exception_handler(PermissionError)
+async def permission_error_handler(request: Request, exc: PermissionError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=403,
+        content={"status": "error", "message": "You don't seem to have the rights to execute this call"},
+    )
+
+
+@app.exception_handler(ExpiredSignatureError)
+async def expired_sig_handler(request: Request, exc: ExpiredSignatureError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401,
+        content={"status": "error", "message": "The JWT token is expired", "errorCode": "auth_expired"},
+    )
+
+
+@app.exception_handler(InvalidKeyError)
+async def invalid_key_handler(request: Request, exc: InvalidKeyError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401, content={"status": "error", "data": "Invalid keys {}".format(exc)}
+    )
+
+
+@app.exception_handler(InvalidTokenError)
+async def invalid_token_handler(request: Request, exc: InvalidTokenError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401,
+        content={"status": "error", "message": "Invalid authentication header: {}".format(exc)},
+    )
+
+
+@app.exception_handler(InvalidSignatureError)
+async def invalid_sig_handler(request: Request, exc: InvalidSignatureError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401, content={"status": "error", "message": "Invalid token signature"}
+    )
+
+
+@app.exception_handler(InvalidHeaderError)
+async def invalid_header_handler(request: Request, exc: InvalidHeaderError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401,
+        content={"status": "error", "message": "Invalid header, JWT token missing? {}".format(exc)},
+    )
+
+
+@app.exception_handler(MissingAuthorizationError)
+async def missing_auth_handler(request: Request, exc: MissingAuthorizationError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401, content={"status": "error", "message": "JWT token missing?"}
+    )
+
+
+@app.exception_handler(NoAuthorizationError)
+async def no_auth_handler(request: Request, exc: NoAuthorizationError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=401, content={"status": "error", "message": "JWT token missing?"}
+    )
+
+
+@app.exception_handler(ConnectionError)
+async def connection_error_handler(request: Request, exc: ConnectionError) -> CnaasJSONResponse:
+    return CnaasJSONResponse(
+        status_code=500,
+        content={"status": "error", "message": "ConnectionError: {}".format(exc)},
+    )
+
+
+# --- Request logging middleware ---
+
+
+@app.middleware("http")
+async def log_request_middleware(request: Request, call_next):  # type: ignore
+    response = await call_next(request)
+
+    user = "unknown"
+    if "/auth/" not in str(request.url):
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            try:
+                from cnaas_nms.app_settings import auth_settings
+
+                if auth_settings.OIDC_ENABLED:
+                    from cnaas_nms.tools.oidc.oidc_client_call import get_oauth_token_info
+                    from cnaas_nms.tools.security import MyBearerTokenValidator
+
+                    token_string = auth_header.split(" ")[-1]
+                    validator = MyBearerTokenValidator()
+                    token = validator.authenticate_token(token_string)
+                    token_info = get_oauth_token_info(token)
+                    if token_info and auth_settings.OIDC_USERNAME_ATTRIBUTE in token_info:
+                        user = token_info[auth_settings.OIDC_USERNAME_ATTRIBUTE]
+                    elif token_info and "client_id" in token_info:
+                        user = token_info["client_id"]
+                else:
+                    from flask_jwt_extended import decode_token
+
+                    token_string = auth_header.split(" ")[-1]
+                    user = decode_token(token_string).get("sub", "unknown")
+            except Exception:
+                user = "unknown"
+    else:
+        user = "unauthenticated"
+
+    logger.info(
+        "User: {}, Method: {}, Status: {}, URL: {}".format(user, request.method, response.status_code, request.url)
+    )
+    return response
+
+
+# --- Register routers ---
+
+api_prefix = "/api/{}".format(__api_version__)
+app.include_router(system.router, prefix=api_prefix)
+app.include_router(groups.router, prefix=api_prefix)
+app.include_router(plugins.router, prefix=api_prefix)

--- a/src/cnaas_nms/api/fastapi_app.py
+++ b/src/cnaas_nms/api/fastapi_app.py
@@ -6,6 +6,7 @@ from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidKeyError, 
 
 from cnaas_nms.api.response import CnaasJSONResponse
 from cnaas_nms.api.routers import (
+    device,
     firmware,
     groups,
     interface,
@@ -165,3 +166,4 @@ app.include_router(linknet.router, prefix=api_prefix)
 app.include_router(mgmtdomain.router, prefix=api_prefix)
 app.include_router(interface.router, prefix=api_prefix)
 app.include_router(firmware.router, prefix=api_prefix)
+app.include_router(device.router, prefix=api_prefix)

--- a/src/cnaas_nms/api/filtering.py
+++ b/src/cnaas_nms/api/filtering.py
@@ -125,12 +125,8 @@ def pagination_headers(
     page = max(1, page)
 
     if page < last_page:
-        links.append(
-            '<{}>; rel="next"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": page + 1}))
-        )
-        links.append(
-            '<{}>; rel="last"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": last_page}))
-        )
+        links.append('<{}>; rel="next"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": page + 1})))
+        links.append('<{}>; rel="last"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": last_page})))
 
     if links:
         headers["Link"] = ",".join(links)

--- a/src/cnaas_nms/api/filtering.py
+++ b/src/cnaas_nms/api/filtering.py
@@ -1,0 +1,138 @@
+"""Framework-agnostic filtering and pagination utilities for FastAPI endpoints.
+
+These parallel the Flask-dependent functions in generic.py but accept explicit
+parameters instead of reading from flask.request.
+"""
+
+import math
+import re
+import urllib.parse
+from typing import Any, Dict
+
+import sqlalchemy
+from sqlalchemy.orm import Query
+
+FILTER_RE = re.compile(r"^filter\[([a-zA-Z0-9_.]+)\](\[[a-z]+\])?$")
+
+
+def build_filter(
+    f_class: Any,
+    query: Query,
+    args: Dict[str, str],
+    per_page: int = 50,
+    page: int = 1,
+) -> Query:
+    """Generate SQLAlchemy filter from query params dict and return filtered query.
+
+    Args:
+        f_class: SQLAlchemy model class
+        query: Base SQLAlchemy query
+        args: Dict of query string parameters (e.g. from request.query_params)
+        per_page: Results per page (1-1000)
+        page: Page number (1-based)
+
+    Raises:
+        ValueError: If filter attribute or value is invalid
+    """
+    f_class_order_by_field = None
+    order = None
+
+    for arg, value in args.items():
+        match = re.match(FILTER_RE, arg)
+        if arg == "sort" and isinstance(value, str):
+            order_by_field = value.lower()
+            if order_by_field.startswith("-"):
+                order_by_field = order_by_field.lstrip("-")
+                order = sqlalchemy.desc
+            else:
+                order = sqlalchemy.asc
+
+            if order_by_field in f_class.__table__._columns.keys():
+                f_class_order_by_field = getattr(f_class, order_by_field)
+            continue
+
+        if not match or len(match.groups()) != 2:
+            continue
+
+        attribute = match.groups()[0].replace(".", "_")
+        operator = match.groups()[1]
+        if operator:
+            operator = operator.lstrip("[").rstrip("]")
+
+        if attribute not in f_class.__table__._columns.keys():
+            raise ValueError("{} is not a valid attribute to filter on".format(attribute))
+
+        allowed_names = None
+        if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.Enum):
+            value = value.upper()
+            allowed_names = set(item.name for item in f_class.__table__._columns[attribute].type.enum_class)
+            if value not in allowed_names:
+                raise ValueError("{} is not a valid value for {}".format(value, attribute))
+
+        f_class_field = getattr(f_class, attribute)
+        if operator == "contains":
+            if allowed_names:
+                raise ValueError("Cannot use 'contains' operator for enum types")
+            if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.Integer):
+                raise ValueError("Cannot use 'contains' operator for integer types")
+            if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.DateTime):
+                raise ValueError("Cannot use 'contains' operator for datetime types")
+            f_class_op = getattr(f_class_field, "ilike")
+            value = "%" + value + "%"
+        else:
+            f_class_op = getattr(f_class_field, "__eq__")
+
+        query = query.filter(f_class_op(value))
+
+    if f_class_order_by_field and order:
+        query = query.order_by(order(f_class_order_by_field))
+    else:
+        if "id" in f_class.__table__._columns.keys():
+            order = sqlalchemy.asc
+            f_class_order_by_field = getattr(f_class, "id")
+            query = query.order_by(order(f_class_order_by_field))
+
+    query = query.limit(per_page)
+    query = query.offset((max(1, page) - 1) * per_page)
+    return query
+
+
+def pagination_headers(
+    total_count: int,
+    args: Dict[str, str],
+    per_page: int = 50,
+    page: int = 1,
+    base_url: str = "",
+) -> Dict[str, Any]:
+    """Build pagination headers (X-Total-Count, Link).
+
+    Args:
+        total_count: Total number of results
+        args: Dict of query string parameters
+        per_page: Results per page
+        page: Current page number (1-based)
+        base_url: Base URL for Link header construction
+    """
+    links = []
+    headers: Dict[str, Any] = {
+        "X-Total-Count": str(total_count),
+    }
+
+    last_page = math.ceil(total_count / per_page) if per_page > 0 else 1
+    if last_page <= 1:
+        return headers
+
+    page = max(1, page)
+
+    if page < last_page:
+        links.append(
+            '<{}>; rel="next"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": page + 1}))
+        )
+        links.append(
+            '<{}>; rel="last"'.format(base_url + "?" + urllib.parse.urlencode({**args, "page": last_page}))
+        )
+
+    if links:
+        headers["Link"] = ",".join(links)
+
+    return headers

--- a/src/cnaas_nms/api/response.py
+++ b/src/cnaas_nms/api/response.py
@@ -1,0 +1,33 @@
+import json
+from ipaddress import _IPAddressBase
+from typing import Any, Dict
+
+from fastapi.responses import JSONResponse
+
+
+def empty_result(status: str = "success", data: Any = None) -> Dict[str, Any]:
+    """Standard CNaaS response envelope, framework-agnostic."""
+    if status == "success":
+        return {"status": status, "data": data}
+    elif status == "error":
+        return {"status": status, "message": data if data else "Unknown error"}
+    else:
+        return {}
+
+
+class CnaasJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles IP address objects."""
+
+    def default(self, o: Any) -> Any:
+        if isinstance(o, _IPAddressBase):
+            return str(o)
+        if hasattr(o, "as_dict"):
+            return o.as_dict()
+        return super().default(o)
+
+
+class CnaasJSONResponse(JSONResponse):
+    """JSONResponse subclass that serializes IP addresses to strings."""
+
+    def render(self, content: Any) -> bytes:
+        return json.dumps(content, cls=CnaasJSONEncoder, ensure_ascii=False).encode("utf-8")

--- a/src/cnaas_nms/api/routers/device.py
+++ b/src/cnaas_nms/api/routers/device.py
@@ -1,0 +1,1584 @@
+import datetime
+from copy import deepcopy
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import ValidationError
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.attributes import flag_modified
+
+import cnaas_nms.devicehandler.get
+import cnaas_nms.devicehandler.init_device
+import cnaas_nms.devicehandler.sync_devices
+import cnaas_nms.devicehandler.underlay
+import cnaas_nms.devicehandler.update
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.filtering import build_filter, pagination_headers
+from cnaas_nms.api.generic import parse_pydantic_error
+from cnaas_nms.api.models.stackmembers_model import StackmembersModel
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.app_settings import api_settings
+from cnaas_nms.db.device import Device, DeviceState, DeviceType
+from cnaas_nms.db.interface import Interface
+from cnaas_nms.db.job import InvalidJobError, Job, JobNotFoundError
+from cnaas_nms.db.linknet import Linknet
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import (
+    AccessListGenerationError,
+    SettingsSyntaxError,
+    VlanConflictError,
+    get_device_primary_groups,
+    get_groups,
+    get_settings,
+    rebuild_settings_cache,
+    update_device_primary_groups,
+)
+from cnaas_nms.db.stackmember import Stackmember
+from cnaas_nms.devicehandler.nornir_helper import cnaas_init, inventory_selector
+from cnaas_nms.devicehandler.sync_history import (
+    NewSyncEventModel,
+    SyncHistory,
+    add_sync_event,
+    get_sync_events,
+    remove_sync_events,
+)
+from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.log import get_logger
+
+logger = get_logger()
+
+router = APIRouter(tags=["devices"])
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def device_data_postprocess(device_list: List[Device]) -> List[dict]:
+    device_primary_group = get_device_primary_groups()
+    ret: List[dict] = []
+    for device in device_list:
+        dev_dict = device.as_dict()
+        if device.hostname in device_primary_group.keys():
+            dev_dict["primary_group"] = device_primary_group[device.hostname]
+        ret.append(dev_dict)
+    return ret
+
+
+def _is_name_change_allowed(device: Device, new_hostname: str) -> bool:
+    if device.state != DeviceState.MANAGED:
+        return True
+
+    new_dev = deepcopy(device)
+    new_dev.hostname = new_hostname
+    old_settings, _ = get_settings(device)
+    new_settings, _ = get_settings(new_dev)
+
+    return old_settings == new_settings
+
+
+def init_device_arg_check(device_id: int, json_data: dict) -> dict:
+    parsed_args: dict[str, int | str | list[Any] | None] = {"device_id": device_id}
+    if not isinstance(device_id, int):
+        raise ValueError("'device_id' must be an integer")
+
+    if "hostname" not in json_data:
+        raise ValueError("POST data must include new 'hostname'")
+    else:
+        if not Device.valid_hostname(json_data["hostname"]):
+            raise ValueError("Provided hostname is not valid")
+        else:
+            parsed_args["new_hostname"] = json_data["hostname"]
+
+    if "device_type" not in json_data:
+        raise ValueError("POST data must include 'device_type'")
+    else:
+        try:
+            device_type = str(json_data["device_type"]).upper()
+        except Exception:
+            raise ValueError("'device_type' must be a string")
+
+        if DeviceType.has_name(device_type):
+            parsed_args["device_type"] = device_type
+        else:
+            raise ValueError("Invalid 'device_type' provided")
+
+    if "mlag_peer_id" in json_data or "mlag_peer_hostname" in json_data:
+        if "mlag_peer_id" not in json_data or "mlag_peer_hostname" not in json_data:
+            raise ValueError("Both 'mlag_peer_id' and 'mlag_peer_hostname' must be specified")
+        if not isinstance(json_data["mlag_peer_id"], int):
+            raise ValueError("'mlag_peer_id' must be an integer")
+        if not Device.valid_hostname(json_data["mlag_peer_hostname"]):
+            raise ValueError("Provided 'mlag_peer_hostname' is not valid")
+        parsed_args["mlag_peer_id"] = json_data["mlag_peer_id"]
+        parsed_args["mlag_peer_new_hostname"] = json_data["mlag_peer_hostname"]
+
+    if "neighbors" in json_data and json_data["neighbors"] is not None:
+        if isinstance(json_data["neighbors"], list):
+            for neighbor in json_data["neighbors"]:
+                if not Device.valid_hostname(neighbor):
+                    raise ValueError("Invalid hostname specified in neighbor list")
+            parsed_args["neighbors"] = json_data["neighbors"]
+        else:
+            raise ValueError(
+                "Neighbors must be specified as either a list of hostnames,an empty list, or not specified at all"
+            )
+    else:
+        parsed_args["neighbors"] = None
+
+    if "replace_hostname" in json_data and json_data["replace_hostname"] is not None:
+        parsed_args["replace_hostname"] = json_data["replace_hostname"]
+
+    return parsed_args
+
+
+def parse_syncto_args(json_data: dict) -> dict:
+    # default args
+    kwargs: dict = {
+        "dry_run": True,
+        "auto_push": False,
+        "force": False,
+        "resync": False,
+    }
+
+    if "dry_run" in json_data and isinstance(json_data["dry_run"], bool) and not json_data["dry_run"]:
+        kwargs["dry_run"] = False
+    if "force" in json_data and isinstance(json_data["force"], bool):
+        kwargs["force"] = json_data["force"]
+    if "auto_push" in json_data and isinstance(json_data["auto_push"], bool):
+        kwargs["auto_push"] = json_data["auto_push"]
+    if "resync" in json_data and isinstance(json_data["resync"], bool):
+        kwargs["resync"] = json_data["resync"]
+    if "comment" in json_data and isinstance(json_data["comment"], str):
+        kwargs["job_comment"] = json_data["comment"]
+    if "ticket_ref" in json_data and isinstance(json_data["ticket_ref"], str):
+        kwargs["job_ticket_ref"] = json_data["ticket_ref"]
+    if "confirm_mode" in json_data and isinstance(json_data["confirm_mode"], int):
+        kwargs["confirm_mode_override"] = json_data["confirm_mode"]
+
+    return kwargs
+
+
+def filter_job_dict(job_dict: dict, args: dict) -> dict:
+    """Filter out parts of job result dict based on query string arguments."""
+    filter_map = {"syncto": {"config": 1, "diff": 2}}
+    filter_items = []
+    if (
+        not isinstance(job_dict, dict)
+        or "result" not in job_dict
+        or not isinstance(job_dict["result"], dict)
+        or "devices" not in job_dict["result"]
+        or "function_name" not in job_dict
+        or not isinstance(job_dict["function_name"], str)
+    ):
+        return job_dict
+
+    if job_dict["function_name"].startswith("sync_devices"):
+        for arg, value in args.items():
+            if arg == "filter_jobresult" and isinstance(value, str):
+                for item in value.split(","):
+                    if item in filter_map["syncto"].keys():
+                        filter_items.append(filter_map["syncto"][item])
+        for filter_item in sorted(filter_items, reverse=True):
+            for hostname, value in job_dict["result"]["devices"].items():
+                try:
+                    del job_dict["result"]["devices"][hostname]["job_tasks"][filter_item]
+                except KeyError:
+                    pass
+                except Exception as e:
+                    logger.debug("job filter_response exception: {}".format(e))
+    return job_dict
+
+
+def format_stackmember_errors(errors: list) -> list:
+    return_errors = []
+    for error in errors:
+        error_msg = error["msg"]
+        if error["type"] != "value_error":
+            error_msg = f"{error['loc'][2]}: {error_msg}"
+        return_errors.append(error_msg)
+    return return_errors
+
+
+# ---------------------------------------------------------------------------
+# 1. DeviceByIdApi  GET /device/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{device_id}")
+def get_device_by_id(device_id: int, user: str = Depends(get_current_user)):
+    """Get a device from ID."""
+    result = empty_result()
+    result["data"] = {"devices": []}
+    with sqla_session() as session:
+        instance = session.query(Device).filter(Device.id == device_id).one_or_none()
+        if instance:
+            result["data"]["devices"] = device_data_postprocess([instance])
+        else:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 1. DeviceByIdApi  DELETE /device/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/device/{device_id}")
+def delete_device_by_id(
+    device_id: int,
+    json_data: Optional[dict[str, Any]] = None,
+    user: str = Depends(get_current_user),
+):
+    """Delete device from ID."""
+    if json_data and "factory_default" in json_data:
+        if isinstance(json_data["factory_default"], bool) and json_data["factory_default"] is True:
+            scheduler = Scheduler()
+            job_id = scheduler.add_onetime_job(
+                "cnaas_nms.devicehandler.erase:device_erase",
+                when=1,
+                scheduled_by=user,
+                kwargs={"device_id": device_id},
+            )
+            res = empty_result(data="Scheduled job {} to factory default device".format(job_id))
+            res["job_id"] = job_id
+            return res
+        elif not isinstance(json_data["factory_default"], bool):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Argument factory_default must be boolean"),
+            )
+
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.id == device_id).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+        try:
+            remove_sync_events(dev.hostname)
+            for nei in dev.get_neighbors(session):
+                nei.synchronized = False
+                add_sync_event(nei.hostname, "neighbor_deleted", user)
+        except Exception as e:
+            logger.warning("Could not mark neighbor as unsync after deleting {}: {}".format(dev.hostname, e))
+        try:
+            session.delete(dev)
+            session.commit()
+        except IntegrityError as e:
+            session.rollback()
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(
+                    status="error",
+                    data="Could not remove device because existing references: {}".format(e),
+                ),
+            )
+        except Exception as e:
+            session.rollback()
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Could not remove device: {}".format(e)),
+            )
+        return empty_result(status="success", data={"deleted_device": dev.as_dict()})
+
+
+# ---------------------------------------------------------------------------
+# 1. DeviceByIdApi  PUT /device/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.put("/device/{device_id}")
+def update_device_by_id(
+    device_id: int,
+    json_data: dict[str, Any],
+    user: str = Depends(get_current_user),
+):
+    """Modify device from ID."""
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.id == device_id).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(
+                status_code=404,
+                content=empty_result(status="error", data=f"No device with id {device_id}"),
+            )
+
+        dev_prev_state: DeviceState = dev.state
+
+        current_hostname: str = dev.hostname
+        new_hostname = json_data.get("hostname", current_hostname)
+        is_name_change_request = current_hostname != new_hostname
+
+        if is_name_change_request and not _is_name_change_allowed(dev, new_hostname):
+            msg = (
+                f"Configuration after name change for {current_hostname} would not be the same."
+                f" Please check device specific configuration for {current_hostname} and {new_hostname}"
+            )
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=[msg]),
+            )
+
+        errors = dev.device_update(**json_data)
+        if errors:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=errors),
+            )
+
+        if is_name_change_request:
+            try:
+                # Rebuild settings caches to make sure group memberships are
+                # updated after setting new hostname
+                rebuild_settings_cache()
+
+                # Mark linknet neighbors as unsynchronized
+                linknets = (
+                    session.query(Linknet)
+                    .filter(or_(Linknet.device_a_id == device_id, Linknet.device_b_id == device_id))
+                    .all()
+                )
+
+                neighbor_device_ids = set()
+                for ln in linknets:
+                    if ln.device_a_id == device_id:
+                        neighbor_device_ids.add(ln.device_b_id)
+                    else:
+                        neighbor_device_ids.add(ln.device_a_id)
+
+                for neigh_id in neighbor_device_ids:
+                    neigh_dev = session.query(Device).filter(Device.id == neigh_id).one()
+                    neigh_dev.synchronized = False
+                    add_sync_event(neigh_dev.hostname, "linknet_neighbor_name_change", by=user)
+
+                # Update neighbor interfaces
+                interfaces = (
+                    session.query(Interface).filter(Interface.data["neighbor"].astext == current_hostname).all()
+                )
+                for intf in interfaces:
+                    intf.data["neighbor"] = new_hostname
+                    flag_modified(intf, "data")
+
+                    if intf.device_id not in neighbor_device_ids:
+                        intf_dev = session.query(Device).filter(Device.id == intf.device_id).one()
+                        intf_dev.synchronized = False
+                        add_sync_event(intf_dev.hostname, "neighbor_name_change", by=user)
+
+                dev.synchronized = False
+                add_sync_event(new_hostname, "device_name_change", by=user)
+
+                logger.info(
+                    f"Hostname changed from '{current_hostname}' to '{new_hostname}': "
+                    f"marked {len(neighbor_device_ids)} connected devices as unsynchronized, "
+                    f"updated {len(interfaces)} interface neighbor fields"
+                )
+
+            except SettingsSyntaxError as e:
+                msg = "Error in settings repo configuration: {}".format(e)
+                logger.error(msg)
+                session.rollback()
+                return CnaasJSONResponse(
+                    status_code=500,
+                    content=empty_result(status="error", data=msg),
+                )
+            except VlanConflictError as e:
+                msg = "VLAN conflict in repo configuration: {}".format(e)
+                logger.error(msg)
+                session.rollback()
+                return CnaasJSONResponse(
+                    status_code=500,
+                    content=empty_result(status="error", data=msg),
+                )
+            except AccessListGenerationError as e:
+                msg = str(e)
+                logger.error(msg)
+                session.rollback()
+                return CnaasJSONResponse(
+                    status_code=500,
+                    content=empty_result(status="error", data=msg),
+                )
+
+        if "synchronized" in json_data and json_data["synchronized"]:
+            remove_sync_events(dev.hostname)
+
+        if "state" in json_data and json_data["state"].upper() == "UNMANAGED" and dev_prev_state == DeviceState.MANAGED:
+            add_sync_event(dev.hostname, "was_unmanaged", by=user)
+
+        session.commit()
+        update_device_primary_groups()
+        dev_dict = device_data_postprocess([dev])[0]
+        return empty_result(status="success", data={"updated_device": dev_dict})
+
+
+# ---------------------------------------------------------------------------
+# 2. DeviceByHostnameApi  GET /device/{hostname}
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}")
+def get_device_by_hostname(hostname: str, user: str = Depends(get_current_user)):
+    """Get a device from hostname."""
+    result = empty_result()
+    result["data"] = {"devices": []}
+    with sqla_session() as session:
+        instance = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if instance:
+            result["data"]["devices"] = device_data_postprocess([instance])
+        else:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 3. DeviceApi  POST /devices  (add new device)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/devices")
+def add_device(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Add a device."""
+    supported_platforms = ["eos", "junos", "ios", "iosxr", "nxos", "nxos_ssh"]
+    data: dict = {}
+    errors: list = []
+    data, errors = Device.validate(**json_data)
+    if errors != []:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data=errors),
+        )
+    with sqla_session() as session:
+        instance: Optional[Device] = session.query(Device).filter(Device.hostname == data["hostname"]).one_or_none()
+        if instance:
+            errors.append("Device already exists")
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=errors),
+            )
+        if "platform" not in data or data["platform"] not in supported_platforms:
+            errors.append(
+                "Device platform not specified or not known (must be any of: {})".format(", ".join(supported_platforms))
+            )
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=errors),
+            )
+        if data["device_type"] in ["DIST", "CORE"]:
+            if "management_ip" not in data or not data["management_ip"]:
+                data["management_ip"] = cnaas_nms.devicehandler.underlay.find_free_mgmt_lo_ip(session)
+            if "infra_ip" not in data or not data["infra_ip"]:
+                data["infra_ip"] = cnaas_nms.devicehandler.underlay.find_free_infra_ip(session)
+        new_device = Device.device_create(**data)
+        session.add(new_device)
+        session.flush()
+        update_device_primary_groups()
+        dev_dict = device_data_postprocess([new_device])[0]
+        return empty_result(status="success", data={"added_device": dev_dict})
+
+
+# ---------------------------------------------------------------------------
+# 4. DevicesApi  GET /devices  (list with filtering/pagination)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/devices")
+def get_devices(request: Request, user: str = Depends(get_current_user)):
+    """Get all devices."""
+    logger.info("started get devices")
+    device_list: List[Device] = []
+    total_count = 0
+    args = dict(request.query_params)
+
+    per_page = int(args.get("per_page", 50))
+    page = int(args.get("page", 1))
+
+    with sqla_session() as session:
+        query = session.query(Device, func.count(Device.id).over().label("total"))
+        try:
+            query = build_filter(Device, query, args, per_page=per_page, page=page)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Unable to filter devices: {}".format(e)),
+            )
+        for instance in query:
+            device_list.append(instance.Device)
+            total_count = instance.total
+        data = {"devices": device_data_postprocess(device_list)}
+
+    headers = pagination_headers(
+        total_count, args, per_page=per_page, page=page, base_url=str(request.base_url) + "api/v1.0/devices"
+    )
+    return CnaasJSONResponse(
+        content=empty_result(status="success", data=data),
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. DeviceInitApi  POST /device_init/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_init/{device_id}")
+def init_device(device_id: int, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Init a device."""
+    try:
+        job_kwargs = init_device_arg_check(device_id, json_data)
+    except ValueError as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data=str(e)),
+        )
+
+    # If device init is already in progress, reschedule a new step2 (connectivity check)
+    # instead of trying to restart initialization
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.id == device_id).one_or_none()
+        if dev and dev.state == DeviceState.INIT and dev.management_ip and dev.device_type is not DeviceType.UNKNOWN:
+            scheduler = Scheduler()
+            job_id = scheduler.add_onetime_job(
+                "cnaas_nms.devicehandler.init_device:init_device_step2",
+                when=1,
+                scheduled_by=user,
+                kwargs={"device_id": device_id, "iteration": 1},
+            )
+
+            logger.info("Re-scheduled init step 2 for {} as job # {}".format(device_id, job_id))
+            res = empty_result(data=f"Re-scheduled init step 2 for device_id {device_id}")
+            res["job_id"] = job_id
+            return res
+
+    if job_kwargs["device_type"] == DeviceType.ACCESS.name:
+        del job_kwargs["device_type"]
+        del job_kwargs["neighbors"]
+        scheduler = Scheduler()
+        job_id = scheduler.add_onetime_job(
+            "cnaas_nms.devicehandler.init_device:init_access_device_step1",
+            when=1,
+            scheduled_by=user,
+            kwargs=job_kwargs,
+        )
+    elif job_kwargs["device_type"] in [DeviceType.CORE.name, DeviceType.DIST.name]:
+        scheduler = Scheduler()
+        job_id = scheduler.add_onetime_job(
+            "cnaas_nms.devicehandler.init_device:init_fabric_device_step1",
+            when=1,
+            scheduled_by=user,
+            kwargs=job_kwargs,
+        )
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Unsupported 'device_type' provided"),
+        )
+
+    res = empty_result(data=f"Scheduled job to initialize device_id {str(device_id)}")
+    res["job_id"] = job_id
+
+    return res
+
+
+# ---------------------------------------------------------------------------
+# 6. DeviceInitCheckApi  POST /device_initcheck/{device_id}
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_initcheck/{device_id}")
+def initcheck_device(device_id: int, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Perform init check on a device."""
+    ret: dict[str, Any] = {}
+    linknets_all: list = []
+    mlag_peer_dev: Optional[Device]
+    try:
+        parsed_args = init_device_arg_check(device_id, json_data)
+        target_devtype = DeviceType[parsed_args["device_type"]]
+        target_hostname = parsed_args["new_hostname"]
+        mlag_peer_target_hostname: Optional[str] = None
+        mlag_peer_id: Optional[int] = None
+        mlag_peer_dev = None
+        if "mlag_peer_id" in parsed_args and "mlag_peer_new_hostname" in parsed_args:
+            mlag_peer_target_hostname = parsed_args["mlag_peer_new_hostname"]
+            mlag_peer_id = parsed_args["mlag_peer_id"]
+    except ValueError as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Error parsing arguments: {}".format(e)),
+        )
+
+    with sqla_session() as session:
+        try:
+            dev: Device = cnaas_nms.devicehandler.init_device.pre_init_checks(session, device_id)
+            linknets_all = dev.get_linknets_as_dict(session)
+        except ValueError as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="ValueError in pre_init_checks: {}".format(e)),
+            )
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Exception in pre_init_checks: {}".format(e)),
+            )
+
+        if mlag_peer_id:
+            try:
+                mlag_peer_dev = cnaas_nms.devicehandler.init_device.pre_init_checks(session, mlag_peer_id)
+                linknets_all += mlag_peer_dev.get_linknets_as_dict(session)
+            except ValueError as e:
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(status="error", data="ValueError in pre_init_checks: {}".format(e)),
+                )
+            except Exception as e:
+                return CnaasJSONResponse(
+                    status_code=500,
+                    content=empty_result(status="error", data="Exception in pre_init_checks: {}".format(e)),
+                )
+
+        try:
+            linknets_all += cnaas_nms.devicehandler.update.update_linknets(
+                session,
+                hostname=dev.hostname,
+                devtype=target_devtype,
+                ztp_hostname=target_hostname,
+                mlag_peer_dev=mlag_peer_dev,
+                dry_run=True,
+            )
+            if mlag_peer_dev:
+                linknets_all += cnaas_nms.devicehandler.update.update_linknets(
+                    session,
+                    hostname=mlag_peer_dev.hostname,
+                    devtype=target_devtype,
+                    ztp_hostname=mlag_peer_target_hostname,
+                    mlag_peer_dev=dev,
+                    dry_run=True,
+                )
+            ret["linknets"] = Linknet.deduplicate_linknet_dicts(linknets_all)
+            ret["linknets_compatible"] = True
+        except ValueError as e:
+            ret["linknets_compatible"] = False
+            ret["linknets_error"] = str(e)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Exception in update_linknets: {}".format(e)),
+            )
+
+        try:
+            if "linknets" in ret and ret["linknets"]:
+                try:
+                    ret["neighbors"] = cnaas_nms.devicehandler.init_device.pre_init_check_neighbors(
+                        session, dev, target_devtype, ret["linknets"], parsed_args["neighbors"], mlag_peer_dev
+                    )
+                    ret["neighbors_compatible"] = True
+                except cnaas_nms.devicehandler.init_device.InitVerificationError as e:
+                    ret["neighbors_compatible"] = False
+                    ret["neighbors_error"] = str(e)
+            else:
+                ret["neighbors_compatible"] = False
+                ret["neighbors_error"] = "No linknets found"
+        except (ValueError, cnaas_nms.devicehandler.init_device.InitVerificationError) as e:
+            ret["neighbors_compatible"] = False
+            ret["neighbors_error"] = str(e)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(
+                    status="error",
+                    data="Exception in pre_init_check_neighbors: {}".format(e),
+                ),
+            )
+
+        if mlag_peer_dev:
+            try:
+                ret["mlag_compatible"] = mlag_peer_dev.hostname in ret["neighbors"]
+            except Exception:
+                ret["mlag_compatible"] = False
+
+    ret["parsed_args"] = parsed_args
+    if mlag_peer_id and not ret["mlag_compatible"]:
+        ret["compatible"] = False
+    elif ret["linknets_compatible"] and ret["neighbors_compatible"]:
+        ret["compatible"] = True
+    else:
+        ret["compatible"] = False
+    return empty_result(data=ret)
+
+
+# ---------------------------------------------------------------------------
+# 7. DeviceDiscoverApi  POST /device_discover
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_discover")
+def discover_device(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Discover device."""
+    if "ztp_mac" not in json_data:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="POST data must include 'ztp_mac'"),
+        )
+    if "dhcp_ip" not in json_data:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="POST data must include 'dhcp_ip'"),
+        )
+    ztp_mac = json_data["ztp_mac"]
+    dhcp_ip = json_data["dhcp_ip"]
+
+    job_id = cnaas_nms.devicehandler.init_device.schedule_discover_device(
+        ztp_mac=ztp_mac, dhcp_ip=dhcp_ip, iteration=1, scheduled_by=user
+    )
+
+    logger.debug(f"Discover device for ztp_mac {ztp_mac} scheduled as ID {job_id}")
+
+    res = empty_result(data=f"Scheduled job to discover device for ztp_mac {ztp_mac}")
+    res["job_id"] = job_id
+
+    return res
+
+
+# ---------------------------------------------------------------------------
+# 8. DeviceSyncApi  POST /device_syncto
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_syncto")
+def sync_devices(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Start sync of device(s)."""
+    kwargs = parse_syncto_args(json_data)
+
+    total_count: Optional[int] = None
+    nr = cnaas_init()
+
+    if "hostname" in json_data:
+        hostname = str(json_data["hostname"])
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+            )
+        _, total_count, _ = inventory_selector(nr, hostname=hostname)
+        if total_count != 1:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error",
+                    data=f"Hostname '{hostname}' not found or is not a managed device",
+                ),
+            )
+        kwargs["hostnames"] = [hostname]
+        what = hostname
+    elif "device_type" in json_data:
+        devtype_str = str(json_data["device_type"]).upper()
+        if DeviceType.has_name(devtype_str):
+            kwargs["device_type"] = devtype_str
+        else:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error",
+                    data=f"Invalid device type '{json_data['device_type']}' specified",
+                ),
+            )
+        what = f"{json_data['device_type']} devices"
+        _, total_count, _ = inventory_selector(nr, resync=kwargs["resync"], device_type=devtype_str)
+    elif "group" in json_data:
+        group_name = str(json_data["group"])
+        if group_name not in get_groups():
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Could not find a group with name {}".format(group_name)),
+            )
+        kwargs["group"] = group_name
+        what = "group {}".format(group_name)
+        _, total_count, _ = inventory_selector(nr, resync=kwargs["resync"], group=group_name)
+    elif "all" in json_data and isinstance(json_data["all"], bool) and json_data["all"]:
+        what = "all devices"
+        _, total_count, _ = inventory_selector(nr, resync=kwargs["resync"])
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="No devices to synchronize were specified"),
+        )
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.sync_devices:sync_devices",
+        when=1,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+
+    res = empty_result(data=f"Scheduled job to synchronize {what}")
+    res["job_id"] = job_id
+
+    headers: dict[str, str] = {}
+    if total_count:
+        headers["X-Total-Count"] = str(total_count)
+    return CnaasJSONResponse(content=res, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# 9. DeviceSyncHostnameApi  POST /device_syncto/{hostname}
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_syncto/{hostname}")
+def sync_device_by_hostname(
+    hostname: str,
+    json_data: dict[str, Any],
+    user: str = Depends(get_current_user),
+):
+    """Start sync of device by hostname."""
+    kwargs = parse_syncto_args(json_data)
+
+    total_count: Optional[int] = None
+    nr = cnaas_init()
+
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+        )
+    _, total_count, _ = inventory_selector(nr, hostname=hostname)
+    if total_count != 1:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(
+                status="error",
+                data=f"Hostname '{hostname}' not found or is not a managed device",
+            ),
+        )
+    kwargs["hostnames"] = [hostname]
+    what = hostname
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.sync_devices:sync_devices",
+        when=1,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+    res = empty_result(data=f"Scheduled job to synchronize {what}")
+    res["job_id"] = job_id
+
+    headers: dict[str, str] = {}
+    if total_count:
+        headers["X-Total-Count"] = str(total_count)
+    return CnaasJSONResponse(content=res, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# 10. DeviceUpdateFactsApi  POST /device_update_facts
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_update_facts")
+def update_facts(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Start update facts of device(s)."""
+    kwargs: dict = {}
+
+    total_count: Optional[int] = None
+
+    if "hostname" in json_data:
+        hostname = str(json_data["hostname"])
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+            )
+        with sqla_session() as session:
+            dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+            if not dev or (dev.state != DeviceState.MANAGED and dev.state != DeviceState.UNMANAGED):
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error",
+                        data=f"Hostname '{hostname}' not found or is in invalid state",
+                    ),
+                )
+        kwargs["hostname"] = hostname
+        total_count = 1
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="No target to be updated was specified"),
+        )
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.update:update_facts",
+        when=1,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+
+    res = empty_result(data=f"Scheduled job to update facts for {hostname}")
+    res["job_id"] = job_id
+
+    headers: dict[str, str] = {}
+    if total_count:
+        headers["X-Total-Count"] = str(total_count)
+    return CnaasJSONResponse(content=res, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# 11. DeviceUpdateInterfacesApi  POST /device_update_interfaces
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_update_interfaces")
+def update_interfaces(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Update/scan interfaces of device."""
+    kwargs: dict = {"replace": False, "delete_all": False, "mlag_peer_hostname": None}
+
+    total_count: Optional[int] = None
+
+    if "hostname" in json_data:
+        hostname = str(json_data["hostname"])
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+            )
+        with sqla_session() as session:
+            dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+            if not dev or (dev.state != DeviceState.MANAGED and dev.state != DeviceState.UNMANAGED):
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error",
+                        data=f"Hostname '{hostname}' not found or is in invalid state",
+                    ),
+                )
+            if dev.device_type != DeviceType.ACCESS:
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error",
+                        data="Only devices of type ACCESS has interface database to update",
+                    ),
+                )
+        kwargs["hostname"] = hostname
+        total_count = 1
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="No target to be updated was specified"),
+        )
+
+    if "mlag_peer_hostname" in json_data:
+        mlag_peer_hostname = str(json_data["mlag_peer_hostname"])
+        if not Device.valid_hostname(mlag_peer_hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error",
+                    data=f"Hostname '{mlag_peer_hostname}' is not a valid hostname",
+                ),
+            )
+        with sqla_session() as session:
+            dev = session.query(Device).filter(Device.hostname == mlag_peer_hostname).one_or_none()
+            if not dev or (dev.state != DeviceState.MANAGED and dev.state != DeviceState.UNMANAGED):
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error",
+                        data=f"Hostname '{mlag_peer_hostname}' not found or is in invalid state",
+                    ),
+                )
+            if dev.device_type != DeviceType.ACCESS:
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error",
+                        data="Only devices of type ACCESS has interface database to update",
+                    ),
+                )
+        kwargs["mlag_peer_hostname"] = mlag_peer_hostname
+
+    if "replace" in json_data and isinstance(json_data["replace"], bool) and json_data["replace"]:
+        kwargs["replace"] = True
+
+    if "delete_all" in json_data and isinstance(json_data["delete_all"], bool) and json_data["delete_all"]:
+        kwargs["delete_all"] = True
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.update:update_interfacedb",
+        when=1,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+
+    res = empty_result(data=f"Scheduled job to update interfaces for {hostname}")
+    res["job_id"] = job_id
+
+    headers: dict[str, str] = {}
+    if total_count:
+        headers["X-Total-Count"] = str(total_count)
+    return CnaasJSONResponse(content=res, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# 12. DeviceGenerateConfigApi  GET /device/{hostname}/generate_config
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/generate_config")
+def generate_config(hostname: str, user: str = Depends(get_current_user)):
+    """Get device configuration."""
+    result = empty_result()
+    result["data"] = {"config": None}
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+
+    try:
+        config, template_vars = cnaas_nms.devicehandler.sync_devices.generate_only(hostname)
+        template_vars["host"] = hostname
+        data = {
+            "hostname": hostname,
+            "generated_config": config,
+            "available_variables": template_vars,
+        }
+
+        result["data"]["config"] = data
+
+    except Exception as e:
+        logger.exception(f"Exception while generating config for device {hostname}")
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result(
+                status="error",
+                data="Exception while generating config for device {}: {} {}".format(hostname, type(e), str(e)),
+            ),
+        )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 13. DeviceRunningConfigApi  GET /device/{hostname}/running_config
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/running_config")
+def get_running_config(hostname: str, request: Request, user: str = Depends(get_current_user)):
+    """Get running configuration from device."""
+    args = dict(request.query_params)
+    result = empty_result()
+    result["data"] = {"config": None}
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+
+        try:
+            if "interface" in args:
+                running_config = cnaas_nms.devicehandler.get.get_running_config_interface(
+                    session, hostname, args["interface"]
+                )
+            else:
+                running_config = cnaas_nms.devicehandler.get.get_running_config(hostname)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result("error", "Exception: {}".format(str(e))),
+            )
+
+    result["data"]["config"] = running_config
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 14. DeviceLldpNeighborsApi  GET /device/{hostname}/lldp_neighbors
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/lldp_neighbors")
+def get_lldp_neighbors(hostname: str, user: str = Depends(get_current_user)):
+    """Get LLDP neighbors for device."""
+    result = empty_result()
+    result["data"] = {"lldp_neighbors": None}
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+    try:
+        lldp_result = cnaas_nms.devicehandler.get.get_neighbors(hostname)[hostname][0]
+        if lldp_result.failed:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Failed to get LLDP neighbors"),
+            )
+        lldp_data = lldp_result.result["lldp_neighbors"]
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result(status="error", data="Exception: {}".format(str(e))),
+        )
+    result["data"]["lldp_neighbors"] = lldp_data
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 15. DeviceLldpNeighborsDetailApi  GET /device/{hostname}/lldp_neighbors_detail
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/lldp_neighbors_detail")
+def get_lldp_neighbors_detail(hostname: str, user: str = Depends(get_current_user)):
+    """Get detailed LLDP neighbors for device."""
+    result = empty_result()
+    result["data"] = {"lldp_neighbors_detail": None}
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+    try:
+        lldp_result = cnaas_nms.devicehandler.get.get_neighbors(hostname, details=True)[hostname][0]
+        if lldp_result.failed:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Failed to get LLDP neighbors"),
+            )
+        lldp_data = lldp_result.result["lldp_neighbors_detail"]
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result(status="error", data="Exception: {}".format(str(e))),
+        )
+    result["data"]["lldp_neighbors_detail"] = lldp_data
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 16. DevicePreviousConfigApi  GET /device/{hostname}/previous_config
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/previous_config")
+def get_previous_config(hostname: str, request: Request, user: str = Depends(get_current_user)):
+    """Get previous configuration for device."""
+    args = dict(request.query_params)
+    result = empty_result()
+    result["data"] = {"config": None}
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+
+    kwargs: dict[str, Any] = {}
+    if "job_id" in args:
+        try:
+            kwargs["job_id"] = int(args["job_id"])
+        except Exception:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "job_id must be an integer"),
+            )
+    elif "previous" in args:
+        try:
+            kwargs["previous"] = int(args["previous"])
+        except Exception:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "previous must be an integer"),
+            )
+    elif "before" in args:
+        try:
+            kwargs["before"] = datetime.datetime.fromisoformat(args["before"])
+        except Exception:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "before must be a valid ISO format date time string"),
+            )
+
+    with sqla_session() as session:
+        try:
+            result["data"] = Job.get_previous_config(session, hostname, **kwargs)
+        except JobNotFoundError as e:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", str(e)))
+        except InvalidJobError as e:
+            return CnaasJSONResponse(status_code=500, content=empty_result("error", str(e)))
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result("error", "Unhandled exception: {}".format(e)),
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 17. DeviceApplyConfigApi  POST /device/{hostname}/apply_config
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device/{hostname}/apply_config")
+def apply_config(hostname: str, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Apply exact specified configuration to device without using templates."""
+    apply_kwargs: dict[str, Any] = {"hostname": hostname}
+    allow_live_run = api_settings.ALLOW_APPLY_CONFIG_LIVERUN
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+
+    if "full_config" not in json_data:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "full_config must be specified"),
+        )
+
+    if "dry_run" in json_data and isinstance(json_data["dry_run"], bool) and not json_data["dry_run"]:
+        if allow_live_run:
+            apply_kwargs["dry_run"] = False
+        else:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "Apply config live_run is not allowed"),
+            )
+    else:
+        apply_kwargs["dry_run"] = True
+
+    apply_kwargs["config"] = json_data["full_config"]
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.sync_devices:apply_config",
+        when=1,
+        scheduled_by=user,
+        kwargs=apply_kwargs,
+    )
+
+    res = empty_result(data=f"Scheduled job to apply config {hostname}")
+    res["job_id"] = job_id
+
+    return res
+
+
+# ---------------------------------------------------------------------------
+# 18. DeviceRestoreApi  POST /device/{hostname}/restore
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device/{hostname}/restore")
+def restore_config(hostname: str, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Restore configuration to previous version."""
+    apply_kwargs: dict[str, Any] = {"hostname": hostname}
+    config = None
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+
+    if "job_id" in json_data:
+        try:
+            job_id = int(json_data["job_id"])
+        except Exception:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "job_id must be an integer"),
+            )
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "job_id must be specified"),
+        )
+
+    with sqla_session() as session:
+        try:
+            prev_config_result = Job.get_previous_config(session, hostname, job_id=job_id)
+            failed = prev_config_result["failed"]
+            if not failed and "config" in prev_config_result:
+                config = prev_config_result["config"]
+        except JobNotFoundError as e:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", str(e)))
+        except InvalidJobError as e:
+            return CnaasJSONResponse(status_code=500, content=empty_result("error", str(e)))
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result("error", "Unhandled exception: {}".format(e)),
+            )
+
+    if failed:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "The specified job_id has a failed status"),
+        )
+
+    if not config:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result("error", "No config found in this job"),
+        )
+
+    if "dry_run" in json_data and isinstance(json_data["dry_run"], bool) and not json_data["dry_run"]:
+        apply_kwargs["dry_run"] = False
+    else:
+        apply_kwargs["dry_run"] = True
+
+    apply_kwargs["config"] = config
+
+    scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.sync_devices:apply_config",
+        when=1,
+        scheduled_by=user,
+        kwargs=apply_kwargs,
+    )
+
+    res = empty_result(data=f"Scheduled job to restore {hostname}")
+    res["job_id"] = job_id
+
+    return res
+
+
+# ---------------------------------------------------------------------------
+# 19. DeviceCertApi  POST /device_cert
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device_cert")
+def renew_cert(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Execute certificate related actions on device."""
+    kwargs: dict = {}
+
+    if "action" in json_data and isinstance(json_data["action"], str):
+        action = json_data["action"].upper()
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Required field 'action' was not specified"),
+        )
+
+    if "comment" in json_data and isinstance(json_data["comment"], str):
+        kwargs["job_comment"] = json_data["comment"]
+    if "ticket_ref" in json_data and isinstance(json_data["ticket_ref"], str):
+        kwargs["job_ticket_ref"] = json_data["ticket_ref"]
+
+    total_count: Optional[int] = None
+    nr = cnaas_init()
+
+    if "hostname" in json_data:
+        hostname = str(json_data["hostname"])
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+            )
+        _, total_count, _ = inventory_selector(nr, hostname=hostname)
+        if total_count != 1:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error",
+                    data=f"Hostname '{hostname}' not found or is not a managed device",
+                ),
+            )
+        kwargs["hostname"] = hostname
+    elif "group" in json_data:
+        group_name = str(json_data["group"])
+        if group_name not in get_groups():
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Could not find a group with name {}".format(group_name)),
+            )
+        kwargs["group"] = group_name
+        _, total_count, _ = inventory_selector(nr, group=group_name)
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="No devices were specified"),
+        )
+
+    if action == "RENEW":
+        scheduler = Scheduler()
+        job_id = scheduler.add_onetime_job(
+            "cnaas_nms.devicehandler.cert:renew_cert",
+            when=1,
+            scheduled_by=user,
+            kwargs=kwargs,
+        )
+
+        res = empty_result(data="Scheduled job to renew certificates")
+        res["job_id"] = job_id
+
+        headers: dict[str, str] = {}
+        if total_count:
+            headers["X-Total-Count"] = str(total_count)
+        return CnaasJSONResponse(content=res, headers=headers)
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data=f"Unknown action specified: {action}"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 20. DeviceStackmembersApi  GET /device/{hostname}/stackmembers
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/stackmembers")
+def get_stackmembers(hostname: str, user: str = Depends(get_current_user)):
+    """Get stackmembers for device."""
+    result = empty_result(data={"stackmembers": []})
+    with sqla_session() as session:
+        device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not device:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+        stackmembers = device.get_stackmembers(session)
+        for stackmember in stackmembers:
+            result["data"]["stackmembers"].append(stackmember.as_dict())
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 20. DeviceStackmembersApi  PUT /device/{hostname}/stackmembers
+# ---------------------------------------------------------------------------
+
+
+@router.put("/device/{hostname}/stackmembers")
+def update_stackmembers(
+    hostname: str,
+    json_data: dict[str, Any],
+    user: str = Depends(get_current_user),
+):
+    """Update stackmembers for device."""
+    try:
+        validated_json_data = StackmembersModel(**json_data).model_dump()
+        data = validated_json_data["stackmembers"]
+    except ValidationError as e:
+        errors = format_stackmember_errors(e.errors())
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", errors),
+        )
+    result = empty_result(data={"stackmembers": []})
+    with sqla_session() as session:
+        device_instance = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not device_instance:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+        try:
+            for stackmember in device_instance.get_stackmembers(session):
+                session.delete(stackmember)
+            session.flush()
+            for stackmember_data in data:
+                stackmember_data["device_id"] = device_instance.id
+                new_stackmember = Stackmember(**stackmember_data)
+                session.add(new_stackmember)
+                result["data"]["stackmembers"].append(new_stackmember.as_dict())
+        except ValueError as e:
+            session.rollback()
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", str(e)),
+            )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 21. DeviceSyncHistoryApi  GET /device/{hostname}/synchistory
+# ---------------------------------------------------------------------------
+
+
+@router.get("/device/{hostname}/synchistory")
+def get_synchistory(hostname: str, user: str = Depends(get_current_user)):
+    """Get sync history for device."""
+    result = empty_result()
+    result["data"] = {"hostnames": {}}
+    sync_history: SyncHistory
+
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+    sync_history = get_sync_events([hostname])
+
+    result["data"]["hostnames"] = sync_history.asdict()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 21. DeviceSyncHistoryApi  POST /device/{hostname}/synchistory
+# ---------------------------------------------------------------------------
+
+
+@router.post("/device/{hostname}/synchistory")
+def add_synchistory_event(
+    hostname: str,
+    json_data: dict[str, Any],
+    user: str = Depends(get_current_user),
+):
+    """Add a sync history event."""
+    try:
+        validated_json_data = NewSyncEventModel(**json_data).model_dump()
+    except ValidationError as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", parse_pydantic_error(e, NewSyncEventModel, json_data)),
+        )
+    with sqla_session() as session:
+        device_instance = session.query(Device).filter(Device.hostname == validated_json_data["hostname"]).one_or_none()
+        if not device_instance:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "Device not found"),
+            )
+    try:
+        add_sync_event(**validated_json_data)
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result("error", str(e)),
+        )
+    return empty_result(data=validated_json_data)
+
+
+# ---------------------------------------------------------------------------
+# 21. DeviceSyncHistoryApi  DELETE /device/{hostname}/synchistory
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/device/{hostname}/synchistory")
+def delete_synchistory(hostname: str, user: str = Depends(get_current_user)):
+    """Delete sync history for device."""
+    if not Device.valid_hostname(hostname):
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Invalid hostname specified"),
+        )
+    with sqla_session() as session:
+        device_instance = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not device_instance:
+            return CnaasJSONResponse(
+                status_code=404,
+                content=empty_result("error", "Device not found"),
+            )
+    try:
+        remove_sync_events(hostname)
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result("error", str(e)),
+        )
+    return empty_result(status="success", data=f"Removed sync events for {hostname}")

--- a/src/cnaas_nms/api/routers/firmware.py
+++ b/src/cnaas_nms/api/routers/firmware.py
@@ -1,0 +1,268 @@
+import json
+from datetime import datetime
+from typing import Any, Optional
+
+import requests
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.app_settings import api_settings
+from cnaas_nms.db.device import Device
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import get_groups
+from cnaas_nms.devicehandler.nornir_helper import cnaas_init, inventory_selector
+from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.log import get_logger
+
+logger = get_logger()
+
+router = APIRouter(tags=["firmware"])
+
+
+class FirmwareDownload(BaseModel):
+    url: str
+    checksum: Optional[dict[str, str]] = None
+    sha1: Optional[str] = None
+    verify_tls: bool
+    filename: Optional[str] = None
+
+
+class FirmwareUpgradecheck(BaseModel):
+    group: str
+
+
+@router.get("/firmware")
+def get_firmwares(user: str = Depends(get_current_user)):
+    """Get firmwares."""
+    try:
+        res = requests.get(api_settings.HTTPD_URL, verify=api_settings.VERIFY_TLS)
+        json_data = json.loads(res.content)["data"]
+    except Exception as e:
+        logger.exception(f"Exception when getting files: {e}")
+        return CnaasJSONResponse(status_code=404, content=empty_result(status="error", data="Could not get files"))
+    return empty_result(status="success", data=json_data)
+
+
+@router.post("/firmware")
+def download_firmware(firmware_data: FirmwareDownload, user: str = Depends(get_current_user)):
+    """Download new firmware."""
+    kwargs: dict[str, Any] = {}
+
+    if not firmware_data.checksum and not firmware_data.sha1:
+        return CnaasJSONResponse(content=empty_result(status="error", data="Missing parameter checksum"))
+
+    kwargs["url"] = firmware_data.url
+
+    if firmware_data.sha1:
+        kwargs["sha1"] = firmware_data.sha1
+    else:
+        kwargs["checksum"] = firmware_data.checksum
+
+    kwargs["verify_tls"] = firmware_data.verify_tls
+
+    scheduler: Scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.api.firmware:download_firmware_to_nms",
+        when=1,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+    res = empty_result(data="Scheduled job to download firmware")
+    res["job_id"] = job_id
+
+    return res
+
+
+@router.get("/firmware/{filename}")
+def get_firmware_image(filename: str, user: str = Depends(get_current_user)):
+    """Get information about a single firmware."""
+    try:
+        res = requests.get(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
+        json_data = json.loads(res.content)["data"]
+    except Exception as e:
+        logger.exception(f"Exception when getting file: {e}")
+        return CnaasJSONResponse(status_code=404, content=empty_result(status="error", data="Could not get file"))
+    return empty_result(status="success", data=json_data)
+
+
+@router.delete("/firmware/{filename}")
+def delete_firmware(filename: str, user: str = Depends(get_current_user)):
+    """Remove firmware."""
+    try:
+        res = requests.delete(f"{api_settings.HTTPD_URL}/{filename}", verify=api_settings.VERIFY_TLS)
+        json_data = json.loads(res.content)["data"]
+    except Exception as e:
+        logger.exception(f"Exception when deleting file: {e}")
+        return CnaasJSONResponse(status_code=404, content=empty_result(status="error", data="Could not delete file"))
+    return empty_result(status="success", data=json_data)
+
+
+@router.post("/firmware/{filename}/set-default")
+def set_default_firmware(filename: str, user: str = Depends(get_current_user)):
+    """Set a firmware as the default image."""
+    try:
+        res = requests.post(f"{api_settings.HTTPD_URL}/{filename}/set-default", verify=api_settings.VERIFY_TLS)
+        json_data = json.loads(res.content)["data"]
+    except Exception as e:
+        logger.exception(f"Exception when setting file as default: {e}")
+        return CnaasJSONResponse(
+            status_code=404, content=empty_result(status="error", data="Could not set file as default")
+        )
+    return empty_result(status="success", data=json_data)
+
+
+@router.post("/firmware/upgrade")
+def upgrade_firmware(json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Upgrade firmware on device."""
+    kwargs: dict[str, Any] = {}
+    seconds = 1
+    date_format = "%Y-%m-%d %H:%M:%S"
+    url = api_settings.FIRMWARE_URL
+
+    if "url" not in json_data and url == "":
+        return CnaasJSONResponse(
+            content=empty_result(
+                status="error", data='No external address configured for HTTPD, please specify one with "url"'
+            )
+        )
+
+    if "url" not in json_data:
+        kwargs["url"] = url
+    else:
+        if isinstance(json_data["url"], str):
+            kwargs["url"] = json_data["url"]
+        else:
+            return CnaasJSONResponse(content=empty_result(status="error", data="url should be a string"))
+
+    for bool_field in ["activate", "download", "reboot", "pre_flight", "post_flight", "staggered_upgrade"]:
+        if bool_field in json_data:
+            if isinstance(json_data[bool_field], bool):
+                kwargs[bool_field] = json_data[bool_field]
+            else:
+                return CnaasJSONResponse(content=empty_result(status="error", data=f"{bool_field} should be a boolean"))
+
+    if "post_waittime" in json_data:
+        if isinstance(json_data["post_waittime"], int):
+            kwargs["post_waittime"] = json_data["post_waittime"]
+        else:
+            return CnaasJSONResponse(content=empty_result(status="error", data="post_waittime should be an integer"))
+
+    if "filename" in json_data:
+        if isinstance(json_data["filename"], str):
+            kwargs["filename"] = json_data["filename"]
+        else:
+            return CnaasJSONResponse(content=empty_result(status="error", data="filename should be a string"))
+
+    total_count: Optional[int] = None
+    nr = cnaas_init()
+
+    if "hostname" in json_data:
+        hostname = str(json_data["hostname"])
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data=f"Hostname '{hostname}' is not a valid hostname"),
+            )
+        _, total_count, _ = inventory_selector(nr, hostname=hostname)
+        if total_count != 1:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error", data=f"Hostname '{hostname}' not found or is not a managed device"
+                ),
+            )
+        kwargs["hostname"] = hostname
+    elif "group" in json_data:
+        group_name = str(json_data["group"])
+        if group_name not in get_groups():
+            return CnaasJSONResponse(
+                content=empty_result(status="error", data="Could not find a group with name {}".format(group_name))
+            )
+        kwargs["group"] = group_name
+        _, total_count, _ = inventory_selector(nr, group=group_name)
+    else:
+        return CnaasJSONResponse(
+            status_code=400, content=empty_result(status="error", data="No devices to upgrade were specified")
+        )
+
+    if "comment" in json_data and isinstance(json_data["comment"], str):
+        kwargs["job_comment"] = json_data["comment"]
+    if "ticket_ref" in json_data and isinstance(json_data["ticket_ref"], str):
+        kwargs["job_ticket_ref"] = json_data["ticket_ref"]
+
+    if "start_at" in json_data:
+        try:
+            time_start = datetime.strptime(json_data["start_at"], date_format)
+            time_now = datetime.utcnow()
+
+            if time_start < time_now:
+                return CnaasJSONResponse(content=empty_result(status="error", data="start_at must be in the future"))
+            time_diff = time_start - time_now
+            seconds = int(time_diff.total_seconds())
+        except Exception as e:
+            logger.exception(f"Exception when scheduling job: {e}")
+            return CnaasJSONResponse(
+                content=empty_result(status="error", data=f"Invalid date format, should be: {date_format}")
+            )
+
+    scheduler: Scheduler = Scheduler()
+    job_id = scheduler.add_onetime_job(
+        "cnaas_nms.devicehandler.firmware:device_upgrade",
+        when=seconds,
+        scheduled_by=user,
+        kwargs=kwargs,
+    )
+    res = empty_result(data="Scheduled job to upgrade devices")
+    res["job_id"] = job_id
+
+    headers = {}
+    if total_count:
+        headers["X-Total-Count"] = str(total_count)
+    return CnaasJSONResponse(content=res, headers=headers)
+
+
+@router.post("/firmware/upgradecheck")
+def firmware_upgradecheck(check_data: FirmwareUpgradecheck, user: str = Depends(get_current_user)):
+    """Perform upgrade check on device group."""
+    nr = cnaas_init()
+    nr_filtered_group, dev_count, _ = inventory_selector(nr, group=check_data.group)
+
+    device_hostname_list = list(nr_filtered_group.inventory.hosts.keys())
+
+    with sqla_session() as session:
+        upgrade_groups: list[list[str]] = []
+        device_list: list[Device] = []
+
+        for device in device_hostname_list:
+            dev: Optional[Device] = session.query(Device).filter(Device.hostname == device).one_or_none()
+            if not dev:
+                raise Exception("Could not find device: {}".format(device))
+            device_list.append(dev)
+
+        try:
+            from cnaas_nms.devicehandler.upgradeorder import determine_upgrade_order
+
+            upgrade_device_groups: list[list[Device]] = determine_upgrade_order(session, device_list)
+        except NotImplementedError as e:
+            return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=str(e)))
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data=f"Could not determine upgrade order: {str(e)}"),
+            )
+        if not upgrade_device_groups:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error", data="Could not determine upgrade order for the specified device group"
+                ),
+            )
+        upgrade_groups = [[device.hostname for device in group] for group in upgrade_device_groups]
+
+    ret = empty_result(
+        status="success",
+        data={"upgrade_groups": upgrade_groups, "device_count": dev_count, "steps": len(upgrade_groups)},
+    )
+    return CnaasJSONResponse(content=ret, headers={"X-Total-Count": str(dev_count)})

--- a/src/cnaas_nms/api/routers/groups.py
+++ b/src/cnaas_nms/api/routers/groups.py
@@ -1,0 +1,105 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.device import Device, DeviceState
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import get_group, get_group_settings, get_groups
+
+router = APIRouter(tags=["groups"])
+
+
+def groups_populate(group_name: Optional[str] = None) -> dict:
+    if group_name:
+        tmpgroups: dict = {group_name: []}
+    else:
+        tmpgroups = {key: [] for key in get_groups()}
+    with sqla_session() as session:
+        devices: List[Device] = session.query(Device).all()
+        for dev in devices:
+            groups = get_groups(dev)
+            for group in groups:
+                if group in tmpgroups:
+                    tmpgroups[group].append(dev.hostname)
+    return tmpgroups
+
+
+def groups_settings_populate(group_name: Optional[str] = None) -> dict:
+    settings, _ = get_group_settings()
+
+    if group_name:
+        group_list = [group for group in settings.groups if group.name == group_name]
+    else:
+        group_list = settings.groups
+
+    ret = {}
+    for group in group_list:
+        ret[group.name] = group.model_dump()
+        del ret[group.name]["name"]
+
+    return ret
+
+
+def groups_osversion_populate(group_name: str):
+    os_versions: dict = {}
+
+    group = get_group(group_name)
+    if not group:
+        raise ValueError("Could not find group {}".format(group_name))
+
+    with sqla_session() as session:
+        devices: List[Device] = (
+            session.query(Device).filter(Device.state == DeviceState.MANAGED).order_by(Device.hostname.asc()).all()
+        )
+        for dev in devices:
+            if not dev.os_version:
+                continue
+            if group.matches(dev):
+                if dev.os_version in os_versions:
+                    os_versions[dev.os_version].append(dev.hostname)
+                else:
+                    os_versions[dev.os_version] = [dev.hostname]
+    return {group_name: os_versions}
+
+
+@router.get("/groups")
+def get_groups_api(user: str = Depends(get_current_user)):
+    """Get all groups."""
+    result = {"groups": groups_populate(), "group_settings": groups_settings_populate()}
+    return empty_result(status="success", data=result)
+
+
+@router.get("/groups/{group_name}")
+def get_group_by_name(group_name: str, user: str = Depends(get_current_user)):
+    """Get a single group by name."""
+    if group_name not in get_groups():
+        return CnaasJSONResponse(
+            status_code=404,
+            content=empty_result(status="error", data="No such group found, or group is not valid"),
+        )
+    result = {
+        "groups": groups_populate(group_name),
+        "group_settings": groups_settings_populate(group_name),
+    }
+    return empty_result(status="success", data=result)
+
+
+@router.get("/groups/{group_name}/os_version")
+def get_group_os_version(group_name: str, user: str = Depends(get_current_user)):
+    """Get OS version of all devices in a group."""
+    try:
+        group_os_versions = groups_osversion_populate(group_name)
+    except ValueError as e:
+        return CnaasJSONResponse(
+            status_code=404,
+            content=empty_result(status="error", data="Exception while getting group {}: {}".format(group_name, str(e))),
+        )
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=500,
+            content=empty_result(status="error", data="Exception while getting group {}: {}".format(group_name, str(e))),
+        )
+    result = {"groups": group_os_versions}
+    return empty_result(status="success", data=result)

--- a/src/cnaas_nms/api/routers/groups.py
+++ b/src/cnaas_nms/api/routers/groups.py
@@ -94,12 +94,16 @@ def get_group_os_version(group_name: str, user: str = Depends(get_current_user))
     except ValueError as e:
         return CnaasJSONResponse(
             status_code=404,
-            content=empty_result(status="error", data="Exception while getting group {}: {}".format(group_name, str(e))),
+            content=empty_result(
+                status="error", data="Exception while getting group {}: {}".format(group_name, str(e))
+            ),
         )
     except Exception as e:
         return CnaasJSONResponse(
             status_code=500,
-            content=empty_result(status="error", data="Exception while getting group {}: {}".format(group_name, str(e))),
+            content=empty_result(
+                status="error", data="Exception while getting group {}: {}".format(group_name, str(e))
+            ),
         )
     result = {"groups": group_os_versions}
     return empty_result(status="success", data=result)

--- a/src/cnaas_nms/api/routers/interface.py
+++ b/src/cnaas_nms/api/routers/interface.py
@@ -1,0 +1,320 @@
+import datetime
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.device import Device
+from cnaas_nms.db.interface import Interface, InterfaceConfigType
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import get_settings
+from cnaas_nms.devicehandler.interface_state import bounce_interfaces, get_interface_states
+from cnaas_nms.devicehandler.sync_devices import resolve_vlanid, resolve_vlanid_list
+from cnaas_nms.devicehandler.sync_history import add_sync_event
+
+router = APIRouter(tags=["interfaces"])
+
+
+@router.get("/device/{hostname}/interfaces")
+def get_interfaces(hostname: str, user: str = Depends(get_current_user)):
+    """List all interfaces."""
+    result = empty_result()
+    result["data"] = {"interfaces": []}
+    with sqla_session() as session:
+        dev = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+        result["data"]["hostname"] = dev.hostname
+        intfs = session.query(Interface).filter(Interface.device == dev).all()
+        interfaces = []
+        for intf in intfs:
+            ifdict = intf.as_dict()
+            ifdict["indexnum"] = Interface.interface_index_num(ifdict["name"])
+            interfaces.append(ifdict)
+        result["data"]["interfaces"] = sorted(interfaces, key=lambda i: i["indexnum"])
+    return result
+
+
+@router.put("/device/{hostname}/interfaces")
+def update_interfaces(hostname: str, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Update interface configuration.
+
+    Example: {"interfaces": {"Ethernet1": {"configtype": "ACCESS_AUTO"}}}
+    """
+    data: dict[str, Any] = {}
+    errors: list[str] = []
+    device_settings = None
+
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+
+        updated = False
+        if "interfaces" in json_data and isinstance(json_data["interfaces"], dict):
+            for if_name, if_dict in json_data["interfaces"].items():
+                if not isinstance(if_dict, dict):
+                    errors.append("Each interface must have a dict with data to update")
+                    continue
+                intf: Optional[Interface] = (
+                    session.query(Interface)
+                    .filter(Interface.device == dev)
+                    .filter(Interface.name == if_name)
+                    .one_or_none()
+                )
+                if not intf:
+                    errors.append(f"Interface {if_name} not found")
+                    continue
+                if intf.data and isinstance(intf.data, dict):
+                    intfdata_original: dict[str, Any] = dict(intf.data)
+                    intfdata: dict[str, Any] = dict(intf.data)
+                else:
+                    intfdata_original = {}
+                    intfdata = {}
+
+                if "configtype" in if_dict and if_dict["configtype"]:
+                    try:
+                        configtype = if_dict["configtype"].upper()
+                    except AttributeError:
+                        errors.append("configtype is not a string")
+                    else:
+                        if InterfaceConfigType.has_name(configtype):
+                            if intf.configtype != InterfaceConfigType[configtype]:
+                                intf.configtype = InterfaceConfigType[configtype]
+                                updated = True
+                                data[if_name] = {"configtype": configtype}
+                        else:
+                            errors.append(f"Invalid configtype received: {configtype}")
+
+                if "data" in if_dict and if_dict["data"]:
+                    if not device_settings:
+                        device_settings, _ = get_settings(dev, dev.device_type)
+                    if "vxlan" in if_dict["data"]:
+                        if if_dict["data"]["vxlan"] in device_settings["vxlans"]:
+                            intfdata["vxlan"] = if_dict["data"]["vxlan"]
+                        else:
+                            errors.append(
+                                "Specified VXLAN {} is not present in {}".format(if_dict["data"]["vxlan"], hostname)
+                            )
+                    if "untagged_vlan" in if_dict["data"]:
+                        if if_dict["data"]["untagged_vlan"] is None:
+                            if "untagged_vlan" in intfdata:
+                                del intfdata["untagged_vlan"]
+                        else:
+                            vlan_id = resolve_vlanid(if_dict["data"]["untagged_vlan"], device_settings["vxlans"])
+                            if vlan_id:
+                                intfdata["untagged_vlan"] = if_dict["data"]["untagged_vlan"]
+                            else:
+                                errors.append(
+                                    "Specified VLAN name {} is not present in {}".format(
+                                        if_dict["data"]["untagged_vlan"], hostname
+                                    )
+                                )
+                    if "tagged_vlan_list" in if_dict["data"]:
+                        if isinstance(if_dict["data"]["tagged_vlan_list"], list):
+                            vlan_id_list = resolve_vlanid_list(
+                                if_dict["data"]["tagged_vlan_list"], device_settings["vxlans"]
+                            )
+                            if len(vlan_id_list) == len(if_dict["data"]["tagged_vlan_list"]):
+                                intfdata["tagged_vlan_list"] = if_dict["data"]["tagged_vlan_list"]
+                            else:
+                                errors.append(
+                                    "Some VLAN names {} are not present in {}".format(
+                                        ", ".join(if_dict["data"]["tagged_vlan_list"]), hostname
+                                    )
+                                )
+                        else:
+                            errors.append(
+                                "tagged_vlan_list should be of type list, found {}".format(
+                                    type(if_dict["data"]["tagged_vlan_list"])
+                                )
+                            )
+                    if "neighbor" in if_dict["data"]:
+                        if isinstance(if_dict["data"]["neighbor"], str) and Device.valid_hostname(
+                            if_dict["data"]["neighbor"]
+                        ):
+                            intfdata["neighbor"] = if_dict["data"]["neighbor"]
+                        elif if_dict["data"]["neighbor"] is None:
+                            if "neighbor" in intfdata:
+                                del intfdata["neighbor"]
+                        else:
+                            errors.append(
+                                "Neighbor must be valid hostname, got: {}".format(if_dict["data"]["neighbor"])
+                            )
+                    if "neighbor_id" in if_dict["data"]:
+                        if isinstance(if_dict["data"]["neighbor_id"], int):
+                            intfdata["neighbor_id"] = if_dict["data"]["neighbor_id"]
+                        elif if_dict["data"]["neighbor_id"] is None:
+                            if "neighbor_id" in intfdata:
+                                del intfdata["neighbor_id"]
+                        else:
+                            errors.append(
+                                "Neighbor_id must be valid integer, got: {}".format(if_dict["data"]["neighbor_id"])
+                            )
+                    if "description" in if_dict["data"]:
+                        if (
+                            isinstance(if_dict["data"]["description"], str)
+                            and len(if_dict["data"]["description"]) <= 64
+                        ):
+                            if if_dict["data"]["description"]:
+                                intfdata["description"] = if_dict["data"]["description"]
+                            elif "description" in intfdata:
+                                del intfdata["description"]
+                        elif if_dict["data"]["description"] is None:
+                            if "description" in intfdata:
+                                del intfdata["description"]
+                        else:
+                            errors.append(
+                                "Description must be a string of 0-64 characters, got: {}".format(
+                                    if_dict["data"]["description"]
+                                )
+                            )
+                    if "enabled" in if_dict["data"]:
+                        if type(if_dict["data"]["enabled"]) is bool:
+                            intfdata["enabled"] = if_dict["data"]["enabled"]
+                        else:
+                            errors.append(
+                                "Enabled must be a bool, true or false, got: {}".format(if_dict["data"]["enabled"])
+                            )
+                    if "aggregate_id" in if_dict["data"]:
+                        if type(if_dict["data"]["aggregate_id"]) is int:
+                            intfdata["aggregate_id"] = if_dict["data"]["aggregate_id"]
+                        elif if_dict["data"]["aggregate_id"] is None:
+                            if "aggregate_id" in intfdata:
+                                del intfdata["aggregate_id"]
+                        else:
+                            errors.append("Aggregate ID must be an integer: {}".format(if_dict["data"]["aggregate_id"]))
+                    if "bpdu_filter" in if_dict["data"]:
+                        if type(if_dict["data"]["bpdu_filter"]) is bool:
+                            intfdata["bpdu_filter"] = if_dict["data"]["bpdu_filter"]
+                        else:
+                            errors.append(
+                                "bpdu_filter must be a bool, true or false, got: {}".format(
+                                    if_dict["data"]["bpdu_filter"]
+                                )
+                            )
+                    if "redundant_link" in if_dict["data"]:
+                        if type(if_dict["data"]["redundant_link"]) is bool:
+                            intfdata["redundant_link"] = if_dict["data"]["redundant_link"]
+                        else:
+                            errors.append(
+                                "redundant_link must be a bool, true or false, got: {}".format(
+                                    if_dict["data"]["redundant_link"]
+                                )
+                            )
+                    if "tags" in if_dict["data"]:
+                        if isinstance(if_dict["data"]["tags"], list):
+                            intfdata["tags"] = if_dict["data"]["tags"]
+                        else:
+                            errors.append("tags should be of type list, found {}".format(type(if_dict["data"]["tags"])))
+                    if "cli_append_str" in if_dict["data"]:
+                        if isinstance(if_dict["data"]["cli_append_str"], str):
+                            intfdata["cli_append_str"] = if_dict["data"]["cli_append_str"]
+                        else:
+                            errors.append(
+                                "cli_append_str must be a string, got: {}".format(if_dict["data"]["cli_append_str"])
+                            )
+                elif "data" in if_dict and not if_dict["data"]:
+                    intfdata: None = None  # type: ignore[no-redef]
+
+                if intfdata != intfdata_original:
+                    intf.data = intfdata
+                    updated = True
+                    if if_name in data:
+                        data[if_name]["data"] = intfdata
+                    else:
+                        data[if_name] = {"data": intfdata}
+
+        if updated:
+            dev.synchronized = False
+            add_sync_event(hostname, "interface_updated", user)
+
+    if errors:
+        if data:
+            ret = {"errors": errors, "updated": data}
+        else:
+            ret = {"errors": errors}
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=ret))
+    else:
+        return empty_result(status="success", data={"updated": data})
+
+
+@router.get("/device/{hostname}/interfaces_export")
+def export_interfaces(
+    hostname: str,
+    include_uplinks: bool = Query(False),
+    include_downlinks: bool = Query(True),
+    include_descriptions: bool = Query(True),
+    user: str = Depends(get_current_user),
+):
+    """Export all interfaces for local download."""
+    result: dict[str, dict] = {"interfaces": {}}
+    with sqla_session() as session:
+        dev = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Device not found"))
+        intfs = session.query(Interface).filter(Interface.device == dev).all()
+        for intf in intfs:
+            session.expunge(intf)
+            if not include_uplinks and intf.configtype == InterfaceConfigType.ACCESS_UPLINK:
+                continue
+            if not include_downlinks and intf.configtype == InterfaceConfigType.ACCESS_DOWNLINK:
+                continue
+            ifdict = intf.as_dict()
+            del ifdict["name"]
+            del ifdict["device_id"]
+            if not include_descriptions:
+                if "data" in ifdict and ifdict["data"] and "description" in ifdict["data"]:
+                    del ifdict["data"]["description"]
+            result["interfaces"][intf.name] = ifdict
+
+    timestamp_str: str = datetime.datetime.isoformat(datetime.datetime.now(), timespec="seconds")
+    return CnaasJSONResponse(
+        content=result,
+        headers={
+            "Content-Disposition": f"attachment; filename={hostname}-interfaces-{timestamp_str}.json",
+        },
+    )
+
+
+@router.get("/device/{hostname}/interface_status")
+def get_interface_status(hostname: str, user: str = Depends(get_current_user)):
+    """List all interfaces status."""
+    result = empty_result()
+    try:
+        result["data"] = {"interface_status": get_interface_states(hostname)}
+    except ValueError as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "Could not get interface states, invalid input: {}".format(e)),
+        )
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "Could not get interface states, unknown exception: {}".format(e)),
+        )
+    return result
+
+
+@router.put("/device/{hostname}/interface_status")
+def bounce_interface_status(hostname: str, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Bounce selected interfaces by applying bounce-down/bounce-up template."""
+    if "bounce_interfaces" in json_data and isinstance(json_data["bounce_interfaces"], list):
+        interfaces: List[str] = json_data["bounce_interfaces"]
+        try:
+            bounce_success = bounce_interfaces(hostname, interfaces)
+        except ValueError as e:
+            return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=str(e)))
+        except Exception as e:
+            return CnaasJSONResponse(status_code=500, content=empty_result(status="error", data=str(e)))
+
+        if bounce_success:
+            return empty_result(status="success", data="Bounced interfaces: {}".format(", ".join(interfaces)))
+        else:
+            return empty_result(
+                status="success",
+                data="No error, but no interfaces changed state: {}".format(", ".join(interfaces)),
+            )
+    else:
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data="Unknown action"))

--- a/src/cnaas_nms/api/routers/jobs.py
+++ b/src/cnaas_nms/api/routers/jobs.py
@@ -1,0 +1,193 @@
+import time
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from sqlalchemy import func
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.filtering import build_filter, pagination_headers
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.job import Job, JobStatus
+from cnaas_nms.db.joblock import Joblock
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.log import get_logger
+
+router = APIRouter(tags=["jobs"])
+
+
+class JobAction(BaseModel):
+    action: str
+    abort_reason: Optional[str] = None
+
+
+class JoblockDelete(BaseModel):
+    name: str
+
+
+def filter_job_dict(job_dict: dict, args: dict) -> dict:
+    """Filter out parts of job result dict based on query string arguments."""
+    logger = get_logger()
+    filter_map = {"syncto": {"config": 1, "diff": 2}}
+    filter_items = []
+    if (
+        not isinstance(job_dict, dict)
+        or "result" not in job_dict
+        or not isinstance(job_dict["result"], dict)
+        or "devices" not in job_dict["result"]
+        or "function_name" not in job_dict
+        or not isinstance(job_dict["function_name"], str)
+    ):
+        return job_dict
+
+    if job_dict["function_name"].startswith("sync_devices"):
+        for arg, value in args.items():
+            if arg == "filter_jobresult" and isinstance(value, str):
+                for item in value.split(","):
+                    if item in filter_map["syncto"].keys():
+                        filter_items.append(filter_map["syncto"][item])
+        for filter_item in sorted(filter_items, reverse=True):
+            for hostname, value in job_dict["result"]["devices"].items():
+                try:
+                    del job_dict["result"]["devices"][hostname]["job_tasks"][filter_item]
+                except KeyError:
+                    pass
+                except Exception as e:
+                    logger.debug("job filter_response exception: {}".format(e))
+    return job_dict
+
+
+@router.get("/jobs")
+def get_jobs(request: Request, user: str = Depends(get_current_user)):
+    """Get one or more jobs."""
+    data: dict[str, Any] = {"jobs": []}
+    total_count = 0
+    args = dict(request.query_params)
+
+    per_page = int(args.get("per_page", 50))
+    page = int(args.get("page", 1))
+
+    with sqla_session() as session:
+        query = session.query(Job, func.count(Job.id).over().label("total"))
+        try:
+            query = build_filter(Job, query, args, per_page=per_page, page=page)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Unable to filter jobs: {}".format(e)),
+            )
+        for instance in query:
+            job_dict = instance.Job.as_dict()
+            filtered_job_dict = filter_job_dict(job_dict, args)
+            data["jobs"].append(filtered_job_dict)
+            total_count = instance.total
+
+    headers = pagination_headers(total_count, args, per_page=per_page, page=page, base_url=str(request.base_url) + "api/v1.0/jobs")
+    return CnaasJSONResponse(
+        content=empty_result(status="success", data=data),
+        headers=headers,
+    )
+
+
+@router.get("/job/{job_id}")
+def get_job_by_id(job_id: int, request: Request, user: str = Depends(get_current_user)):
+    """Get job information by ID."""
+    args = dict(request.query_params)
+    with sqla_session() as session:
+        job = session.query(Job).filter(Job.id == job_id).one_or_none()
+        if job:
+            job_dict = job.as_dict()
+            filtered_job_dict = filter_job_dict(job_dict, args)
+            return empty_result(data={"jobs": [filtered_job_dict]})
+        else:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="No job with id {} found".format(job_id)),
+            )
+
+
+@router.put("/job/{job_id}")
+def modify_job(job_id: int, job_action: JobAction, user: str = Depends(get_current_user)):
+    """Modify a job (e.g. abort)."""
+    with sqla_session() as session:
+        job = session.query(Job).filter(Job.id == job_id).one_or_none()
+        if not job:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="No job with id {} found".format(job_id)),
+            )
+        job_status = job.status
+
+    action = str(job_action.action).upper()
+    if action == "ABORT":
+        allowed_jobstates = [JobStatus.SCHEDULED, JobStatus.RUNNING]
+        if job_status not in allowed_jobstates:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(
+                    status="error",
+                    data="Job id {} is in state {}, must be {} to abort".format(
+                        job_id, job_status, (" or ".join([x.name for x in allowed_jobstates]))
+                    ),
+                ),
+            )
+        abort_reason = "Aborted via API call"
+        if job_action.abort_reason and isinstance(job_action.abort_reason, str):
+            abort_reason = job_action.abort_reason[:255]
+
+        abort_reason += " (aborted by {})".format(user)
+
+        if job_status == JobStatus.SCHEDULED:
+            scheduler = Scheduler()
+            scheduler.remove_scheduled_job(job_id=job_id, abort_message=abort_reason)
+            time.sleep(2)
+        elif job_status == JobStatus.RUNNING:
+            with sqla_session() as session:
+                job = session.query(Job).filter(Job.id == job_id).one_or_none()
+                if not job:
+                    return CnaasJSONResponse(
+                        status_code=400,
+                        content=empty_result(status="error", data="No job with id {} found".format(job_id)),
+                    )
+                job.status = JobStatus.ABORTING
+
+        with sqla_session() as session:
+            job = session.query(Job).filter(Job.id == job_id).one_or_none()
+            if not job:
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(status="error", data="No job with id {} found".format(job_id)),
+                )
+            return empty_result(data={"jobs": [job.as_dict()]})
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result(status="error", data="Unknown action: {}".format(action)),
+        )
+
+
+@router.get("/joblocks")
+def get_joblocks(user: str = Depends(get_current_user)):
+    """Get job locks."""
+    locks = []
+    with sqla_session() as session:
+        for lock in session.query(Joblock).all():
+            locks.append(lock.as_dict())
+    return empty_result("success", data={"locks": locks})
+
+
+@router.delete("/joblocks")
+def delete_joblock(joblock_delete: JoblockDelete, user: str = Depends(get_current_user)):
+    """Remove a job lock."""
+    with sqla_session() as session:
+        lock = session.query(Joblock).filter(Joblock.name == joblock_delete.name).one_or_none()
+        if lock:
+            session.delete(lock)
+        else:
+            return CnaasJSONResponse(
+                status_code=404,
+                content=empty_result("error", "No such lock found in database"),
+            )
+
+    return empty_result("success", data={"name": joblock_delete.name, "status": "deleted"})

--- a/src/cnaas_nms/api/routers/jobs.py
+++ b/src/cnaas_nms/api/routers/jobs.py
@@ -83,7 +83,9 @@ def get_jobs(request: Request, user: str = Depends(get_current_user)):
             data["jobs"].append(filtered_job_dict)
             total_count = instance.total
 
-    headers = pagination_headers(total_count, args, per_page=per_page, page=page, base_url=str(request.base_url) + "api/v1.0/jobs")
+    headers = pagination_headers(
+        total_count, args, per_page=per_page, page=page, base_url=str(request.base_url) + "api/v1.0/jobs"
+    )
     return CnaasJSONResponse(
         content=empty_result(status="success", data=data),
         headers=headers,

--- a/src/cnaas_nms/api/routers/linknet.py
+++ b/src/cnaas_nms/api/routers/linknet.py
@@ -1,0 +1,204 @@
+from ipaddress import IPv4Network
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ValidationError
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.generic import parse_pydantic_error, update_sqla_object
+from cnaas_nms.api.linknet import f_linknet
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.device import Device, DeviceType
+from cnaas_nms.db.linknet import Linknet
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.devicehandler.sync_history import add_sync_event
+from cnaas_nms.devicehandler.underlay import find_free_infra_linknet
+
+router = APIRouter(tags=["linknets"])
+
+
+class LinknetCreate(BaseModel):
+    device_a: str
+    device_b: str
+    device_a_port: str
+    device_b_port: str
+    ipv4_network: Optional[str] = None
+
+
+class LinknetDelete(BaseModel):
+    id: int
+
+
+def validate_hostname(hostname: str) -> None:
+    if not Device.valid_hostname(hostname):
+        raise ValueError("Invalid hostname: {}".format(hostname))
+    with sqla_session() as session:
+        dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+        if not dev:
+            raise ValueError("Hostname {} not found in database".format(hostname))
+
+
+@router.get("/linknets")
+def get_linknets(user: str = Depends(get_current_user)):
+    """Get all linknets."""
+    result: dict[str, Any] = {"linknets": []}
+    with sqla_session() as session:
+        query = session.query(Linknet)
+        for instance in query:
+            result["linknets"].append(instance.as_dict())
+    return empty_result(status="success", data=result)
+
+
+@router.post("/linknets", status_code=201)
+def create_linknet(linknet_data: LinknetCreate, user: str = Depends(get_current_user)):
+    """Add a new linknet."""
+    errors = []
+    for device_arg in ["device_a", "device_b"]:
+        try:
+            validate_hostname(getattr(linknet_data, device_arg))
+        except ValueError as e:
+            errors.append("Bad parameter {}: {}".format(device_arg, e))
+
+    new_prefix = None
+    if linknet_data.ipv4_network:
+        try:
+            new_prefix = IPv4Network(linknet_data.ipv4_network)
+        except Exception as e:
+            errors.append("Invalid ipv4_network: {}".format(e))
+
+    if errors:
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=errors))
+
+    with sqla_session() as session:
+        dev_a: Optional[Device] = session.query(Device).filter(Device.hostname == linknet_data.device_a).one_or_none()
+        if not dev_a:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Hostname '{}' not found".format(linknet_data.device_a)),
+            )
+
+        dev_b: Optional[Device] = session.query(Device).filter(Device.hostname == linknet_data.device_b).one_or_none()
+        if not dev_b:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result(status="error", data="Hostname '{}' not found".format(linknet_data.device_b)),
+            )
+
+        ip_linknet_devtypes = [DeviceType.CORE, DeviceType.DIST]
+        if dev_a.device_type in ip_linknet_devtypes and dev_b.device_type in ip_linknet_devtypes:
+            if not new_prefix:
+                new_prefix = find_free_infra_linknet(session)
+            if not new_prefix:
+                return CnaasJSONResponse(
+                    status_code=400,
+                    content=empty_result(
+                        status="error", data="Device types requires IP linknets, but no prefix could be found"
+                    ),
+                )
+
+        try:
+            new_linknet = Linknet.create_linknet(
+                session,
+                linknet_data.device_a,
+                linknet_data.device_a_port,
+                linknet_data.device_b,
+                linknet_data.device_b_port,
+                new_prefix,
+            )
+            session.add(new_linknet)
+            session.commit()
+            data = new_linknet.as_dict()
+        except Exception as e:
+            session.rollback()
+            return CnaasJSONResponse(status_code=500, content=empty_result(status="error", data=str(e)))
+
+    return empty_result(status="success", data=data)
+
+
+@router.delete("/linknets")
+def delete_linknet_by_body(linknet_delete: LinknetDelete, user: str = Depends(get_current_user)):
+    """Remove linknet by ID (in request body)."""
+    with sqla_session() as session:
+        cur_linknet: Optional[Linknet] = session.query(Linknet).filter(Linknet.id == linknet_delete.id).one_or_none()
+        if not cur_linknet:
+            return CnaasJSONResponse(
+                status_code=404, content=empty_result(status="error", data="No such linknet found in database")
+            )
+        cur_linknet.device_a.synchronized = False
+        add_sync_event(cur_linknet.device_a.hostname, "linknet_deleted", user)
+        cur_linknet.device_b.synchronized = False
+        add_sync_event(cur_linknet.device_b.hostname, "linknet_deleted", user)
+        session.delete(cur_linknet)
+        session.commit()
+        return empty_result(status="success", data={"deleted_linknet": cur_linknet.as_dict()})
+
+
+@router.get("/linknet/{linknet_id}")
+def get_linknet_by_id(linknet_id: int, user: str = Depends(get_current_user)):
+    """Get a single linknet by ID."""
+    result = empty_result()
+    result["data"] = {"linknets": []}
+    with sqla_session() as session:
+        instance = session.query(Linknet).filter(Linknet.id == linknet_id).one_or_none()
+        if instance:
+            result["data"]["linknets"].append(instance.as_dict())
+        else:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Linknet not found"))
+    return result
+
+
+@router.delete("/linknet/{linknet_id}")
+def delete_linknet_by_id(linknet_id: int, user: str = Depends(get_current_user)):
+    """Remove a linknet by ID."""
+    with sqla_session() as session:
+        instance: Optional[Linknet] = session.query(Linknet).filter(Linknet.id == linknet_id).one_or_none()
+        if instance:
+            instance.device_a.synchronized = False
+            add_sync_event(instance.device_a.hostname, "linknet_deleted", user)
+            instance.device_b.synchronized = False
+            add_sync_event(instance.device_b.hostname, "linknet_deleted", user)
+            session.delete(instance)
+            session.commit()
+            return empty_result(status="success", data={"deleted_linknet": instance.as_dict()})
+        else:
+            return CnaasJSONResponse(
+                status_code=404, content=empty_result("error", "No such linknet found in database")
+            )
+
+
+@router.put("/linknet/{linknet_id}")
+def update_linknet(linknet_id: int, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Update data on existing linknet."""
+    errors = []
+    for device_arg in ["device_a", "device_b"]:
+        if device_arg in json_data:
+            try:
+                validate_hostname(json_data[device_arg])
+            except ValueError as e:
+                errors.append("Bad parameter {}: {}".format(device_arg, e))
+
+    if errors:
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=errors))
+
+    with sqla_session() as session:
+        instance: Optional[Linknet] = session.query(Linknet).filter(Linknet.id == linknet_id).one_or_none()
+        if instance:
+            try:
+                validate_data = {**instance.as_dict(), **json_data}
+                f_linknet(**validate_data).model_dump()
+            except ValidationError as e:
+                errors += parse_pydantic_error(e, f_linknet, validate_data)
+            if errors:
+                return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=errors))
+
+            changed: bool = update_sqla_object(instance, json_data)
+            if changed:
+                instance.device_a.synchronized = False
+                add_sync_event(instance.device_a.hostname, "linknet_updated", user)
+                instance.device_b.synchronized = False
+                add_sync_event(instance.device_b.hostname, "linknet_updated", user)
+                return empty_result(status="success", data={"updated_linknet": instance.as_dict()})
+            else:
+                return empty_result(status="success", data={"unchanged_linknet": instance.as_dict()})
+        else:
+            return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data="linknet not found"))

--- a/src/cnaas_nms/api/routers/mgmtdomain.py
+++ b/src/cnaas_nms/api/routers/mgmtdomain.py
@@ -1,0 +1,184 @@
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.filtering import build_filter
+from cnaas_nms.api.generic import parse_pydantic_error, update_sqla_object
+from cnaas_nms.api.mgmtdomain import f_mgmtdomain
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.device import Device
+from cnaas_nms.db.mgmtdomain import Mgmtdomain
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.devicehandler.sync_history import add_sync_event
+
+router = APIRouter(tags=["mgmtdomains"])
+
+
+class MgmtdomainCreate(BaseModel):
+    device_a: str
+    device_b: str
+    vlan: int
+    ipv4_gw: Optional[str] = None
+    ipv6_gw: Optional[str] = None
+    description: Optional[str] = None
+
+
+@router.get("/mgmtdomains")
+def get_mgmtdomains(request: Request, user: str = Depends(get_current_user)):
+    """Get all management domains."""
+    result = empty_result()
+    result["data"] = {"mgmtdomains": []}
+    args = dict(request.query_params)
+    per_page = int(args.get("per_page", 50))
+    page = int(args.get("page", 1))
+
+    with sqla_session() as session:
+        query = session.query(Mgmtdomain)
+        try:
+            query = build_filter(Mgmtdomain, query, args, per_page=per_page, page=page)
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result(status="error", data="Unable to filter mgmtdomains: {}".format(e)),
+            )
+        for instance in query:
+            result["data"]["mgmtdomains"].append(instance.as_dict())
+    return result
+
+
+@router.post("/mgmtdomains")
+def create_mgmtdomain(mgmtdomain_data: MgmtdomainCreate, user: str = Depends(get_current_user)):
+    """Add management domain."""
+    json_data = mgmtdomain_data.model_dump()
+    data: dict[str, Any] = {}
+    errors = []
+
+    with sqla_session() as session:
+        hostname_a = str(json_data["device_a"])
+        if not Device.valid_hostname(hostname_a):
+            errors.append(f"Invalid hostname for device_a: {hostname_a}")
+        else:
+            device_a: Optional[Device] = session.query(Device).filter(Device.hostname == hostname_a).one_or_none()
+            if not device_a:
+                errors.append(f"Device with hostname {hostname_a} not found")
+            else:
+                data["device_a"] = device_a
+
+        hostname_b = str(json_data["device_b"])
+        if not Device.valid_hostname(hostname_b):
+            errors.append(f"Invalid hostname for device_b: {hostname_b}")
+        else:
+            device_b: Optional[Device] = session.query(Device).filter(Device.hostname == hostname_b).one_or_none()
+            if not device_b:
+                errors.append(f"Device with hostname {hostname_b} not found")
+            else:
+                data["device_b"] = device_b
+
+        try:
+            data = {**data, **f_mgmtdomain(**json_data).model_dump()}
+        except ValidationError as e:
+            errors += parse_pydantic_error(e, f_mgmtdomain, json_data)
+
+        required_keys_1 = ["device_a", "device_b", "vlan", "ipv4_gw"]
+        required_keys_2 = ["device_a", "device_b", "vlan", "ipv6_gw"]
+        required_in_data = all(key in data for key in required_keys_1) or all(key in data for key in required_keys_2)
+        required_in_json_data = all(key in json_data for key in required_keys_1) or all(
+            key in json_data for key in required_keys_2
+        )
+        if required_in_data and required_in_json_data:
+            new_mgmtd = Mgmtdomain()
+            new_mgmtd.device_a = data["device_a"]
+            new_mgmtd.device_b = data["device_b"]
+            new_mgmtd.ipv4_gw = data["ipv4_gw"]
+            new_mgmtd.ipv6_gw = data["ipv6_gw"]
+            new_mgmtd.vlan = data["vlan"]
+            try:
+                session.add(new_mgmtd)
+                session.flush()
+            except IntegrityError as e:
+                session.rollback()
+                if "duplicate" in str(e) and e.orig:
+                    return CnaasJSONResponse(
+                        status_code=400,
+                        content=empty_result("error", "Duplicate value: {}".format(e.orig.args[0])),
+                    )
+                else:
+                    return CnaasJSONResponse(
+                        status_code=400,
+                        content=empty_result("error", "Integrity error: {}".format(e)),
+                    )
+
+            device_a.synchronized = False  # type: ignore[union-attr]
+            add_sync_event(device_a.hostname, "mgmtdomain_created", user)  # type: ignore[union-attr]
+            device_b.synchronized = False  # type: ignore[union-attr]
+            add_sync_event(device_b.hostname, "mgmtdomain_created", user)  # type: ignore[union-attr]
+            return empty_result(status="success", data={"added_mgmtdomain": new_mgmtd.as_dict()})
+        else:
+            errors.append(
+                "Not all required inputs were found: {} OR {}".format(
+                    ", ".join(required_keys_1), ", ".join(required_keys_2)
+                )
+            )
+            return CnaasJSONResponse(status_code=400, content=empty_result("error", errors))
+
+
+@router.get("/mgmtdomain/{mgmtdomain_id}")
+def get_mgmtdomain_by_id(mgmtdomain_id: int, user: str = Depends(get_current_user)):
+    """Get management domain by ID."""
+    result = empty_result()
+    result["data"] = {"mgmtdomains": []}
+    with sqla_session() as session:
+        instance = session.query(Mgmtdomain).filter(Mgmtdomain.id == mgmtdomain_id).one_or_none()
+        if instance:
+            result["data"]["mgmtdomains"].append(instance.as_dict())
+        else:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Management domain not found"))
+    return result
+
+
+@router.delete("/mgmtdomain/{mgmtdomain_id}")
+def delete_mgmtdomain(mgmtdomain_id: int, user: str = Depends(get_current_user)):
+    """Remove management domain."""
+    with sqla_session() as session:
+        instance: Optional[Mgmtdomain] = session.query(Mgmtdomain).filter(Mgmtdomain.id == mgmtdomain_id).one_or_none()
+        if instance:
+            instance.device_a.synchronized = False
+            add_sync_event(instance.device_a.hostname, "mgmtdomain_deleted", user)
+            instance.device_b.synchronized = False
+            add_sync_event(instance.device_b.hostname, "mgmtdomain_deleted", user)
+            session.delete(instance)
+            session.commit()
+            return empty_result(status="success", data={"deleted_mgmtdomain": instance.as_dict()})
+        else:
+            return CnaasJSONResponse(status_code=404, content=empty_result("error", "Management domain not found"))
+
+
+@router.put("/mgmtdomain/{mgmtdomain_id}")
+def update_mgmtdomain(mgmtdomain_id: int, json_data: dict[str, Any], user: str = Depends(get_current_user)):
+    """Modify management domain."""
+    errors = []
+    try:
+        f_mgmtdomain(**json_data).model_dump()
+    except ValidationError as e:
+        errors += parse_pydantic_error(e, f_mgmtdomain, json_data)
+
+    if errors:
+        return CnaasJSONResponse(status_code=400, content=empty_result("error", errors))
+
+    with sqla_session() as session:
+        instance: Optional[Mgmtdomain] = session.query(Mgmtdomain).filter(Mgmtdomain.id == mgmtdomain_id).one_or_none()
+        if instance:
+            changed: bool = update_sqla_object(instance, json_data)
+            if changed:
+                instance.device_a.synchronized = False
+                add_sync_event(instance.device_a.hostname, "mgmtdomain_updated", user)
+                instance.device_b.synchronized = False
+                add_sync_event(instance.device_b.hostname, "mgmtdomain_updated", user)
+                return empty_result(status="success", data={"updated_mgmtdomain": instance.as_dict()})
+            else:
+                return empty_result(status="success", data={"unchanged_mgmtdomain": instance.as_dict()})
+        else:
+            return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data="mgmtdomain not found"))

--- a/src/cnaas_nms/api/routers/plugins.py
+++ b/src/cnaas_nms/api/routers/plugins.py
@@ -20,9 +20,7 @@ def get_plugins(user: str = Depends(get_current_user)):
         plugindata = pmh.get_plugindata()
         plugin_module_names = pmh.get_plugins()
     except Exception as e:
-        return CnaasJSONResponse(
-            content=empty_result("error", "Error retrieving plugins {}".format(str(e)))
-        )
+        return CnaasJSONResponse(content=empty_result("error", "Error retrieving plugins {}".format(str(e))))
     else:
         return empty_result("success", {"loaded_plugins": plugin_module_names, "plugindata": plugindata})
 

--- a/src/cnaas_nms/api/routers/plugins.py
+++ b/src/cnaas_nms/api/routers/plugins.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.plugins.pluginmanager import PluginManagerHandler
+
+router = APIRouter(tags=["plugins"])
+
+
+class PluginAction(BaseModel):
+    action: str
+
+
+@router.get("/plugins")
+def get_plugins(user: str = Depends(get_current_user)):
+    """List all plugins."""
+    try:
+        pmh = PluginManagerHandler()
+        plugindata = pmh.get_plugindata()
+        plugin_module_names = pmh.get_plugins()
+    except Exception as e:
+        return CnaasJSONResponse(
+            content=empty_result("error", "Error retrieving plugins {}".format(str(e)))
+        )
+    else:
+        return empty_result("success", {"loaded_plugins": plugin_module_names, "plugindata": plugindata})
+
+
+@router.put("/plugins")
+def modify_plugins(plugin_action: PluginAction, user: str = Depends(get_current_user)):
+    """Modify plugins."""
+    if str(plugin_action.action).upper() == "SELFTEST":
+        pmh = PluginManagerHandler()
+        res = pmh.pm.hook.selftest()
+        return empty_result("success", {"result": res})
+    else:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "Unknown action specified"),
+        )

--- a/src/cnaas_nms/api/routers/repository.py
+++ b/src/cnaas_nms/api/routers/repository.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.db.git import RepoType, get_repo_status, refresh_repo
+from cnaas_nms.db.joblock import JoblockError
+from cnaas_nms.db.settings import SettingsSyntaxError, VerifyPathException
+
+router = APIRouter(tags=["repository"])
+
+
+class RepositoryAction(BaseModel):
+    action: str
+
+
+@router.get("/repository/{repo}")
+def get_repository(repo: str, user: str = Depends(get_current_user)):
+    """Get repository information."""
+    try:
+        repo_type = RepoType[str(repo).upper()]
+    except Exception:
+        return CnaasJSONResponse(status_code=400, content=empty_result("error", "Invalid repository type"))
+    return empty_result("success", get_repo_status(repo_type))
+
+
+@router.put("/repository/{repo}")
+def modify_repository(repo: str, repo_action: RepositoryAction, user: str = Depends(get_current_user)):
+    """Modify repository."""
+    try:
+        repo_type = RepoType[str(repo).upper()]
+    except Exception:
+        return CnaasJSONResponse(status_code=400, content=empty_result("error", "Invalid repository type"))
+
+    if str(repo_action.action).upper() == "REFRESH":
+        try:
+            res = refresh_repo(repo_type, user)
+            return empty_result("success", res)
+        except VerifyPathException as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "Repository structure is invalid ({}): {}".format(type(e).__name__, str(e))),
+            )
+        except JoblockError as e:
+            return CnaasJSONResponse(
+                status_code=503,
+                content=empty_result(
+                    "error",
+                    "Another job is locking configuration of devices, try again later ({})".format(str(e)),
+                ),
+            )
+        except SettingsSyntaxError as e:
+            return CnaasJSONResponse(
+                status_code=400,
+                content=empty_result("error", "Syntax error in repository: {}".format(str(e))),
+            )
+        except Exception as e:
+            return CnaasJSONResponse(
+                status_code=500,
+                content=empty_result("error", "Error in repository: {}".format(str(e))),
+            )
+    else:
+        return CnaasJSONResponse(status_code=400, content=empty_result("error", "Invalid action"))

--- a/src/cnaas_nms/api/routers/repository.py
+++ b/src/cnaas_nms/api/routers/repository.py
@@ -39,7 +39,9 @@ def modify_repository(repo: str, repo_action: RepositoryAction, user: str = Depe
         except VerifyPathException as e:
             return CnaasJSONResponse(
                 status_code=400,
-                content=empty_result("error", "Repository structure is invalid ({}): {}".format(type(e).__name__, str(e))),
+                content=empty_result(
+                    "error", "Repository structure is invalid ({}): {}".format(type(e).__name__, str(e))
+                ),
             )
         except JoblockError as e:
             return CnaasJSONResponse(

--- a/src/cnaas_nms/api/routers/settings.py
+++ b/src/cnaas_nms/api/routers/settings.py
@@ -47,7 +47,9 @@ def get_settings_api(
                 model = dev.model
                 session.expunge(dev)
             else:
-                return CnaasJSONResponse(status_code=400, content=empty_result("error", "Hostname not found in database"))
+                return CnaasJSONResponse(
+                    status_code=400, content=empty_result("error", "Hostname not found in database")
+                )
 
     if device_type:
         if DeviceType.has_name(device_type.upper()):

--- a/src/cnaas_nms/api/routers/settings.py
+++ b/src/cnaas_nms/api/routers/settings.py
@@ -1,0 +1,99 @@
+import json
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import CnaasJSONResponse, empty_result
+from cnaas_nms.app_settings import api_settings
+from cnaas_nms.db.device import Device, DeviceType
+from cnaas_nms.db.helper import json_dumper
+from cnaas_nms.db.session import sqla_session
+from cnaas_nms.db.settings import (
+    AccessListGenerationError,
+    SettingsSyntaxError,
+    check_settings_syntax,
+    check_system_access_lists,
+    get_generated_access_lists,
+    get_settings,
+    get_settings_root,
+)
+from cnaas_nms.tools.mergedict import merge_dict_origin
+
+router = APIRouter(tags=["settings"])
+
+settings_root_model = get_settings_root()
+
+
+@router.get("/settings")
+def get_settings_api(
+    hostname: Optional[str] = Query(None),
+    device_type: Optional[str] = Query(None),
+    user: str = Depends(get_current_user),
+):
+    """Get settings."""
+    dev = None
+    resolved_device_type = None
+    model = None
+
+    if hostname:
+        if not Device.valid_hostname(hostname):
+            return CnaasJSONResponse(status_code=400, content=empty_result("error", "Invalid hostname specified"))
+        with sqla_session() as session:
+            dev = session.query(Device).filter(Device.hostname == hostname).one_or_none()
+            if dev:
+                resolved_device_type = dev.device_type
+                model = dev.model
+                session.expunge(dev)
+            else:
+                return CnaasJSONResponse(status_code=400, content=empty_result("error", "Hostname not found in database"))
+
+    if device_type:
+        if DeviceType.has_name(device_type.upper()):
+            resolved_device_type = DeviceType[device_type.upper()]
+        else:
+            return CnaasJSONResponse(status_code=400, content=empty_result("error", "Invalid device type specified"))
+
+    try:
+        settings, settings_origin = get_settings(dev, resolved_device_type, model)
+    except Exception as e:
+        return CnaasJSONResponse(
+            status_code=400,
+            content=empty_result("error", "Error getting settings: {}".format(str(e))),
+        )
+
+    return empty_result(data={"settings": settings, "settings_origin": settings_origin})
+
+
+@router.get("/settings/model")
+def get_settings_model():
+    """Get the settings JSON schema."""
+    return JSONResponse(content=settings_root_model.model_json_schema())
+
+
+@router.post("/settings/model")
+def validate_settings_model(request_body: dict[str, Any]):
+    """Validate settings against the schema."""
+    syntax_dict, syntax_dict_origin = merge_dict_origin({}, request_body, {}, "API POST data")
+    try:
+        ret = check_settings_syntax(syntax_dict, syntax_dict_origin)
+        if "access_lists" in syntax_dict:
+            ret_copy = ret.copy()
+            ret_copy["system_access_lists"] = list(ret_copy.get("access_lists", {}).keys())
+            get_generated_access_lists(platform="eos", settings=ret_copy)
+        if "access_lists" in syntax_dict and "system_access_lists" in syntax_dict:
+            check_system_access_lists(syntax_dict)
+    except SettingsSyntaxError as e:
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=str(e)))
+    except AccessListGenerationError as e:
+        return CnaasJSONResponse(status_code=400, content=empty_result(status="error", data=str(e)))
+    else:
+        return empty_result(status="success", data=ret)
+
+
+@router.get("/settings/server")
+def get_settings_server(user: str = Depends(get_current_user)):
+    """Get server settings."""
+    ret_dict = {"api": api_settings.model_dump()}
+    return JSONResponse(content=json.loads(json.dumps(ret_dict, default=json_dumper)))

--- a/src/cnaas_nms/api/routers/system.py
+++ b/src/cnaas_nms/api/routers/system.py
@@ -1,0 +1,45 @@
+from os.path import abspath, dirname
+
+from fastapi import APIRouter, Depends
+from git import InvalidGitRepositoryError, NoSuchPathError, Repo
+
+import cnaas_nms.version
+from cnaas_nms.api.dependencies import get_current_user
+from cnaas_nms.api.response import empty_result
+from cnaas_nms.scheduler.scheduler import Scheduler
+
+router = APIRouter(tags=["system"])
+
+
+@router.get("/system/version")
+def get_version():
+    """Get the running version of CNaaS NMS."""
+    version_str = cnaas_nms.version.__version__
+    try:
+        src_repo_path = dirname(dirname(dirname(abspath(cnaas_nms.version.__file__))))
+        local_repo = Repo(src_repo_path)
+        git_version_str = "Git commit {} ({})".format(
+            local_repo.head.commit.name_rev, local_repo.head.commit.committed_datetime
+        )
+    except (InvalidGitRepositoryError, NoSuchPathError):
+        git_version_str = "No git repo found"
+    except Exception:
+        git_version_str = "Unhandled exception"
+
+    return empty_result(status="success", data={"version": version_str, "git_version": git_version_str})
+
+
+@router.post("/system/shutdown")
+def shutdown_system(user: str = Depends(get_current_user)):
+    """Shutdown the CNaaS NMS system."""
+    print("System shutdown API called, exiting...")
+    scheduler = Scheduler()
+    try:
+        scheduler.shutdown_mule()
+    except Exception:
+        pass
+    try:
+        scheduler.shutdown()
+    except Exception:
+        pass
+    return empty_result(status="success", data="Shutdown initiated")

--- a/src/cnaas_nms/api/tests/test_fastapi_foundation.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_foundation.py
@@ -1,0 +1,92 @@
+"""Tests for the FastAPI app foundation: CORS, error handlers, auth, and simple endpoints."""
+
+import unittest
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cnaas_nms.api.fastapi_app import app
+
+client = TestClient(app)
+
+
+class TestCORS(unittest.TestCase):
+    def test_cors_headers_present(self):
+        response = client.options(
+            "/api/v1.0/system/version",
+            headers={"Origin": "http://example.com", "Access-Control-Request-Method": "GET"},
+        )
+        assert "access-control-allow-origin" in response.headers
+
+
+class TestSystemEndpoints(unittest.TestCase):
+    def test_get_version(self):
+        response = client.get("/api/v1.0/system/version")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "version" in data["data"]
+        assert "git_version" in data["data"]
+
+    def test_shutdown_endpoint_exists(self):
+        """Verify the shutdown endpoint exists and is reachable.
+
+        The actual shutdown may fail because the scheduler isn't running in
+        test mode, but the endpoint should respond (not 404).
+        """
+        response = client.post("/api/v1.0/system/shutdown")
+        assert response.status_code != 404
+
+
+class TestPluginEndpoints(unittest.TestCase):
+    def test_get_plugins(self):
+        response = client.get("/api/v1.0/plugins")
+        # May succeed or error depending on plugin manager state
+        data = response.json()
+        assert data["status"] in ("success", "error")
+
+    def test_put_plugins_unknown_action(self):
+        response = client.put("/api/v1.0/plugins", json={"action": "UNKNOWN"})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "Unknown action" in data["message"]
+
+    def test_put_plugins_missing_action(self):
+        response = client.put("/api/v1.0/plugins", json={})
+        # Pydantic validation will reject missing required field
+        assert response.status_code == 422
+
+
+class TestResponseFormat(unittest.TestCase):
+    """Verify that the response format matches the Flask API contract."""
+
+    def test_success_response_has_status_and_data(self):
+        response = client.get("/api/v1.0/system/version")
+        data = response.json()
+        assert "status" in data
+        assert "data" in data
+        assert data["status"] == "success"
+
+    def test_error_response_has_status_and_message(self):
+        response = client.put("/api/v1.0/plugins", json={"action": "INVALID"})
+        data = response.json()
+        assert "status" in data
+        assert "message" in data
+        assert data["status"] == "error"
+
+
+class TestOpenAPIDocs(unittest.TestCase):
+    def test_openapi_json_available(self):
+        response = client.get("/api/openapi.json")
+        assert response.status_code == 200
+        data = response.json()
+        assert "paths" in data
+
+    def test_docs_page_available(self):
+        response = client.get("/api/doc/")
+        assert response.status_code == 200
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_fastapi_foundation.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_foundation.py
@@ -2,7 +2,6 @@
 
 import unittest
 
-import pytest
 from fastapi.testclient import TestClient
 
 from cnaas_nms.api.fastapi_app import app

--- a/src/cnaas_nms/api/tests/test_fastapi_pr2.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_pr2.py
@@ -1,0 +1,126 @@
+"""Tests for PR 2 FastAPI endpoints: repository, settings, jobs."""
+
+import unittest
+
+from fastapi.testclient import TestClient
+
+from cnaas_nms.api.fastapi_app import app
+
+client = TestClient(app)
+
+
+class TestRepositoryEndpoints(unittest.TestCase):
+    def test_get_repository_invalid_type(self):
+        response = client.get("/api/v1.0/repository/invalid_repo")
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "Invalid repository type" in data["message"]
+
+    def test_put_repository_invalid_type(self):
+        response = client.put("/api/v1.0/repository/invalid_repo", json={"action": "REFRESH"})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_put_repository_invalid_action(self):
+        response = client.put("/api/v1.0/repository/settings", json={"action": "INVALID"})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "Invalid action" in data["message"]
+
+    def test_put_repository_missing_action(self):
+        response = client.put("/api/v1.0/repository/settings", json={})
+        # Pydantic validation rejects missing required field
+        assert response.status_code == 422
+
+
+class TestSettingsEndpoints(unittest.TestCase):
+    def test_get_settings_model_schema(self):
+        response = client.get("/api/v1.0/settings/model")
+        assert response.status_code == 200
+        data = response.json()
+        # Should return a JSON schema
+        assert "properties" in data or "type" in data or "$defs" in data
+
+    def test_post_settings_model_empty(self):
+        response = client.post("/api/v1.0/settings/model", json={})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+
+    def test_get_settings_invalid_hostname(self):
+        response = client.get("/api/v1.0/settings?hostname=not a valid hostname!!!")
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_get_settings_invalid_device_type(self):
+        response = client.get("/api/v1.0/settings?device_type=NONEXISTENT")
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "Invalid device type" in data["message"]
+
+
+class TestJobEndpoints(unittest.TestCase):
+    def test_get_job_not_found(self):
+        response = client.get("/api/v1.0/job/999999")
+        # Without DB this will error, but endpoint should exist
+        assert response.status_code != 404 or response.status_code == 400
+
+    def test_put_job_unknown_action(self):
+        response = client.put("/api/v1.0/job/1", json={"action": "UNKNOWN"})
+        # Either job not found (400) or unknown action (400)
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_put_job_missing_action(self):
+        response = client.put("/api/v1.0/job/1", json={})
+        # Pydantic validation rejects missing required field
+        assert response.status_code == 422
+
+    def test_delete_joblock_missing_name(self):
+        response = client.request("DELETE", "/api/v1.0/joblocks", json={})
+        # Pydantic validation rejects missing required field
+        assert response.status_code == 422
+
+
+class TestResponseFormat(unittest.TestCase):
+    """Verify backwards-compatible response format for new endpoints."""
+
+    def test_repository_error_format(self):
+        response = client.get("/api/v1.0/repository/invalid")
+        data = response.json()
+        assert "status" in data
+        assert "message" in data
+        assert data["status"] == "error"
+
+    def test_settings_model_is_json(self):
+        response = client.get("/api/v1.0/settings/model")
+        assert response.headers["content-type"] == "application/json"
+
+
+class TestOpenAPIInclusion(unittest.TestCase):
+    """Verify new endpoints appear in OpenAPI spec."""
+
+    def test_repository_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("repository" in path for path in paths)
+
+    def test_settings_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("settings" in path for path in paths)
+
+    def test_jobs_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("job" in path for path in paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_fastapi_pr3.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_pr3.py
@@ -1,0 +1,140 @@
+"""Tests for PR 3 FastAPI endpoints: linknet and mgmtdomain."""
+
+import unittest
+
+from fastapi.testclient import TestClient
+
+from cnaas_nms.api.fastapi_app import app
+
+client = TestClient(app)
+
+
+class TestLinknetEndpoints(unittest.TestCase):
+    def test_get_linknet_not_found(self):
+        response = client.get("/api/v1.0/linknet/999999")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["status"] == "error"
+        assert "not found" in data["message"].lower()
+
+    def test_delete_linknet_not_found(self):
+        response = client.delete("/api/v1.0/linknet/999999")
+        assert response.status_code == 404
+
+    def test_create_linknet_invalid_hostname(self):
+        response = client.post(
+            "/api/v1.0/linknets",
+            json={
+                "device_a": "not valid!!!",
+                "device_b": "also-not-valid!!!",
+                "device_a_port": "eth0",
+                "device_b_port": "eth1",
+            },
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_create_linknet_missing_fields(self):
+        response = client.post("/api/v1.0/linknets", json={"device_a": "test"})
+        # Pydantic validation rejects missing required fields
+        assert response.status_code == 422
+
+    def test_delete_linknet_by_body_missing_id(self):
+        response = client.request("DELETE", "/api/v1.0/linknets", json={})
+        assert response.status_code == 422
+
+    def test_put_linknet_not_found(self):
+        response = client.put("/api/v1.0/linknet/999999", json={"ipv4_network": "10.0.0.0/31"})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+
+class TestMgmtdomainEndpoints(unittest.TestCase):
+    def test_get_mgmtdomain_not_found(self):
+        response = client.get("/api/v1.0/mgmtdomain/999999")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["status"] == "error"
+        assert "not found" in data["message"].lower()
+
+    def test_delete_mgmtdomain_not_found(self):
+        response = client.delete("/api/v1.0/mgmtdomain/999999")
+        assert response.status_code == 404
+
+    def test_create_mgmtdomain_invalid_hostname(self):
+        response = client.post(
+            "/api/v1.0/mgmtdomains",
+            json={
+                "device_a": "not valid!!!",
+                "device_b": "also not valid!!!",
+                "vlan": 100,
+                "ipv4_gw": "10.0.0.1/24",
+            },
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_create_mgmtdomain_missing_fields(self):
+        response = client.post("/api/v1.0/mgmtdomains", json={"device_a": "test"})
+        assert response.status_code == 422
+
+    def test_put_mgmtdomain_not_found(self):
+        response = client.put("/api/v1.0/mgmtdomain/999999", json={"vlan": 200})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_put_mgmtdomain_invalid_ipv4(self):
+        response = client.put("/api/v1.0/mgmtdomain/999999", json={"ipv4_gw": "not-an-ip"})
+        assert response.status_code == 400
+
+
+class TestPydanticValidation(unittest.TestCase):
+    """Test that existing Pydantic models (f_linknet, f_mgmtdomain) still work."""
+
+    def test_f_linknet_valid(self):
+        from cnaas_nms.api.linknet import f_linknet
+
+        obj = f_linknet(ipv4_network="10.0.0.0/31", device_a_ip="10.0.0.0", device_b_ip="10.0.0.1")
+        assert obj.ipv4_network == "10.0.0.0/31"
+
+    def test_f_linknet_invalid_prefix(self):
+        from pydantic import ValidationError
+
+        from cnaas_nms.api.linknet import f_linknet
+
+        with self.assertRaises(ValidationError):
+            f_linknet(ipv4_network="10.0.0.0/16")
+
+    def test_f_mgmtdomain_valid(self):
+        from cnaas_nms.api.mgmtdomain import f_mgmtdomain
+
+        obj = f_mgmtdomain(vlan=100, ipv4_gw="10.0.0.1/24")
+        assert obj.vlan == 100
+
+    def test_f_mgmtdomain_invalid_gw(self):
+        from pydantic import ValidationError
+
+        from cnaas_nms.api.mgmtdomain import f_mgmtdomain
+
+        with self.assertRaises(ValidationError):
+            f_mgmtdomain(ipv4_gw="not-an-ip")
+
+
+class TestOpenAPIInclusion(unittest.TestCase):
+    def test_linknet_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("linknet" in path for path in paths)
+
+    def test_mgmtdomain_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("mgmtdomain" in path for path in paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_fastapi_pr4.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_pr4.py
@@ -1,0 +1,88 @@
+"""Tests for PR 4 FastAPI endpoints: interface and firmware."""
+
+import unittest
+
+from fastapi.testclient import TestClient
+
+from cnaas_nms.api.fastapi_app import app
+
+client = TestClient(app)
+
+
+class TestInterfaceEndpoints(unittest.TestCase):
+    def test_get_interfaces_device_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/interfaces")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["status"] == "error"
+        assert "not found" in data["message"].lower()
+
+    def test_put_interfaces_device_not_found(self):
+        response = client.put(
+            "/api/v1.0/device/nonexistent-host/interfaces",
+            json={"interfaces": {"Ethernet1": {"configtype": "ACCESS_AUTO"}}},
+        )
+        assert response.status_code == 404
+
+    def test_export_interfaces_device_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/interfaces_export")
+        assert response.status_code == 404
+
+    def test_interface_status_device_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/interface_status")
+        # May return 400 (invalid input) or some other error since device doesn't exist
+        assert response.status_code in (400, 404, 500)
+
+    def test_bounce_interfaces_unknown_action(self):
+        response = client.put(
+            "/api/v1.0/device/nonexistent-host/interface_status",
+            json={"invalid_key": "value"},
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+
+class TestFirmwareEndpoints(unittest.TestCase):
+    def test_post_firmware_missing_checksum(self):
+        response = client.post(
+            "/api/v1.0/firmware",
+            json={"url": "http://example.com/fw.bin", "verify_tls": True},
+        )
+        data = response.json()
+        assert data["status"] == "error"
+        assert "checksum" in data["message"].lower()
+
+    def test_post_firmware_missing_fields(self):
+        response = client.post("/api/v1.0/firmware", json={})
+        assert response.status_code == 422
+
+    def test_upgrade_url_type_validation(self):
+        response = client.post(
+            "/api/v1.0/firmware/upgrade",
+            json={"url": 12345, "hostname": "testhost"},
+        )
+        # url is not a string, should return error
+        data = response.json()
+        assert data["status"] == "error"
+        assert "string" in data["message"].lower()
+
+    def test_upgradecheck_missing_group(self):
+        response = client.post("/api/v1.0/firmware/upgradecheck", json={})
+        assert response.status_code == 422
+
+
+class TestOpenAPIInclusion(unittest.TestCase):
+    def test_interface_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("interfaces" in path for path in paths)
+
+    def test_firmware_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("firmware" in path for path in paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_fastapi_pr5.py
+++ b/src/cnaas_nms/api/tests/test_fastapi_pr5.py
@@ -1,0 +1,170 @@
+"""Tests for PR 5-6 FastAPI endpoints: device (read + write)."""
+
+import unittest
+
+from fastapi.testclient import TestClient
+
+from cnaas_nms.api.fastapi_app import app
+
+client = TestClient(app)
+
+
+class TestDeviceReadEndpoints(unittest.TestCase):
+    """PR 5: Read-only device endpoints."""
+
+    def test_get_device_by_id_not_found(self):
+        response = client.get("/api/v1.0/device/999999")
+        assert response.status_code == 404
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_get_device_by_hostname_not_found(self):
+        # Use a valid-looking hostname so it doesn't get caught by int parsing
+        response = client.get("/api/v1.0/device/nonexistent-host")
+        # FastAPI tries /device/{device_id} first (int), then /device/{hostname}
+        # "nonexistent-host" is not an int so FastAPI returns 404 (hostname route)
+        assert response.status_code in (404, 422)  # 422 if int route matches first
+
+    def test_get_generate_config_invalid_hostname(self):
+        response = client.get("/api/v1.0/device/not valid!!!/generate_config")
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "invalid hostname" in data["message"].lower()
+
+    def test_get_running_config_invalid_hostname(self):
+        response = client.get("/api/v1.0/device/not valid!!!/running_config")
+        assert response.status_code == 400
+
+    def test_get_lldp_neighbors_invalid_hostname(self):
+        response = client.get("/api/v1.0/device/not valid!!!/lldp_neighbors")
+        assert response.status_code == 400
+
+    def test_get_lldp_neighbors_detail_invalid_hostname(self):
+        response = client.get("/api/v1.0/device/not valid!!!/lldp_neighbors_detail")
+        assert response.status_code == 400
+
+    def test_get_previous_config_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/previous_config")
+        assert response.status_code == 404
+
+    def test_get_stackmembers_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/stackmembers")
+        # May be 404 or 500 depending on DB access
+        assert response.status_code in (404, 500)
+
+
+class TestDeviceWriteEndpoints(unittest.TestCase):
+    """PR 6: Write device endpoints."""
+
+    def test_delete_device_not_found(self):
+        response = client.delete("/api/v1.0/device/999999")
+        assert response.status_code == 404
+
+    def test_put_device_not_found(self):
+        response = client.put("/api/v1.0/device/999999", json={"hostname": "test"})
+        assert response.status_code == 404
+
+    def test_post_device_missing_fields(self):
+        response = client.post("/api/v1.0/devices", json={})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_post_device_invalid_platform(self):
+        response = client.post(
+            "/api/v1.0/devices",
+            json={
+                "hostname": "testdevice",
+                "platform": "unsupported",
+                "state": "MANAGED",
+                "device_type": "ACCESS",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_init_device_missing_hostname(self):
+        response = client.post("/api/v1.0/device_init/999999", json={})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+
+    def test_init_device_missing_device_type(self):
+        response = client.post("/api/v1.0/device_init/999999", json={"hostname": "testhost"})
+        assert response.status_code == 400
+
+    def test_initcheck_missing_args(self):
+        response = client.post("/api/v1.0/device_initcheck/999999", json={})
+        assert response.status_code == 400
+
+    def test_discover_missing_ztp_mac(self):
+        response = client.post("/api/v1.0/device_discover", json={})
+        assert response.status_code == 400
+        data = response.json()
+        assert data["status"] == "error"
+        assert "ztp_mac" in data["message"].lower()
+
+    def test_syncto_in_openapi(self):
+        """Verify syncto endpoints are registered via OpenAPI spec."""
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("device_syncto" in path for path in paths)
+
+    def test_update_facts_no_hostname(self):
+        response = client.post("/api/v1.0/device_update_facts", json={})
+        assert response.status_code == 400
+
+    def test_update_facts_invalid_hostname(self):
+        response = client.post("/api/v1.0/device_update_facts", json={"hostname": "not valid!!!"})
+        assert response.status_code == 400
+
+    def test_update_interfaces_no_hostname(self):
+        response = client.post("/api/v1.0/device_update_interfaces", json={})
+        assert response.status_code == 400
+
+    def test_cert_missing_action(self):
+        response = client.post("/api/v1.0/device_cert", json={})
+        assert response.status_code == 400
+
+    def test_synchistory_get_not_found(self):
+        response = client.get("/api/v1.0/device/nonexistent-host/synchistory")
+        # Returns empty or 404
+        assert response.status_code in (200, 404)
+
+    def test_apply_config_missing_config(self):
+        response = client.post(
+            "/api/v1.0/device/testhost/apply_config",
+            json={},
+        )
+        # Missing full_config should error
+        assert response.status_code in (400, 422, 500)
+
+
+class TestDeviceResponseFormat(unittest.TestCase):
+    def test_device_error_format(self):
+        response = client.get("/api/v1.0/device/999999")
+        data = response.json()
+        assert "status" in data
+        assert data["status"] == "error"
+
+
+class TestDeviceOpenAPI(unittest.TestCase):
+    def test_device_endpoints_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("device" in path for path in paths)
+        assert any("devices" in path for path in paths)
+
+    def test_device_syncto_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("syncto" in path for path in paths)
+
+    def test_device_init_in_openapi(self):
+        response = client.get("/api/openapi.json")
+        paths = response.json()["paths"]
+        assert any("device_init" in path for path in paths)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_generic.py
+++ b/src/cnaas_nms/api/tests/test_generic.py
@@ -1,7 +1,7 @@
 """Unit tests for generic.py and the framework-agnostic filtering/response utilities."""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from pydantic import BaseModel, ValidationError
 
@@ -170,7 +170,7 @@ class TestBuildFilter(unittest.TestCase):
         mock_query.limit.return_value = mock_query
         mock_query.offset.return_value = mock_query
 
-        result = build_filter(mock_model, mock_query, {})
+        build_filter(mock_model, mock_query, {})
         mock_query.limit.assert_called_once_with(50)
         mock_query.offset.assert_called_once_with(0)
 
@@ -191,7 +191,7 @@ class TestBuildFilter(unittest.TestCase):
         mock_query.limit.return_value = mock_query
         mock_query.offset.return_value = mock_query
 
-        result = build_filter(mock_model, mock_query, {}, per_page=10, page=3)
+        build_filter(mock_model, mock_query, {}, per_page=10, page=3)
         mock_query.limit.assert_called_once_with(10)
         mock_query.offset.assert_called_once_with(20)
 

--- a/src/cnaas_nms/api/tests/test_generic.py
+++ b/src/cnaas_nms/api/tests/test_generic.py
@@ -1,0 +1,200 @@
+"""Unit tests for generic.py and the framework-agnostic filtering/response utilities."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel, ValidationError
+
+from cnaas_nms.api.filtering import build_filter, pagination_headers
+from cnaas_nms.api.generic import empty_result, parse_pydantic_error, update_sqla_object
+from cnaas_nms.api.response import empty_result as fastapi_empty_result
+
+
+class TestEmptyResult(unittest.TestCase):
+    def test_success_with_data(self):
+        result = empty_result(status="success", data={"key": "value"})
+        assert result == {"status": "success", "data": {"key": "value"}}
+
+    def test_success_with_none(self):
+        result = empty_result(status="success", data=None)
+        assert result == {"status": "success", "data": None}
+
+    def test_error_with_message(self):
+        result = empty_result(status="error", data="Something went wrong")
+        assert result == {"status": "error", "message": "Something went wrong"}
+
+    def test_error_with_none(self):
+        result = empty_result(status="error", data=None)
+        assert result == {"status": "error", "message": "Unknown error"}
+
+    def test_unknown_status(self):
+        result = empty_result(status="unknown")
+        assert result == {}
+
+
+class TestFastapiEmptyResult(unittest.TestCase):
+    """Verify the FastAPI response helper produces identical output."""
+
+    def test_success_with_data(self):
+        result = fastapi_empty_result(status="success", data={"key": "value"})
+        assert result == {"status": "success", "data": {"key": "value"}}
+
+    def test_error_with_message(self):
+        result = fastapi_empty_result(status="error", data="Something went wrong")
+        assert result == {"status": "error", "message": "Something went wrong"}
+
+    def test_error_with_none(self):
+        result = fastapi_empty_result(status="error", data=None)
+        assert result == {"status": "error", "message": "Unknown error"}
+
+    def test_unknown_status(self):
+        result = fastapi_empty_result(status="unknown")
+        assert result == {}
+
+
+class TestUpdateSqlaObject(unittest.TestCase):
+    def test_update_changes_attributes(self):
+        obj = MagicMock()
+        obj.name = "old"
+        obj.value = 1
+        changed = update_sqla_object(obj, {"name": "new", "value": 2})
+        assert changed is True
+        assert obj.name == "new"
+        assert obj.value == 2
+
+    def test_no_change_returns_false(self):
+        obj = MagicMock()
+        obj.name = "same"
+        changed = update_sqla_object(obj, {"name": "same"})
+        assert changed is False
+
+    def test_id_field_is_skipped(self):
+        obj = MagicMock()
+        obj.id = 1
+        obj.name = "old"
+        changed = update_sqla_object(obj, {"id": 999, "name": "new"})
+        assert changed is True
+        assert obj.id == 1  # id should not be changed
+
+    def test_nonexistent_attribute_is_skipped(self):
+        obj = MagicMock(spec=["name"])
+        obj.name = "old"
+        # MagicMock with spec will raise AttributeError for non-existent attrs
+        changed = update_sqla_object(obj, {"nonexistent": "value"})
+        assert changed is False
+
+
+class TestParsePydanticError(unittest.TestCase):
+    def test_parse_validation_error(self):
+        class TestModel(BaseModel):
+            name: str
+            age: int
+
+        try:
+            TestModel(name=123, age="not_a_number")  # type: ignore
+        except ValidationError as e:
+            errors = parse_pydantic_error(e, TestModel, {"name": 123, "age": "not_a_number"})
+            assert len(errors) > 0
+            assert any("age" in err for err in errors)
+
+
+class TestPaginationHeaders(unittest.TestCase):
+    def test_single_page(self):
+        headers = pagination_headers(total_count=10, args={}, per_page=50, page=1, base_url="http://test/api")
+        assert headers["X-Total-Count"] == "10"
+        assert "Link" not in headers
+
+    def test_multiple_pages(self):
+        headers = pagination_headers(total_count=100, args={}, per_page=10, page=1, base_url="http://test/api")
+        assert headers["X-Total-Count"] == "100"
+        assert "Link" in headers
+        assert 'rel="next"' in headers["Link"]
+        assert 'rel="last"' in headers["Link"]
+        assert "page=2" in headers["Link"]
+        assert "page=10" in headers["Link"]
+
+    def test_last_page_no_next(self):
+        headers = pagination_headers(total_count=100, args={}, per_page=10, page=10, base_url="http://test/api")
+        assert headers["X-Total-Count"] == "100"
+        assert "Link" not in headers
+
+    def test_preserves_existing_args(self):
+        headers = pagination_headers(
+            total_count=100,
+            args={"filter[name]": "test"},
+            per_page=10,
+            page=1,
+            base_url="http://test/api",
+        )
+        assert "filter%5Bname%5D=test" in headers["Link"]
+
+    def test_zero_results(self):
+        headers = pagination_headers(total_count=0, args={}, per_page=50, page=1, base_url="http://test/api")
+        assert headers["X-Total-Count"] == "0"
+        assert "Link" not in headers
+
+
+class TestBuildFilter(unittest.TestCase):
+    """Test build_filter with a mock SQLAlchemy model."""
+
+    def _make_mock_model(self, include_id: bool = True):
+        """Create a mock SQLAlchemy model class with a table-like structure."""
+        import sqlalchemy
+
+        mock_model = MagicMock()
+        mock_model.__table__ = MagicMock()
+
+        columns = ["hostname", "state"]
+        if include_id:
+            columns.insert(0, "id")
+        mock_model.__table__._columns.keys.return_value = columns
+
+        id_col = MagicMock()
+        id_col.type = sqlalchemy.Integer()
+        hostname_col = MagicMock()
+        hostname_col.type = sqlalchemy.String()
+        state_col = MagicMock()
+        state_col.type = sqlalchemy.String()
+
+        col_map = {"id": id_col, "hostname": hostname_col, "state": state_col}
+        mock_model.__table__._columns.__getitem__ = lambda self, key: col_map[key]
+
+        return mock_model
+
+    def test_empty_args_no_id(self):
+        """Test build_filter with no args and no id column (skips order_by)."""
+        mock_model = self._make_mock_model(include_id=False)
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.offset.return_value = mock_query
+
+        result = build_filter(mock_model, mock_query, {})
+        mock_query.limit.assert_called_once_with(50)
+        mock_query.offset.assert_called_once_with(0)
+
+    def test_invalid_filter_attribute(self):
+        mock_model = self._make_mock_model()
+        mock_query = MagicMock()
+
+        with self.assertRaises(ValueError) as ctx:
+            build_filter(mock_model, mock_query, {"filter[invalid_col]": "test"})
+        assert "not a valid attribute" in str(ctx.exception)
+
+    def test_pagination_params_no_id(self):
+        """Test pagination with explicit per_page/page, no id column."""
+        mock_model = self._make_mock_model(include_id=False)
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.offset.return_value = mock_query
+
+        result = build_filter(mock_model, mock_query, {}, per_page=10, page=3)
+        mock_query.limit.assert_called_once_with(10)
+        mock_query.offset.assert_called_once_with(20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add FastAPI app skeleton (dual-stack alongside Flask) with CORS, exception handlers, request logging middleware, and auth dependency
- Convert **all** non-auth endpoints to FastAPI routers: system, groups, plugins, repository, settings, jobs, linknet, mgmtdomain, interface, firmware, and all 21 device endpoint groups
- Add framework-agnostic filtering/pagination utilities (`filtering.py`, `response.py`)
- Add 105 unit tests covering existing `generic.py` functions and new FastAPI infrastructure
- Add `fastapi>=0.115`, `uvicorn[standard]>=0.30`, `httpx>=0.27` to dependencies

## Migration Plan

This covers **PR 1-6 of 9** in the Flask → FastAPI migration. See [`FASTAPI_MIGRATION_PLAN.md`](FASTAPI_MIGRATION_PLAN.md) for the full plan.

### Key decisions
- **Dual-stack**: Flask stays running untouched, FastAPI built in `api/routers/`
- **Sync endpoints** (`def`, not `async def`): SQLAlchemy sessions are sync; FastAPI runs them in thread pool
- **Same response format**: `{"status": "success/error", "data/message": ...}`
- **gunicorn + uvicorn workers** for production (final PR)

### Progress
- [x] **PR 1**: Foundation + system, groups, plugins endpoints ✅
- [x] **PR 2**: Repository, settings, jobs endpoints ✅
- [x] **PR 3**: Linknet + Management Domain ✅
- [x] **PR 4**: Interface + Firmware ✅
- [x] **PR 5-6**: Device endpoints (all 21 groups) ✅
- [ ] **PR 7**: Auth/OIDC
- [ ] **PR 8**: WebSocket migration
- [ ] **PR 9**: Final switchover + cleanup

### Note on SonarCloud code duplication

SonarCloud reports duplication on new code exceeding the 3% threshold. This is **expected and intentional** during the dual-stack transition: the new FastAPI routers mirror the existing Flask endpoint logic to ensure backwards compatibility. The duplication will be resolved in **PR 9 (final switchover)** when the old Flask route files are removed. The security hotspots flagged are broad `except Exception` patterns carried over from the original Flask code.

## Test plan
- [x] 105 unit tests pass (32 PR1 + 17 PR2 + 18 PR3 + 11 PR4 + 27 PR5-6)
- [x] 101 pre-existing non-integration tests still pass (no regressions)
- [x] ruff lint + format clean
- [x] Unit tests in Docker CI pass
- [ ] Integration tests in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)