### PR TITLE
Update docker versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 # Version control
-.git
+# API need to see the git repo to display the latest commit hash in the UI.
+# Can be changed later to some docker build step instead.
+#.git
 .github
 .git-blame-ignore-revs
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -51,6 +51,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy venv from builder
 COPY --chmod=555 --from=builder --chown=root:www-data /opt/cnaas/venv /opt/cnaas/venv
 
+# Copy over .git folder to get git commit hash in the UI.
+# Should be changed later to another method
+COPY .git /opt/cnaas/venv/cnaas-nms/.git
+
 # Copy nginx/supervisor configs
 COPY docker/api/config/supervisord_app.conf /etc/supervisor/supervisord.conf
 COPY docker/api/config/nginx_app.conf /etc/nginx/sites-available/

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,8 +1,8 @@
 # Stage 1: Builder - install dependencies
-FROM python:3.13-slim-bookworm AS builder
+FROM python:3.13-slim-trixie AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential libpq-dev libpcre2-dev libpcre3-dev libssl-dev git \
+    build-essential libpq-dev libpcre2-dev libssl-dev git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -38,7 +38,7 @@ COPY alembic.ini /opt/cnaas/venv/cnaas-nms/
 
 
 # Stage 2: Runtime - minimal production image
-FROM python:3.13-slim-bookworm AS runtime
+FROM python:3.13-slim-trixie AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 nginx supervisor ssh-client \

--- a/docker/api/config/nginx_app.conf
+++ b/docker/api/config/nginx_app.conf
@@ -1,11 +1,9 @@
 server {
-    listen 1443 ssl http2;
-    # TODO, when upgrading to newer version of nginx
-    # http2 on;
+    listen 1443 ssl;
+    http2 on;
     server_name cnaas;
     client_max_body_size 200M;
 
-    ssl on;
     ssl_certificate /etc/nginx/conf.d/cnaas_snakeoil.crt;
     ssl_certificate_key /etc/nginx/conf.d/cnaas_snakeoil.key;
 

--- a/docker/dhcpd/Dockerfile
+++ b/docker/dhcpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     isc-dhcp-server python3-venv supervisor bind9-host git \

--- a/src/cnaas_nms/version.py
+++ b/src/cnaas_nms/version.py
@@ -1,3 +1,3 @@
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 __version_info__ = tuple([field for field in __version__.split(".")])
 __api_version__ = "v1.0"

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -59,8 +59,8 @@ on_err() {
 	$COMPOSE_COMMAND logs -n 100 cnaas_api
 }
 
-# trap on_exit EXIT
-# trap on_err ERR
+trap on_exit EXIT
+trap on_err ERR
 
 docker volume create cnaas-templates
 docker volume create cnaas-settings

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -142,7 +142,7 @@ MULE_PID="$($COMPOSE_COMMAND logs cnaas_api | awk '/spawned uWSGI mule/{print $6
 echo "Found mule at pid $MULE_PID"
 # Allow for code coverage files to be saved
 $COMPOSE_COMMAND exec -u root -T cnaas_api chown -R www-data:www-data /opt/cnaas/venv/cnaas-nms/src/
-curl -ks -H "Authorization: Bearer $JWT_AUTH_TOKEN" "https://localhost/api/v1.0/system/shutdown" -d "{}" -X POST -H "Content-Type: application/json"
+curl -m 5 -ks -H "Authorization: Bearer $JWT_AUTH_TOKEN" "https://localhost/api/v1.0/system/shutdown" -d "{}" -X POST -H "Content-Type: application/json"
 sleep 3
 
 echo "Starting unit tests..."


### PR DESCRIPTION
- Updated docker version to trixie
- Updated nginx to a newer syntax
trixie has a newer version of nginx
- Small fixes
  - Bumped internal version
  - Added git commit info to /system/version api call
  `{"status": "success", "data": {"version": "1.9.0", "git_version": "Git commit a999a3a3ecd7449a3ee0bfd71553b8c2d88f4692 chore.update_docker_versions (2026-04-16 08:47:07+00:00)"}}`