### PR TITLE
Opt out of new default ssl_context so eAPI works in python3.13

### DIFF
--- a/src/cnaas_nms/tools/pki.py
+++ b/src/cnaas_nms/tools/pki.py
@@ -32,6 +32,7 @@ def get_ssl_context():
         logger.debug("Using system default CAs")
         new_ssl_context = ssl.create_default_context()
 
+    # Opt out of strict verification to allow for self-signed certs that don't have a full chain
     new_ssl_context.verify_flags &= ~(ssl.VERIFY_X509_STRICT | ssl.VERIFY_X509_PARTIAL_CHAIN)
 
     return new_ssl_context

--- a/src/cnaas_nms/tools/pki.py
+++ b/src/cnaas_nms/tools/pki.py
@@ -32,6 +32,8 @@ def get_ssl_context():
         logger.debug("Using system default CAs")
         new_ssl_context = ssl.create_default_context()
 
+    new_ssl_context.verify_flags &= ~(ssl.VERIFY_X509_STRICT | ssl.VERIFY_X509_PARTIAL_CHAIN)
+
     return new_ssl_context
 
 


### PR DESCRIPTION
Fix for python3.13 ssl error:

Previous error before this fix:

<details>
<summary>Click to expand</summary>  

```
 "result": "Traceback (most recent call last):
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/pyeapi/eapilib.py\", line 435, in send
     self.transport.endheaders(message_body=data)
     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
   File \"/usr/local/lib/python3.13/http/client.py\", line 1353, in endheaders
     self._send_output(message_body, encode_chunked=encode_chunked)
     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File \"/usr/local/lib/python3.13/http/client.py\", line 1113, in _send_output
     self.send(msg)
     ~~~~~~~~~^^^^^
   File \"/usr/local/lib/python3.13/http/client.py\", line 1057, in send
     self.connect()
     ~~~~~~~~~~~~^^
   File \"/usr/local/lib/python3.13/http/client.py\", line 1499, in connect
     self.sock = self._context.wrap_socket(self.sock,
                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
                                           server_hostname=server_hostname)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File \"/usr/local/lib/python3.13/ssl.py\", line 455, in wrap_socket
     return self.sslsocket_class._create(
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         sock=sock,
         ^^^^^^^^^^
     ...<5 lines>...
         session=session
         ^^^^^^^^^^^^^^^
     )
     ^
   File \"/usr/local/lib/python3.13/ssl.py\", line 1076, in _create
     self.do_handshake()
     ~~~~~~~~~~~~~~~~~^^
   File \"/usr/local/lib/python3.13/ssl.py\", line 1372, in do_handshake
     self._sslobj.do_handshake()
     ~~~~~~~~~~~~~~~~~~~~~~~~~^^
 ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
 
 During handling of the above exception, another exception occurred:
 
 Traceback (most recent call last):
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/nornir/core/task.py\", line 98, in start
     r = self.task(self, **self.params)
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/nornir_napalm/plugins/tasks/napalm_get.py\", line 32, in napalm_get
     device = task.host.get_connection(CONNECTION_NAME, task.nornir.config)
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/nornir/core/inventory.py\", line 476, in get_connection
     self.open_connection(
        ~~~~~~~~~~~~~~~~~~~~^
         connection=connection,
         ^^^^^^^^^^^^^^^^^^^^^^
     ...<6 lines>...
         extras=conn.extras,
         ^^^^^^^^^^^^^^^^^^^
     )
     ^
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/nornir/core/inventory.py\", line 528, in open_connection
     conn_obj.open(
        ~~~~~~~~~~~~~^
         hostname=hostname,
         ^^^^^^^^^^^^^^^^^^
     ...<5 lines>...
         configuration=configuration,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     )
     ^
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/nornir_napalm/plugins/connections/__init__.py\", line 57, in open
     connection.open()
     ~~~~~~~~~~~~~~~^^
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/napalm/eos/eos.py\", line 226, in open
     sh_ver = self._run_commands([\"show version\"])
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/napalm/eos/eos.py\", line 280, in _run_commands
     return self.device.run_commands(commands, **kwargs)
            ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/pyeapi/client.py\", line 899, in run_commands
     response = self._connection.execute(commands, encoding, **kwargs)
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/pyeapi/eapilib.py\", line 629, in execute
     response = self.send(request)
   File \"/opt/cnaas/venv/lib/python3.13/site-packages/pyeapi/eapilib.py\", line 473, in send
     raise ConnectionError(str(self), error_msg)
 pyeapi.eapilib.ConnectionError: Socket error during eAPI connection: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
```
</details>


Links:
https://github.com/napalm-automation-community/napalm-srlinux/issues/64
https://github.com/python/cpython/issues/138193#issuecomment-3570721181