### PR TITLE
Feature Juniper SRX Access lists generation

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -298,6 +298,15 @@ Access list examples
          protocol: [tcp, udp]
          option: "established"
          action: "accept"
+    "JUNIPER-SRX-ACL":
+      comment: |
+        Shows how to create a Juniper SRX access-list
+        Must have a custom header_map for srx otherwise it will not be able to render
+      header_map:
+        srx: "from-zone all to-zone all {INET_FAMILY}"
+      terms:
+        - name: "allow-all"
+          action: "accept"
 
 groups.yml
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "absl-py==2.3.1",
-  "aerleon==1.14.1",
+  "aerleon==1.16.0",
   "alembic==1.15.2",
   "apscheduler==3.11",
   "async-timeout>=4.0.2",

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -14,7 +14,7 @@ from aerleon.api import Generate
 from aerleon.lib import naming
 from aerleon.lib.policy_builder import PolicyDict, PolicyFilter, PolicyFilterTermsOnly, TermsList
 from aerleon.lib.yaml import PolicyTypeError
-from netutils.lib_mapper import AERLEON_LIB_MAPPER_REVERSE, NAPALM_LIB_MAPPER
+from netutils.lib_mapper import AERLEON_LIB_MAPPER, AERLEON_LIB_MAPPER_REVERSE, NAPALM_LIB_MAPPER
 from pydantic import BaseModel, ValidationError
 from redis import StrictRedis
 from redis_lru import RedisLRU
@@ -1067,15 +1067,20 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
     return aerleon_definitions
 
 
-def napalm_to_aerleon(platform: str) -> str:
+def napalm_to_aerleon(platform: str, device_model: Optional[str] = None) -> str:
     """
     Translates napalm platform to aerleon
     If not found it will return the platform as is
     """
+    # There is no direct translation between napalm juniper and srx
+    # So we manually handle it here
+    if device_model and platform == "junos" and device_model.lower().startswith("srx"):
+        return "srx"
+
     return AERLEON_LIB_MAPPER_REVERSE.get(NAPALM_LIB_MAPPER.get(platform, ""), platform)
 
 
-def _get_aerleon_translated_terms(terms: TermsList) -> TermsList:
+def _get_aerleon_translated_terms(terms: TermsList, device_model: Optional[str] = None) -> TermsList:
     """
     Convert Napalm platform names (e.g. 'ios', 'eos') inside term dictionaries
     into their corresponding Aerleon generator names (e.g. 'cisco_ios',
@@ -1087,7 +1092,7 @@ def _get_aerleon_translated_terms(terms: TermsList) -> TermsList:
 
     def translate(value):
         if isinstance(value, str):
-            return napalm_to_aerleon(value)
+            return napalm_to_aerleon(value, device_model)
         if isinstance(value, dict):
             return {translate(k): translate(v) for k, v in value.items()}
         if isinstance(value, list):
@@ -1097,7 +1102,7 @@ def _get_aerleon_translated_terms(terms: TermsList) -> TermsList:
     return [translate(term) for term in terms]
 
 
-def _get_aerleon_inet(platform: str, inet_family: Literal["ipv4", "ipv6"]) -> str:
+def _get_aerleon_inet(aerleon_platform: str, inet_family: Literal["ipv4", "ipv6"]) -> str:
     """
     Maps ipv4 or ipv6 to aerleon inet-format.
     Differs between different types of devices.
@@ -1106,13 +1111,23 @@ def _get_aerleon_inet(platform: str, inet_family: Literal["ipv4", "ipv6"]) -> st
     To get support for other platforms define a custom header_map in f_access_list for that platform.
     """
     inet_family_map = {
-        "eos": {"ipv4": "extended", "ipv6": "inet6"},
-        "ios": {"ipv4": "extended", "ipv6": "inet6"},
-        "iosxr": {"ipv4": "", "ipv6": "inet6"},
-        "junos": {"ipv4": "inet", "ipv6": "inet6"},
-        "nxos": {"ipv4": "extended", "ipv6": "inet6"},
+        # Arista
+        # napalm eos
+        "arista": {"ipv4": "extended", "ipv6": "inet6"},
+        # Cisco
+        # napalm ios
+        "cisco": {"ipv4": "extended", "ipv6": "inet6"},
+        # napalm nxos
+        "cisconx": {"ipv4": "extended", "ipv6": "inet6"},
+        # napalm iosxr
+        "ciscoxr": {"ipv4": "", "ipv6": "inet6"},
+        # Juniper
+        # napalm junos
+        "juniper": {"ipv4": "inet", "ipv6": "inet6"},
+        # juniper srx, no direct napalm -> aerleon translation
+        "srx": {"ipv4": "inet", "ipv6": "inet6"},
     }
-    return inet_family_map.get(platform, {}).get(inet_family, inet_family)
+    return inet_family_map.get(aerleon_platform, {}).get(inet_family, inet_family)
 
 
 def _get_all_access_lists(data: List[Dict[str, str]]) -> Iterator[str]:
@@ -1175,13 +1190,15 @@ def get_generated_access_lists(
     # Fix for mypy to understand settings is not dict | None but only dict
     assert settings is not None
 
+    device_model = dev.model if dev else None
+
     # Get aerleon platform name from NMS napalm platform
-    aerleon_platform = napalm_to_aerleon(platform)
+    aerleon_platform = napalm_to_aerleon(platform, device_model)
     # Could not get a valid aerleon platform
-    if aerleon_platform not in AERLEON_LIB_MAPPER_REVERSE.values():
+    if aerleon_platform not in AERLEON_LIB_MAPPER.keys():
         logger = get_logger()
         logger.error(
-            f"Platform: {platform} is not supported for access_list generation, no access-lists will be generated."
+            f"Platform: {platform} (Aerleon platform: {aerleon_platform}) is not supported for access_list generation, no access-lists will be generated."
         )
         return {}
 
@@ -1207,19 +1224,24 @@ def get_generated_access_lists(
         access_list: f_access_list = f_access_list.model_construct(**access_list_dict)
 
         # Get aerleon header format, defaults to "{ACL_NAME} {INET_FAMILY}"
-        header = access_list.header_map.get(platform, "{ACL_NAME} {INET_FAMILY}")
+        # Try first to get the aerleon specific platform and fallback to napalm
+        header = access_list.header_map.get(
+            aerleon_platform, access_list.header_map.get(platform, "{ACL_NAME} {INET_FAMILY}")
+        )
 
         inside_policies = []
-        acl_terms = _get_aerleon_translated_terms(access_list.terms)
+        acl_terms = _get_aerleon_translated_terms(access_list.terms, device_model)
 
         # Add all access_lists to includes
-        # Only needs to be done once as terms are inet-agnistic
+        # Only needs to be done once as terms are inet-agnostic
         included_list: PolicyFilterTermsOnly = {"terms": acl_terms}
         includes.update({access_list_name: included_list})
 
         for inet_family in access_list.inet_families:
             # Format acl_header for the specific inet_family
-            acl_header = header.format(ACL_NAME=access_list_name, INET_FAMILY=_get_aerleon_inet(platform, inet_family))
+            acl_header = header.format(
+                ACL_NAME=access_list_name, INET_FAMILY=_get_aerleon_inet(aerleon_platform, inet_family)
+            )
             inside_policy_dict: PolicyFilter = {
                 "header": {"targets": {aerleon_platform: acl_header}, "comment": access_list.comment},
                 "terms": acl_terms,

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -470,7 +470,7 @@ class f_access_list(BaseModel):
 
     @field_validator("header_map", mode="after")
     @classmethod
-    def verify_header_map(cls, v: Dict[str, str]) -> Dict[str, str]:
+    def validate_header_map(cls, v: Dict[str, str]) -> Dict[str, str]:
         """Make sure header_map only contains valid options"""
         valid_platforms = list(NAPALM_LIB_MAPPER.keys()) + list(AERLEON_LIB_MAPPER.keys())
         for k in v.keys():

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -6,6 +6,7 @@ from ipaddress import AddressValueError, IPv4Address, IPv4Interface, IPv4Network
 from typing import Annotated, Dict, List, Literal, Optional, Self, Union
 
 from aerleon.lib.policy_builder import TermsList
+from netutils.lib_mapper import AERLEON_LIB_MAPPER, NAPALM_LIB_MAPPER
 from pydantic import BaseModel, Field, TypeAdapter, ValidationInfo, field_validator, model_validator
 from pydantic.functional_validators import AfterValidator
 
@@ -466,6 +467,17 @@ class f_access_list(BaseModel):
     def unique_sorted_inet_families(cls, v: List[Literal["ipv4", "ipv6"]]) -> List[Literal["ipv4", "ipv6"]]:
         """Make sure inet_families are unique and sorted"""
         return sorted(set(v))
+
+    @field_validator("header_map", mode="after")
+    @classmethod
+    def verify_header_map(cls, v: Dict[str, str]) -> Dict[str, str]:
+        """Make sure header_map only contains valid options"""
+        valid_platforms = list(NAPALM_LIB_MAPPER.keys()) + list(AERLEON_LIB_MAPPER.keys())
+        for k in v.keys():
+            if k not in valid_platforms:
+                raise ValueError(f"{k} must be a valid napalm or aerleon platform")
+
+        return v
 
     @field_validator("terms", mode="after")
     def validate_term_names(cls, v):

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -28,7 +28,7 @@ from cnaas_nms.db.settings import (
     rebuild_settings_cache,
     verify_dir_structure,
 )
-from cnaas_nms.db.settings_fields import f_group, f_groups
+from cnaas_nms.db.settings_fields import f_access_list, f_group, f_groups
 
 
 class SettingsTests(unittest.TestCase):
@@ -601,6 +601,77 @@ class SettingsTests(unittest.TestCase):
 
             self.assertIn("SOME_INTF_IN", acls.keys())
             self.assertEqual(len(acls), 1)
+
+    def test_acl_juniper_srx(self):
+        settings = {
+            "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
+            "interfaces": [
+                {
+                    "name": "Ethernet1",
+                    "ifclass": "custom",
+                    "vrf": "SOME_VRF",
+                    "ipv4_address": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "ALL_TO_ALL",
+                }
+            ],
+            "access_lists": {
+                "ALL_TO_ALL": {
+                    "header_map": {"srx": "from-zone all to-zone all {INET_FAMILY}"},
+                    "terms": [{"name": "permit-any", "action": "accept"}],
+                }
+            },
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        firewall_device = Device(
+            hostname="test-fw1", platform="junos", device_type=DeviceType.FIREWALL, model="SRX380-POE-AC"
+        )
+        acls = get_generated_access_lists(firewall_device, settings=settings)
+        self.assertIn("ALL_TO_ALL", acls.keys())
+        self.assertEqual(len(acls), 1)
+
+    def test_acl_juniper_srx_error(self):
+        settings = {
+            "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
+            "interfaces": [
+                {
+                    "name": "Ethernet1",
+                    "ifclass": "custom",
+                    "vrf": "SOME_VRF",
+                    "ipv4_address": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "ALL_TO_ALL",
+                }
+            ],
+            "access_lists": {"ALL_TO_ALL": {"terms": [{"name": "permit-any", "action": "accept"}]}},
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        firewall_device = Device(
+            hostname="test-fw1", platform="junos", device_type=DeviceType.FIREWALL, model="SRX380-POE-AC"
+        )
+
+        # Cannot render SRX acl without a custom header map
+        with self.assertRaises(AccessListGenerationError):
+            get_generated_access_lists(firewall_device, settings=settings)
+
+    def test_acl_f_access_list_header_map(self):
+        """Verify f_access_list header_map, can be in napalm or aerleon platform syntax."""
+        data = {
+            "header_map": {"ios": "", "eos": "", "srx": "", "nxos": "", "cisconx": ""},
+            "terms": [{"name": "permit-any", "action": "accept"}],
+        }
+        f_access_list(**data)
+
+    def test_acl_f_access_list_header_map_error(self):
+        """Verify f_access_list header_map error"""
+        # Invalid header_map key
+        data = {"header_map": {"abc": "abc"}, "terms": [{"name": "permit-any", "action": "accept"}]}
+        with self.assertRaises(ValidationError):
+            f_access_list(**data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for Juniper SRX access lists.
Juniper SRX have another format so this adds support for that in the acl generation.

- Added Juniper SRX support
- Added validation for header_map keys
- Added tests
- Updated documentation