### PR TITLE
Access list reference network definition

### DIFF
--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -172,14 +172,32 @@ access_lists.yml
 
     Here are some example jmespath strings:
 
-    All IPv4 and IPv6 gateways of VXLANs in the STUDENT VRF:
-    :code:`vxlans.*[] | [?vrf=='STUDENT'].[ipv4_gw, ipv6_gw][]`
+    All IPv4 and IPv6 addresses from VXLANs in the STUDENT VRF:
+    :code:`vxlans.* | [?vrf=='STUDENT'].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]`
+
+    All IPv4 and IPv6 addresses for vlan name: student2:
+    :code:`vxlans.student2.[ipv4_gw, ipv4_secondaries, ipv6_gw][]`
+
+    All IPv4 and IPv6 addresses for vlans student1 and student2:
+    :code:`vxlans.[student1, student2][].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]`
+
+    All IPv4 and IPv6 addresses for vlans with vlan_id between 500 and 600:
+    :code:`vxlans.* | [?vlan_id >= \`500\` && vlan_id <= \`600\`].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]`
+
+    All IPv4 and IPv6 addresses across all vxlans:
+    :code:`vxlans.*.[ipv4_gw, ipv4_secondaries, ipv6_gw][][]`
 
     All ntp servers:
     :code:`ntp_servers[].host`
 
-    Underlay loopback network:
+    Underlay infra loopback network:
     :code:`underlay.[infra_lo_net]`
+
+    Underlay infra link network:
+    :code:`underlay.[infra_link_net]`
+
+    Underlay management loopback network:
+    :code:`underlay.[mgmt_lo_net]`
 
     All interface IP addresses in the MGMT VRF:
     :code:`interfaces[?vrf == 'MGMT'].[ipv4_address, ipv6_address][]`
@@ -190,6 +208,8 @@ access_lists.yml
     All BGP IPv4 neighbors:
     :code:`extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4`
 
+    All BGP IPv4 and IPv6 neighbors
+    :code:`extroute_bgp.vrfs[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
 
 - service_definitions: Dictionary of {<name>, [entries]}:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -166,6 +166,8 @@ access_lists.yml
 
   Reference:
 
+  * strip_cidr: Removes CIDR and treats all referenced IPs as host addresses. Useful for example in cases where only gateway-addresses are needed in an access list.
+  
   * path: A jmespath string that will be used to get references from other device settings.
     Use a site like: `<https://play.jmespath.org/>`_ to test your jmespath string.
     The result of the jmespath search must be a list of addresses or networks, otherwise an error will be raised during access list generation.
@@ -276,6 +278,10 @@ Access list examples
       # This will contain all BGP neighbors for a device.
       - path: extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4
       - path: extroute_bgp.vrfs[].neighbor_v6[].peer_ipv6
+    "STUDENT_GWS":
+      # This will only have host ips of the actual gateway.
+      - path: vxlans.* | [?vrf=='STUDENT'].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]
+        strip_cidr: true
   service_definitions:
     "BGP":
       - port: 179

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -367,10 +367,12 @@ Access list examples
          protocol: tcp
          source-address: BGP_PEERS
          destination-port: BGP
+         action: "accept"
        - name: "allow-bgp-traffic-outbound"
          protocol: tcp
          destination-address: BGP_PEERS
          destination-port: BGP
+         action: "accept"
 
 groups.yml
 ----------

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -171,7 +171,7 @@ access_lists.yml
     The result of the jmespath search must be a list of addresses or networks, otherwise an error will be raised during access list generation.
 
     Here are some example jmespath strings:
-    
+
     All IPv4 and IPv6 gateways of VXLANs in the STUDENT VRF:
     :code:`vxlans.*[] | [?vrf=='STUDENT'].[ipv4_gw, ipv6_gw][]`
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -154,7 +154,7 @@ access_lists.yml
 
 - network_definitions: Dictionary of {<name>, [entries]}:
 
-  | A network entry can be one of: an address or an include.
+  | A network entry can be one of: an address, an include or a reference.
   | Address:
 
   * address: A IPv4 address, IPv6 address, IPv4 network or IPv6 network.
@@ -163,6 +163,29 @@ access_lists.yml
   Include:
 
   * name: Name of another network object to include in this network definition
+
+  Reference:
+
+  * path: A jmespath string that will be used to get references from other device settings.
+    Use a site like: `<https://play.jmespath.org/>`_ to test your jmespath string.
+    The result of the jmespath search must be a list of addresses or networks, otherwise an error will be raised during access list generation.
+
+    Here are some example jmespath strings:
+    
+    All IPv4 and IPv6 gateways of VXLANs in the STUDENT VRF:
+    :code:`vxlans.*[] | [?vrf=='STUDENT'].[ipv4_gw, ipv6_gw][]`
+
+    All ntp servers:
+    :code:`ntp_servers[].host`
+
+    Underlay loopback network:
+    :code:`underlay.[infra_lo_net]`
+
+    All interface IP addresses in the MGMT VRF:
+    :code:`interfaces[?vrf == 'MGMT'].[ipv4_address, ipv6_address][]`
+
+    All BGP IPv4 and IPv6 neighbors in the STUDENT VRF:
+    :code:`extroute_bgp.vrfs[?name=='STUDENT'].[neighbor_v4[][].peer_ipv4, neighbor_v6[][].peer_ipv6][][]`
 
 - service_definitions: Dictionary of {<name>, [entries]}:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -185,7 +185,11 @@ access_lists.yml
     :code:`interfaces[?vrf == 'MGMT'].[ipv4_address, ipv6_address][]`
 
     All BGP IPv4 and IPv6 neighbors in the STUDENT VRF:
-    :code:`extroute_bgp.vrfs[?name=='STUDENT'].[neighbor_v4[][].peer_ipv4, neighbor_v6[][].peer_ipv6][][]`
+    :code:`extroute_bgp.vrfs[?name=='STUDENT'].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
+
+    All BGP IPv4 neighbors:
+    :code:`extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4`
+
 
 - service_definitions: Dictionary of {<name>, [entries]}:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -272,7 +272,14 @@ Access list examples
       - address: 10.0.0.0/8
       - address: 172.16.0.0/12
       - address: 192.168.0.0/16
+    "BGP_PEERS":
+      # This will contain all BGP neighbors for a device.
+      - path: extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4
+      - path: extroute_bgp.vrfs[].neighbor_v6[].peer_ipv6
   service_definitions:
+    "BGP":
+      - port: 179
+        protocol: tcp
     "DNS":
       - port: 53
         protocol: "udp"
@@ -354,6 +361,16 @@ Access list examples
       terms:
         - name: "allow-all"
           action: "accept"
+    "ALLOW-BGP":
+      terms:
+       - name: "allow-bgp-traffic-inbound"
+         protocol: tcp
+         source-address: BGP_PEERS
+         destination-port: BGP
+       - name: "allow-bgp-traffic-outbound"
+         protocol: tcp
+         destination-address: BGP_PEERS
+         destination-port: BGP
 
 groups.yml
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "gevent==25.4.2",
   "gitpython==3.1.50",
   "greenlet==3.2.1",
+  "jmespath>=1.1.0",
   "markupsafe==3.0.2",
   "napalm==5.1",
   "netmiko==4.5",

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -36,6 +36,9 @@ def validate_json_to_model(json_data):
             ret_copy = ret.copy()
             ret_copy["system_access_lists"] = list(ret_copy.get("access_lists", {}).keys())
 
+            # Remove any keys without any value
+            ret_copy = {k: v for k, v in ret_copy.items() if v}
+
             # Check if we can build aerleon definitions with the provided settings
             try:
                 _build_aerleon_definitions(ret_copy)

--- a/src/cnaas_nms/api/settings.py
+++ b/src/cnaas_nms/api/settings.py
@@ -13,6 +13,7 @@ from cnaas_nms.db.settings import (
     FILE_MODEL_MAP,
     AccessListGenerationError,
     SettingsSyntaxError,
+    _build_aerleon_definitions,
     check_settings_syntax,
     f_root,
     get_generated_access_lists,
@@ -34,6 +35,24 @@ def validate_json_to_model(json_data):
             # Try to generate all access_lists and return any errors
             ret_copy = ret.copy()
             ret_copy["system_access_lists"] = list(ret_copy.get("access_lists", {}).keys())
+
+            # Check if we can build aerleon definitions with the provided settings
+            try:
+                _build_aerleon_definitions(ret_copy)
+            except AccessListGenerationError:
+                # Default jmespath network reference if building definitions fails.
+                # We just want to validate the access list generation and not the network definitions themselves.
+                # TODO: Provide default values for the entire settings model so jmespath references can be properly validated.
+                for net_name, net_defs in ret_copy["network_definitions"].items():
+                    for net_def in net_defs:
+                        if "path" in net_def.keys():
+                            # Default to some random ips that should be valid for any network definition path.
+                            ret_copy["network_definitions"][net_name] = [
+                                {"address": "10.0.0.1"},  # noqa: S1313
+                                {"address": "2001:db8::1"},  # noqa: S1313
+                            ]
+                            break
+
             get_generated_access_lists(platform="eos", settings=ret_copy)
     except SettingsSyntaxError as e:
         return empty_result(status="error", data=str(e)), 400

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -103,6 +103,37 @@ def test_access_list_reference_no_data(testclient: FlaskClient):
     assert "No IP addresses found for network: BGP_PEERS" in result.json["message"]
 
 
+def test_access_list_reference_vxlans(testclient: FlaskClient):
+    """Test that reference to vxlans falls back to standard values instead of being empty"""
+    settings_data = {
+        "network_definitions": {
+            "students_gws": [
+                {"path": "vxlans.* | [?vrf=='STUDENT'].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]"},
+            ]
+        },
+        "access_lists": {
+            "ACLTEST": {"terms": [{"name": "allow_bgp", "destination-address": "students_gws", "action": "accept"}]}
+        },
+    }
+
+    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
+    assert result.status_code == 200
+
+
+def test_access_list_invalid_jmespath(testclient: FlaskClient):
+    """Test that invalid jmespath triggers on /settings/model api"""
+    settings_data = {
+        "network_definitions": {
+            "invalid_path": [
+                {"path": "vxlans]"},
+            ]
+        }
+    }
+
+    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
+    assert result.status_code == 400
+
+
 def test_settings_model(testclient: FlaskClient):
     result = testclient.get("/api/v1.0/settings/model")
     assert result.status_code == 200

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -49,8 +49,58 @@ def test_valid_access_list_setting(testclient: FlaskClient):
     settings_data = {
         "access_lists": {"ACLTEST": {"terms": [{"name": "term_name", "action": "accept"}]}},
     }
+
     result = testclient.post("/api/v1.0/settings/model", json=settings_data)
     assert result.status_code == 200
+
+
+def test_access_list_reference(testclient: FlaskClient):
+    """Makes sure that access lists with jmespath references are able to generate without fully validating the jmespath."""
+    settings_data = {
+        "network_definitions": {
+            "BGP_PEERS": [
+                {"path": "extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4"},
+                {"path": "extroute_bgp.vrfs[].neighbor_v6[].peer_ipv6"},
+            ]
+        },
+        "access_lists": {
+            "ACLTEST": {"terms": [{"name": "allow_bgp", "destination-address": "BGP_PEERS", "action": "accept"}]}
+        },
+    }
+
+    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
+    assert result.status_code == 200
+
+
+def test_access_list_reference_no_data(testclient: FlaskClient):
+    """
+    When sending more data than just the access list with jmespath references,
+    we want to make sure that we still validate that the access list generation fails when no valid data is sent to aerleon.
+    """
+    settings_data = {
+        "extroute_bgp": {
+            "vrfs": [
+                {
+                    "name": "OUTSIDE",
+                    "local_as": 64667,
+                    "neighbor_v4": [],
+                }
+            ]
+        },
+        "network_definitions": {
+            "BGP_PEERS": [
+                {"path": "extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4"},
+            ]
+        },
+        "access_lists": {
+            "ACLTEST": {"terms": [{"name": "allow_bgp", "destination-address": "BGP_PEERS", "action": "accept"}]}
+        },
+    }
+
+    result = testclient.post("/api/v1.0/settings/model", json=settings_data)
+
+    assert result.status_code == 400
+    assert "No IP addresses found for network: BGP_PEERS" in result.json["message"]
 
 
 def test_settings_model(testclient: FlaskClient):

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1082,7 +1082,7 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
                     network_list.append({"address": address})
             else:
                 # Normal aerleon network definition
-                network_list.append(network.get("value"))
+                network_list.append(network)
 
         networks_dict[network_name] = {"values": network_list}
     for service_name, services in settings.get("service_definitions", {}).items():

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1074,7 +1074,11 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
 
                 for address in addresses:
                     try:
-                        ip_interface(address)
+                        # Strip cidr and treat address as a host ip.
+                        if network.get("strip_cidr"):
+                            address = str(ip_interface(address).ip)
+                        else:
+                            address = str(ip_interface(address).network)
                     except ValueError:
                         raise AccessListGenerationError(
                             f"Expected an IP address or network from jmespath search, got {address} (type {type(address).__name__}) in network definition {network_name}."

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1051,6 +1051,33 @@ def get_group_settings_asdict() -> Dict[str, Dict[str, Any]]:
     return group_dict
 
 
+def _resolve_jmespath_networks(network: dict, settings: dict, network_name: str) -> list[dict]:
+    """Resolves and validates a JMESPath network reference into a list of address dictionaries."""
+    addresses = jmespath.search(network["path"], settings)
+
+    if not isinstance(addresses, list):
+        raise AccessListGenerationError(f"Expected a list from jmespath search, got {type(addresses).__name__}.")
+
+    resolved_networks = []
+    for address in addresses:
+        try:
+            interface = ip_interface(address)
+        except ValueError:
+            raise AccessListGenerationError(
+                f"Expected an IP address or network from jmespath search, got {address} "
+                f"(type {type(address).__name__}) in network definition {network_name}."
+            )
+
+        if network.get("strip_cidr"):
+            formatted_address = str(interface.ip)
+        else:
+            formatted_address = str(interface.network)
+
+        resolved_networks.append({"address": formatted_address})
+
+    return resolved_networks
+
+
 def _build_aerleon_definitions(settings: dict) -> naming.Naming:
     """
     Builds Aerleon Naming from settings network_definitions and service_definitions.
@@ -1063,30 +1090,9 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
     for network_name, networks in settings.get("network_definitions", {}).items():
         network_list = []
         for network in networks:
-            # This is a jmespath reference.
-            if "path" in network.keys():
-                addresses = jmespath.search(network["path"], settings)
-
-                if not isinstance(addresses, list):
-                    raise AccessListGenerationError(
-                        f"Expected a list from jmespath search, got {type(addresses).__name__}."
-                    )
-
-                for address in addresses:
-                    try:
-                        ip_interface(address)
-                    except ValueError:
-                        raise AccessListGenerationError(
-                            f"Expected an IP address or network from jmespath search, got {address} (type {type(address).__name__}) in network definition {network_name}."
-                        )
-
-                    # Strip cidr and treat address as a host ip.
-                    if network.get("strip_cidr"):
-                        address = str(ip_interface(address).ip)
-                    else:
-                        address = str(ip_interface(address).network)
-
-                    network_list.append({"address": address})
+            if "path" in network:
+                resolved_addrs = _resolve_jmespath_networks(network, settings, network_name)
+                network_list.extend(resolved_addrs)
             else:
                 # Normal aerleon network definition
                 network_list.append(network)

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1074,15 +1074,18 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
 
                 for address in addresses:
                     try:
-                        # Strip cidr and treat address as a host ip.
-                        if network.get("strip_cidr"):
-                            address = str(ip_interface(address).ip)
-                        else:
-                            address = str(ip_interface(address).network)
+                        ip_interface(address)
                     except ValueError:
                         raise AccessListGenerationError(
                             f"Expected an IP address or network from jmespath search, got {address} (type {type(address).__name__}) in network definition {network_name}."
                         )
+
+                    # Strip cidr and treat address as a host ip.
+                    if network.get("strip_cidr"):
+                        address = str(ip_interface(address).ip)
+                    else:
+                        address = str(ip_interface(address).network)
+
                     network_list.append({"address": address})
             else:
                 # Normal aerleon network definition

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -4,9 +4,11 @@ import logging
 import os
 import re
 import types
+from ipaddress import ip_interface
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union, overload
 
+import jmespath
 import yaml
 from absl import logging as absl_logging
 from aerleon.aclgen import Error as ACLGenError
@@ -1054,12 +1056,37 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
     Builds Aerleon Naming from settings network_definitions and service_definitions.
     Returns a naming.Naming object.
     """
+    logger = get_logger()
+
     aerleon_definitions = naming.Naming()
 
     networks_dict = {}
     services_dict = {}
     for network_name, networks in settings.get("network_definitions", {}).items():
-        networks_dict[network_name] = {"values": networks}
+        network_list = []
+        for network in networks:
+            # This is a jmespath reference.
+            if "path" in network.keys():
+                addresses = jmespath.search(network["path"], settings)
+
+                if not isinstance(addresses, list):
+                    raise AccessListGenerationError(
+                        f"Expected a list from jmespath search, got {type(addresses).__name__}."
+                    )
+
+                for address in addresses:
+                    try:
+                        ip_interface(address)
+                    except ValueError:
+                        raise AccessListGenerationError(
+                            f"Expected an IP address or network from jmespath search, got {address} (type {type(address).__name__}) in network definition {network_name}."
+                        )
+                    network_list.append({"address": address})
+            else:
+                # Normal aerleon network definition
+                network_list.append(network.get("value"))
+
+        networks_dict[network_name] = {"values": network_list}
     for service_name, services in settings.get("service_definitions", {}).items():
         services_dict[service_name] = services
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1056,8 +1056,6 @@ def _build_aerleon_definitions(settings: dict) -> naming.Naming:
     Builds Aerleon Naming from settings network_definitions and service_definitions.
     Returns a naming.Naming object.
     """
-    logger = get_logger()
-
     aerleon_definitions = naming.Naming()
 
     networks_dict = {}

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -3,7 +3,7 @@ import re
 from enum import Enum, StrEnum, auto
 from functools import cached_property
 from ipaddress import AddressValueError, IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Network
-from typing import Annotated, Dict, List, Literal, Optional, Self, Union
+from typing import Annotated, Dict, List, Literal, Optional, Self
 
 import jmespath
 from aerleon.lib.policy_builder import TermsList
@@ -196,7 +196,7 @@ class f_interface(BaseModel):
     untagged_vlan: Optional[int] = vlan_id_schema_optional
     # tagged vlan list can be list of vlans IDs or ranges of VLAN IDs ("1-10")
     tagged_vlan_list: Optional[
-        List[Union[Annotated[int, Field(ge=1, le=4095)], Annotated[str, AfterValidator(vlan_range_check)]]]
+        List[Annotated[int, Field(ge=1, le=4095)] | Annotated[str, AfterValidator(vlan_range_check)]]
     ] = None
     aggregate_id: Optional[int] = None
     tags: Optional[List[str]] = None
@@ -425,7 +425,7 @@ class f_port_template(BaseModel):
 
 
 class f_network_definition(BaseModel):
-    address: Union[IPv4Address, IPv6Address, IPv4Network, IPv6Network]
+    address: IPv4Address | IPv6Address | IPv4Network | IPv6Network
     comment: str = ""
 
     # Convert address to string.
@@ -671,9 +671,9 @@ class f_groups(BaseModel):
 
 class f_access_lists(BaseModel):
     network_definitions: Dict[
-        str, List[Union[f_network_definition, f_network_definition_include, f_network_definition_reference]]
+        str, List[f_network_definition | f_network_definition_include | f_network_definition_reference]
     ] = {}
-    service_definitions: Dict[str, List[Union[f_service_definition, f_service_definition_include]]] = {}
+    service_definitions: Dict[str, List[f_service_definition | f_service_definition_include]] = {}
     access_lists: Dict[access_list_name, f_access_list] = {}
 
     @field_validator("access_lists", mode="after")

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from ipaddress import AddressValueError, IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Network
 from typing import Annotated, Dict, List, Literal, Optional, Self, Union
 
+import jmespath
 from aerleon.lib.policy_builder import TermsList
 from netutils.lib_mapper import AERLEON_LIB_MAPPER, NAPALM_LIB_MAPPER
 from pydantic import BaseModel, Field, TypeAdapter, ValidationInfo, field_validator, model_validator
@@ -423,7 +424,7 @@ class f_port_template(BaseModel):
 
 
 class f_network_definition(BaseModel):
-    address: Union[IPv4Address | IPv6Address | IPv4Network | IPv6Network]
+    address: Union[IPv4Address, IPv6Address, IPv4Network, IPv6Network]
     comment: str = ""
 
     # Convert address to string.
@@ -435,6 +436,24 @@ class f_network_definition(BaseModel):
 
 class f_network_definition_include(BaseModel):
     name: str
+
+
+class f_network_definition_reference(BaseModel):
+    path: str
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def validate_jmespath(cls, v: str) -> str:
+        jmespath.compile(v)
+
+        return v
+
+    @cached_property
+    def jmespath(self) -> jmespath.parser.ParsedResult:
+        """
+        Returns a compiled jmespath expression.
+        """
+        return jmespath.compile(self.path)
 
 
 class f_service_definition(BaseModel):
@@ -655,8 +674,10 @@ class f_groups(BaseModel):
 
 
 class f_access_lists(BaseModel):
-    network_definitions: Dict[str, List[Union[f_network_definition | f_network_definition_include]]] = {}
-    service_definitions: Dict[str, List[Union[f_service_definition | f_service_definition_include]]] = {}
+    network_definitions: Dict[
+        str, List[Union[f_network_definition, f_network_definition_include, f_network_definition_reference]]
+    ] = {}
+    service_definitions: Dict[str, List[Union[f_service_definition, f_service_definition_include]]] = {}
     access_lists: Dict[access_list_name, f_access_list] = {}
 
     @field_validator("access_lists", mode="after")

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -444,8 +444,10 @@ class f_network_definition_reference(BaseModel):
     @field_validator("path", mode="after")
     @classmethod
     def validate_jmespath(cls, v: str) -> str:
-        jmespath.compile(v)
-
+        try:
+            jmespath.compile(v)
+        except jmespath.exceptions.ParseError as e:
+            raise ValueError(str(e))
         return v
 
 

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -448,13 +448,6 @@ class f_network_definition_reference(BaseModel):
 
         return v
 
-    @cached_property
-    def jmespath(self) -> jmespath.parser.ParsedResult:
-        """
-        Returns a compiled jmespath expression.
-        """
-        return jmespath.compile(self.path)
-
 
 class f_service_definition(BaseModel):
     port: int | str

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -441,6 +441,7 @@ class f_network_definition_include(BaseModel):
 
 class f_network_definition_reference(BaseModel):
     path: str
+    strip_cidr: Optional[bool] = False
 
     @field_validator("path", mode="after")
     @classmethod

--- a/src/cnaas_nms/db/settings_fields.py
+++ b/src/cnaas_nms/db/settings_fields.py
@@ -7,6 +7,7 @@ from typing import Annotated, Dict, List, Literal, Optional, Self, Union
 
 import jmespath
 from aerleon.lib.policy_builder import TermsList
+from jmespath.exceptions import ParseError
 from netutils.lib_mapper import AERLEON_LIB_MAPPER, NAPALM_LIB_MAPPER
 from pydantic import BaseModel, Field, TypeAdapter, ValidationInfo, field_validator, model_validator
 from pydantic.functional_validators import AfterValidator
@@ -446,7 +447,7 @@ class f_network_definition_reference(BaseModel):
     def validate_jmespath(cls, v: str) -> str:
         try:
             jmespath.compile(v)
-        except jmespath.exceptions.ParseError as e:
+        except ParseError as e:
             raise ValueError(str(e))
         return v
 

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -704,7 +704,7 @@ class SettingsTests(unittest.TestCase):
 
         self.assertIn("SOME_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
-        self.assertIn("192.168.0.0/24", acls["SOME_ACL"])
+        self.assertIn("192.168.0.0/24", acls["SOME_ACL"])  # noqa: S1313
 
     def test_acl_network_reference_invalid(self):
         settings = {

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -784,13 +784,19 @@ class SettingsTests(unittest.TestCase):
                     "vlan_id": 101,
                     "vlan_name": "SOME_VXLAN",
                     "ipv4_gw": "192.168.0.1/24",  # noqa: S1313
+                    "ipv6_gw": "2001:db8::1/64",  # noqa: S1313
                     "acl_ipv4_in": "SOME_VXLAN_IN",
                     "devices": ["testdevice-d1"],
                 }
             },
-            "network_definitions": {"VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.[ipv4_gw]", "strip_cidr": True}]},
+            "network_definitions": {
+                "VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.[ipv4_gw, ipv4_secondaries, ipv6_gw][]", "strip_cidr": True}]
+            },
             "access_lists": {
-                "SOME_ACL": {"terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}]}
+                "SOME_ACL": {
+                    "inet_families": ["ipv4", "ipv6"],
+                    "terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}],
+                }
             },
             "system_access_lists": ["SOME_ACL"],
         }
@@ -805,6 +811,7 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("SOME_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
         self.assertIn("host 192.168.0.1", acls["SOME_ACL"])  # noqa: S1313
+        self.assertIn("2001:db8::1", acls["SOME_ACL"])  # noqa: S1313
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -673,6 +673,106 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             f_access_list(**data)
 
+    def test_acl_network_reference(self):
+        """Test that network references work and that they are generated correctly"""
+        settings = {
+            "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
+            "vxlans": {
+                "SOME_VXLAN": {
+                    "vni": 100101,
+                    "vrf": "SOME_VRF",
+                    "vlan_id": 101,
+                    "vlan_name": "SOME_VXLAN",
+                    "ipv4_gw": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "SOME_VXLAN_IN",
+                    "devices": ["testdevice-d1"],
+                }
+            },
+            "network_definitions": {"VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.[ipv4_gw]"}]},
+            "access_lists": {
+                "SOME_ACL": {"terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}]}
+            },
+            "system_access_lists": ["SOME_ACL"],
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        acls = get_generated_access_lists(
+            Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
+        )
+
+        self.assertIn("SOME_ACL", acls.keys())
+        self.assertEqual(len(acls), 1)
+        self.assertIn("192.168.0.0/24", acls["SOME_ACL"])
+
+    def test_acl_network_reference_invalid(self):
+        settings = {
+            "network_definitions": {
+                "VXLAN_REF": [{"path": "vxlans.*.."}]  # Not a valid jmespath
+            }
+        }
+
+        with self.assertRaises(ValidationError):
+            f_root(**settings)
+
+    def test_acl_network_reference_no_list(self):
+        settings = {
+            "vxlans": {
+                "SOME_VXLAN": {
+                    "vni": 100101,
+                    "vrf": "SOME_VRF",
+                    "vlan_id": 101,
+                    "vlan_name": "SOME_VXLAN",
+                    "ipv4_gw": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "SOME_VXLAN_IN",
+                    "devices": ["testdevice-d1"],
+                }
+            },
+            "network_definitions": {"VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.ipv4_gw"}]},
+            "access_lists": {
+                "SOME_ACL": {"terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}]}
+            },
+            "system_access_lists": ["SOME_ACL"],
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        # No address = cannot render acl
+        with self.assertRaises(AccessListGenerationError):
+            get_generated_access_lists(
+                Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
+            )
+
+    def test_acl_network_reference_list_no_address(self):
+        settings = {
+            "vxlans": {
+                "SOME_VXLAN": {
+                    "vni": 100101,
+                    "vrf": "SOME_VRF",
+                    "vlan_id": 101,
+                    "vlan_name": "SOME_VXLAN",
+                    "ipv4_gw": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "SOME_VXLAN_IN",
+                    "devices": ["testdevice-d1"],
+                }
+            },
+            "network_definitions": {"VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.acl_ipv4_in"}]},
+            "access_lists": {
+                "SOME_ACL": {"terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}]}
+            },
+            "system_access_lists": ["SOME_ACL"],
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        with self.assertRaises(AccessListGenerationError):
+            get_generated_access_lists(
+                Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -373,13 +373,13 @@ class SettingsTests(unittest.TestCase):
 
     @pytest.mark.integration
     @pytest.mark.usefixtures("settings_directory")
-    def test_acl(self):
+    def test_access_list(self):
         """Generate global acls from integration-test repo"""
         for platform in ["ios", "eos", "junos"]:
             device = Device(hostname=self.testdata["testdevice"], platform=platform)
             get_generated_access_lists(device)
 
-    def test_acl_option(self):
+    def test_access_list_option(self):
         """Test validate and generate access list option"""
         settings = {
             "access_lists": {
@@ -411,7 +411,7 @@ class SettingsTests(unittest.TestCase):
         acls = get_generated_access_lists(platform="eos", settings=settings)
         self.assertEqual(len(acls.keys()), 2)
 
-    def test_acl_invalid_definition(self):
+    def test_access_list_invalid_definition(self):
         """Test invalid network definitions"""
         settings = {
             "network_definitions": {
@@ -427,7 +427,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(AccessListGenerationError):
             get_generated_access_lists(platform="eos", settings=settings)
 
-    def test_acl_no_terms(self):
+    def test_access_list_no_terms(self):
         """Test acl no terms"""
         settings = {
             "access_lists": {"TEST_ACL": {"terms": []}},
@@ -435,7 +435,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             f_root(**settings)
 
-    def test_acl_non_unique_terms(self):
+    def test_access_list_non_unique_terms(self):
         """Test acl non unique terms"""
         settings = {
             "access_lists": {"TEST_ACL": {"terms": [{"name": "same"}, {"name": "same"}]}},
@@ -443,7 +443,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             f_root(**settings)
 
-    def test_acl_include_not_found(self):
+    def test_access_list_include_not_found(self):
         """Test include acl not found"""
         settings = {
             "access_lists": {"TEST_ACL": {"terms": [{"include": "NOT-FOUND-ACL"}]}},
@@ -451,7 +451,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             f_root(**settings)
 
-    def test_acl_include(self):
+    def test_access_list_include(self):
         """Test include acl"""
         settings = {
             "access_lists": {
@@ -465,7 +465,7 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("TEST_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
 
-    def test_acl_nested_include(self):
+    def test_access_list_nested_include(self):
         """Test include acl"""
         settings = {
             "access_lists": {
@@ -482,7 +482,7 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("TEST_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
 
-    def test_acl_include_non_unique(self):
+    def test_access_list_include_non_unique(self):
         """Test include acl where the included terms are not unique together with the parent term names"""
         settings = {
             "access_lists": {
@@ -495,7 +495,7 @@ class SettingsTests(unittest.TestCase):
 
     @pytest.mark.integration
     @pytest.mark.usefixtures("settings_directory")
-    def test_acl_redis_hit(self):
+    def test_access_list_redis_hit(self):
         """
         Run get_generated_access_lists twice with the same device should execute get_settings only once
         """
@@ -530,7 +530,7 @@ class SettingsTests(unittest.TestCase):
         # Assert results are identical
         assert acls1 == acls2
 
-    def test_acl_system_acl(self):
+    def test_access_list_system_acl(self):
         system_acls = ["ACL-TEST"]
         acls = {"ACL-TEST": {"terms": [{"name": "permit-any", "action": "accept"}]}}
         # Works because the system_access_list is defined in access_lists
@@ -539,7 +539,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(SettingsSyntaxError):
             check_system_access_lists({"system_access_lists": system_acls, "access_lists": {}})
 
-    def test_acl_auto_from_vxlans(self):
+    def test_access_list_auto_from_vxlans(self):
         """vxlan that is allocated to a DeviceType.DIST will be auto included to be generated"""
         settings = {
             "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
@@ -575,7 +575,7 @@ class SettingsTests(unittest.TestCase):
         self.assertNotIn("SOME_VXLAN_IN", access_acls.keys())
         self.assertEqual(len(access_acls), 0)
 
-    def test_acl_auto_from_interfaces(self):
+    def test_access_list_auto_from_interfaces(self):
         """interfaces that is allocated to a device will be auto included to be generated"""
         settings = {
             "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
@@ -602,7 +602,7 @@ class SettingsTests(unittest.TestCase):
             self.assertIn("SOME_INTF_IN", acls.keys())
             self.assertEqual(len(acls), 1)
 
-    def test_acl_juniper_srx(self):
+    def test_access_list_juniper_srx(self):
         settings = {
             "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
             "interfaces": [
@@ -632,7 +632,7 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("ALL_TO_ALL", acls.keys())
         self.assertEqual(len(acls), 1)
 
-    def test_acl_juniper_srx_error(self):
+    def test_access_list_juniper_srx_error(self):
         settings = {
             "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
             "interfaces": [
@@ -658,7 +658,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(AccessListGenerationError):
             get_generated_access_lists(firewall_device, settings=settings)
 
-    def test_acl_f_access_list_header_map(self):
+    def test_access_list_f_access_list_header_map(self):
         """Verify f_access_list header_map, can be in napalm or aerleon platform syntax."""
         data = {
             "header_map": {"ios": "", "eos": "", "srx": "", "nxos": "", "cisconx": ""},
@@ -666,14 +666,14 @@ class SettingsTests(unittest.TestCase):
         }
         f_access_list(**data)
 
-    def test_acl_f_access_list_header_map_error(self):
+    def test_access_list_f_access_list_header_map_error(self):
         """Verify f_access_list header_map error"""
         # Invalid header_map key
         data = {"header_map": {"abc": "abc"}, "terms": [{"name": "permit-any", "action": "accept"}]}
         with self.assertRaises(ValidationError):
             f_access_list(**data)
 
-    def test_acl_network_reference(self):
+    def test_access_list_network_reference(self):
         """Test that network references work and that they are generated correctly"""
         settings = {
             "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
@@ -706,7 +706,7 @@ class SettingsTests(unittest.TestCase):
         self.assertEqual(len(acls), 1)
         self.assertIn("192.168.0.0/24", acls["SOME_ACL"])  # noqa: S1313
 
-    def test_acl_network_reference_invalid(self):
+    def test_access_list_network_reference_invalid(self):
         settings = {
             "network_definitions": {
                 "VXLAN_REF": [{"path": "vxlans.*.."}]  # Not a valid jmespath
@@ -716,7 +716,7 @@ class SettingsTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             f_root(**settings)
 
-    def test_acl_network_reference_no_list(self):
+    def test_access_list_network_reference_no_list(self):
         settings = {
             "vxlans": {
                 "SOME_VXLAN": {
@@ -745,7 +745,7 @@ class SettingsTests(unittest.TestCase):
                 Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
             )
 
-    def test_acl_network_reference_list_no_address(self):
+    def test_access_list_network_reference_list_no_address(self):
         settings = {
             "vxlans": {
                 "SOME_VXLAN": {
@@ -772,6 +772,39 @@ class SettingsTests(unittest.TestCase):
             get_generated_access_lists(
                 Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
             )
+
+    def test_access_list_network_reference_strip_cidr(self):
+        """Test that network references work and that they are generated correctly with stripped cidr"""
+        settings = {
+            "vrfs": [{"name": "SOME_VRF", "vrf_id": 101}],
+            "vxlans": {
+                "SOME_VXLAN": {
+                    "vni": 100101,
+                    "vrf": "SOME_VRF",
+                    "vlan_id": 101,
+                    "vlan_name": "SOME_VXLAN",
+                    "ipv4_gw": "192.168.0.1/24",  # noqa: S1313
+                    "acl_ipv4_in": "SOME_VXLAN_IN",
+                    "devices": ["testdevice-d1"],
+                }
+            },
+            "network_definitions": {"VXLAN_REF": [{"path": "vxlans.SOME_VXLAN.[ipv4_gw]", "strip_cidr": True}]},
+            "access_lists": {
+                "SOME_ACL": {"terms": [{"name": "permit-any", "destination-address": "VXLAN_REF", "action": "accept"}]}
+            },
+            "system_access_lists": ["SOME_ACL"],
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        acls = get_generated_access_lists(
+            Device(hostname="testdevice-x1", platform="eos", device_type=DeviceType.DIST), settings=settings
+        )
+
+        self.assertIn("SOME_ACL", acls.keys())
+        self.assertEqual(len(acls), 1)
+        self.assertIn("host 192.168.0.1", acls["SOME_ACL"])  # noqa: S1313
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a reference network_definition that can reference addresses from other settings.
Example, IPv4 gateways in vxlans for vrf: STUDENT.

Uses jmespath as a language to dynamically search settings and populate aerleon network objects.
Must return as a list of addresses.

Example jmespath syntax:

All IPv4 and IPv6 gateways of VXLANs in the STUDENT VRF: `vxlans.*[] | [?vrf=='STUDENT'].[ipv4_gw, ipv6_gw][]`

All BGP IPv4 and IPv6 neighbors in the STUDENT VRF: `extroute_bgp.vrfs[?name=='STUDENT'].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`

All BGP IPv4 neighbors: `extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4`

@indy-independence and @YotaYota please provide feedback if this is something that would be useful.