### PR TITLE
Refactored device add api to support adding other napalm platforms

### DIFF
--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -5,6 +5,9 @@ from typing import Any, List, Optional
 
 from flask import make_response, request
 from flask_restx import Namespace, Resource, fields, marshal
+from napalm import get_network_driver
+from napalm._SUPPORTED_DRIVERS import SUPPORTED_DRIVERS
+from napalm.base.exceptions import ModuleImportError
 from pydantic import ValidationError
 from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
@@ -452,7 +455,6 @@ class DeviceApi(Resource):
     def post(self):
         """Add a device"""
         json_data = request.get_json()
-        supported_platforms = ["eos", "junos", "ios", "iosxr", "nxos", "nxos_ssh"]
         data = {}
         errors = []
         data, errors = Device.validate(**json_data)
@@ -463,10 +465,12 @@ class DeviceApi(Resource):
             if instance:
                 errors.append("Device already exists")
                 return empty_result(status="error", data=errors), 400
-            if "platform" not in data or data["platform"] not in supported_platforms:
+            try:
+                get_network_driver(data.get("platform"))
+            except ModuleImportError as e:
                 errors.append(
-                    "Device platform not specified or not known (must be any of: {})".format(
-                        ", ".join(supported_platforms)
+                    "Device platform not specified or not known (must be any of: {}), napalm driver error: {}".format(
+                        ", ".join(SUPPORTED_DRIVERS), str(e)
                     )
                 )
                 return empty_result(status="error", data=errors), 400

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -127,8 +127,8 @@ class DeviceTests(unittest.TestCase):
     def test_add_device_error(self):
         device_data = {
             "hostname": "testpanosaccess",
-            "management_ip": "10.1.3.5",
-            "dhcp_ip": "11.1.3.5",
+            "management_ip": "10.1.3.5",  # noqa: S1313
+            "dhcp_ip": "11.1.3.5",  # noqa: S1313
             "ztp_mac": "0800275C0999",
             "platform": "panos",
             "state": "MANAGED",
@@ -140,8 +140,8 @@ class DeviceTests(unittest.TestCase):
     def test_add_device_no_platform(self):
         device_data = {
             "hostname": "testnoaccess",
-            "management_ip": "10.1.3.6",
-            "dhcp_ip": "11.1.3.6",
+            "management_ip": "10.1.3.6",  # noqa: S1313
+            "dhcp_ip": "11.1.3.6",  # noqa: S1313
             "ztp_mac": "0800275C0999",
             "state": "MANAGED",
             "device_type": "ACCESS",

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -124,6 +124,31 @@ class DeviceTests(unittest.TestCase):
         result = self.client.post("/api/v1.0/device", json=device_data)
         self.assertEqual(result.status_code, 200)
 
+    def test_add_device_error(self):
+        device_data = {
+            "hostname": "testpanosaccess",
+            "management_ip": "10.1.3.5",
+            "dhcp_ip": "11.1.3.5",
+            "ztp_mac": "0800275C0999",
+            "platform": "panos",
+            "state": "MANAGED",
+            "device_type": "ACCESS",
+        }
+        result = self.client.post("/api/v1.0/device", json=device_data)
+        self.assertEqual(result.status_code, 400)
+
+    def test_add_device_no_platform(self):
+        device_data = {
+            "hostname": "testnoaccess",
+            "management_ip": "10.1.3.6",
+            "dhcp_ip": "11.1.3.6",
+            "ztp_mac": "0800275C0999",
+            "state": "MANAGED",
+            "device_type": "ACCESS",
+        }
+        result = self.client.post("/api/v1.0/device", json=device_data)
+        self.assertEqual(result.status_code, 400)
+
     def test_get_device(self):
         result = self.client.get(f"/api/v1.0/device/{self.hostname}")
         self.assertEqual(result.status_code, 200)

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -124,7 +124,7 @@ class DeviceTests(unittest.TestCase):
         result = self.client.post("/api/v1.0/device", json=device_data)
         self.assertEqual(result.status_code, 200)
 
-    def test_add_device_error(self):
+    def test_add_device_unsupported_platform_error(self):
         device_data = {
             "hostname": "testpanosaccess",
             "management_ip": "10.1.3.5",  # noqa: S1313


### PR DESCRIPTION
Adds dynamic support for napalm platforms(drivers) instead of relying on a static list.
Should then support adding custom napalm drivers to a docker image and being able to create devices.