### PR TITLE
Preserve markdown trailing whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
         exclude: "(docker/.*patch)"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Adds an argument to pre-commit-hooks to not remove trailing whitespace for markdown-files.

Info: https://pypi.org/project/pre-commit-hooks/ 

> To preserve Markdown [hard linebreaks](https://github.github.com/gfm/#hard-line-break) use args: [--markdown-linebreak-ext=md] (or other extensions used by your markdownfiles). If for some reason you want to treat all files as markdown, use --markdown-linebreak-ext=*.

