### PR TITLE
Feature.live run fencing token

### DIFF
--- a/docs/apiref/syncto.rst
+++ b/docs/apiref/syncto.rst
@@ -80,6 +80,12 @@ that setting for a specific job using the API argument confirm_mode (see below).
    This should be a string with max 32 characters.
  - confirm_mode: Optionally override the default commit confirm mode (see above) for this job.
    Must be an integer 0, 1 or 2 if specified.
+ - fencing_token: Optional string that can be provided when doing dry_run=False to prevent
+   unintended configuration changes in case of multiple users working on the same device at
+   the same time. String should consist of a job_id from previous dry_run=True job which
+   generated the intended configuration changes. If the device configuration has changed since
+   that dry run job was executed the syncto job will fail instead of pushing the new configuration
+   to the device.
 
 If neither hostname or device_type is specified all devices that needs to be sycnhronized
 will be selected.

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -777,10 +777,14 @@ def parse_syncto_args(json_data: dict):
         kwargs["job_comment"] = json_data["comment"]
     if "ticket_ref" in json_data and isinstance(json_data["ticket_ref"], str):
         kwargs["job_ticket_ref"] = json_data["ticket_ref"]
-    if "confirm_mode" in json_data and isinstance(json_data["confirm_mode"], int):
+    if "confirm_mode" in json_data:
+        if not isinstance(json_data["confirm_mode"], int):
+            raise ValueError("confirm_mode must be an integer")
         kwargs["confirm_mode_override"] = json_data["confirm_mode"]
-    if "fencing_token" in json_data and isinstance(json_data["fencing_token"], str):
-        kwargs["fencing_token"] = json_data["fencing_token"]
+    if "fencing_token" in json_data:
+        if not isinstance(json_data["fencing_token"], str):
+            raise ValueError("fencing_token must be a string")
+        kwargs["fencing_token"] = int(json_data["fencing_token"])
 
     return kwargs
 

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -143,6 +143,7 @@ device_syncto_model = device_syncto_api.model(
         "auto_push": fields.Boolean(required=False),
         "resync": fields.Boolean(required=False),
         "confirm_mode": fields.Integer(required=False, min=0, max=2),
+        "fencing_token": fields.String(required=False),
     },
 )
 
@@ -154,6 +155,7 @@ device_syncto_hostname_model = device_syncto_api.model(
         "auto_push": fields.Boolean(required=False),
         "resync": fields.Boolean(required=False),
         "confirm_mode": fields.Integer(required=False, min=0, max=2),
+        "fencing_token": fields.String(required=False),
     },
 )
 
@@ -777,6 +779,8 @@ def parse_syncto_args(json_data: dict):
         kwargs["job_ticket_ref"] = json_data["ticket_ref"]
     if "confirm_mode" in json_data and isinstance(json_data["confirm_mode"], int):
         kwargs["confirm_mode_override"] = json_data["confirm_mode"]
+    if "fencing_token" in json_data and isinstance(json_data["fencing_token"], str):
+        kwargs["fencing_token"] = json_data["fencing_token"]
 
     return kwargs
 

--- a/src/cnaas_nms/devicehandler/fencing.py
+++ b/src/cnaas_nms/devicehandler/fencing.py
@@ -1,0 +1,57 @@
+from redis.exceptions import RedisError
+
+from cnaas_nms.db.session import redis_session
+from cnaas_nms.tools.log import get_logger
+
+REDIS_FENCING_TOKENS_KEY = "syncto_fencing_tokens"
+FENCING_TOKEN_TTL = 7200  # 2 hours in seconds
+
+logger = get_logger()
+
+
+class FencingError(Exception):
+    pass
+
+
+def create_syncto_fencing_token(job_id: int):
+    """Save a fencing token (job_id) to Redis after a successful dry run.
+
+    The token is stored in a Redis SET. The entire SET has a TTL of 2 hours
+    as a safety net to prevent tokens from being valid indefinitely.
+    """
+    try:
+        with redis_session() as redis:  # type: ignore
+            redis.sadd(REDIS_FENCING_TOKENS_KEY, str(job_id))
+            redis.expire(REDIS_FENCING_TOKENS_KEY, FENCING_TOKEN_TTL)
+            logger.debug("Created fencing token for job_id {}".format(job_id))
+    except RedisError as e:
+        logger.exception("Redis Error while creating fencing token: {}".format(e))
+        raise
+
+
+def get_fencing_token(job_id: str) -> bool:
+    """Check if a fencing token (job_id) is still valid.
+
+    Returns True if the token exists in the Redis SET, False otherwise.
+    """
+    try:
+        with redis_session() as redis:  # type: ignore
+            return redis.sismember(REDIS_FENCING_TOKENS_KEY, str(job_id))
+    except RedisError as e:
+        logger.exception("Redis Error while checking fencing token: {}".format(e))
+        raise
+
+
+def delete_all_fencing_tokens():
+    """Delete all fencing tokens from Redis.
+
+    Called when a sync event occurs, invalidating all outstanding tokens
+    since the device state may have changed.
+    """
+    try:
+        with redis_session() as redis:  # type: ignore
+            result = redis.delete(REDIS_FENCING_TOKENS_KEY)
+            if result:
+                logger.debug("Deleted all fencing tokens from Redis")
+    except RedisError as e:
+        logger.exception("Redis Error while deleting fencing tokens: {}".format(e))

--- a/src/cnaas_nms/devicehandler/fencing.py
+++ b/src/cnaas_nms/devicehandler/fencing.py
@@ -1,3 +1,6 @@
+import json
+from typing import List
+
 from redis.exceptions import RedisError
 
 from cnaas_nms.db.session import redis_session
@@ -13,40 +16,63 @@ class FencingError(Exception):
     pass
 
 
-def create_syncto_fencing_token(job_id: int):
-    """Save a fencing token (job_id) to Redis after a successful dry run.
+def create_syncto_fencing_token(job_id: int, device_list: List[str]):
+    """Save a fencing token (job_id) with its device list to Redis after a successful dry run.
 
-    The token is stored in a Redis SET. The entire SET has a TTL of 2 hours
+    The token is stored in a Redis HASH where the field is the job_id and the
+    value is the JSON-encoded device list. The entire HASH has a TTL of 2 hours
     as a safety net to prevent tokens from being valid indefinitely.
     """
     try:
         with redis_session() as redis:  # type: ignore
-            redis.sadd(REDIS_FENCING_TOKENS_KEY, str(job_id))
+            redis.hset(REDIS_FENCING_TOKENS_KEY, str(job_id), json.dumps(device_list))
             redis.expire(REDIS_FENCING_TOKENS_KEY, FENCING_TOKEN_TTL)
-            logger.debug("Created fencing token for job_id {}".format(job_id))
+            print_device_list = ", ".join(device_list[:10]) + (
+                f"... ({len(device_list)} total)" if len(device_list) > 10 else ""
+            )
+            logger.debug("Created fencing token for job_id {} with devices: {}".format(job_id, print_device_list))
     except RedisError as e:
         logger.exception("Redis Error while creating fencing token: {}".format(e))
         raise
 
 
-def get_fencing_token(job_id: str) -> bool:
+def get_fencing_token(job_id: int) -> bool:
     """Check if a fencing token (job_id) is still valid.
 
-    Returns True if the token exists in the Redis SET, False otherwise.
+    Returns True if the token exists in the Redis HASH, False otherwise.
     """
     try:
         with redis_session() as redis:  # type: ignore
-            return redis.sismember(REDIS_FENCING_TOKENS_KEY, str(job_id))
+            return redis.hexists(REDIS_FENCING_TOKENS_KEY, str(job_id))
     except RedisError as e:
         logger.exception("Redis Error while checking fencing token: {}".format(e))
         raise
 
 
+def delete_fencing_token(hostname: str):
+    """Delete fencing tokens whose device list contains the given hostname.
+
+    Called when a sync event occurs for a specific host, invalidating only
+    tokens that targeted that host.
+    """
+    try:
+        with redis_session() as redis:  # type: ignore
+            all_tokens = redis.hgetall(REDIS_FENCING_TOKENS_KEY)
+            for token_job_id, device_list_json in all_tokens.items():
+                device_list = json.loads(device_list_json)
+                if hostname in device_list:
+                    redis.hdel(REDIS_FENCING_TOKENS_KEY, token_job_id)
+                    logger.debug(
+                        "Deleted fencing token {} because hostname {} is in device list".format(token_job_id, hostname)
+                    )
+    except RedisError as e:
+        logger.exception("Redis Error while deleting fencing token for hostname {}: {}".format(hostname, e))
+
+
 def delete_all_fencing_tokens():
     """Delete all fencing tokens from Redis.
 
-    Called when a sync event occurs, invalidating all outstanding tokens
-    since the device state may have changed.
+    Invalidates all outstanding tokens regardless of their device lists.
     """
     try:
         with redis_session() as redis:  # type: ignore

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -23,6 +23,7 @@ from cnaas_nms.db.joblock import Joblock, JoblockError
 from cnaas_nms.db.session import redis_session, sqla_session
 from cnaas_nms.db.settings import get_generated_access_lists, get_settings
 from cnaas_nms.devicehandler.changescore import calculate_score
+from cnaas_nms.devicehandler.fencing import FencingError, create_syncto_fencing_token, get_fencing_token
 from cnaas_nms.devicehandler.get import calc_config_hash
 from cnaas_nms.devicehandler.nornir_helper import NornirJobResult, cnaas_init, get_jinja_env, inventory_selector
 from cnaas_nms.devicehandler.sync_history import add_sync_event, remove_sync_events
@@ -908,6 +909,7 @@ def sync_devices(
     scheduled_by: str = "",
     resync: bool = False,
     confirm_mode_override: Optional[int] = None,
+    fencing_token: Optional[str] = None,
 ) -> NornirJobResult:
     """Synchronize devices to their respective templates. If no arguments
     are specified then synchronize all devices that are currently out
@@ -927,6 +929,7 @@ def sync_devices(
                 database, a device selected by hostname is always re-synced
         confirm_mode_override: Override settings commit confirm mode, optional int
                                with value 0, 1 or 2
+        fencing_token: Optional job id string to check for fencing before live run
 
     Returns:
         NornirJobResult
@@ -965,6 +968,12 @@ def sync_devices(
                     time.sleep(2)
             if not lock_ok:
                 raise JoblockError("Unable to acquire lock for configuring devices")
+
+    if not dry_run and fencing_token:
+        if get_fencing_token(fencing_token):
+            logger.info("Fencing token {} is valid, proceeding with live run".format(fencing_token))
+        else:
+            raise FencingError("Fencing token {} is invalid or expired".format(fencing_token))
 
     try:
         nrresult = nr_filtered.run(
@@ -1048,6 +1057,10 @@ def sync_devices(
                 time.sleep(api_settings.COMMIT_CONFIRMED_TIMEOUT)
             logger.info("Releasing lock for devices from syncto job: {}".format(job_id))
             Joblock.release_lock(session, job_id=job_id)
+
+    # Save fencing token after successful dry run
+    if dry_run and job_id:
+        create_syncto_fencing_token(job_id)
 
     if len(device_list) == 0:
         total_change_score = 0

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -973,6 +973,10 @@ def sync_devices(
         if get_fencing_token(fencing_token):
             logger.info("Fencing token {} is valid, proceeding with live run".format(fencing_token))
         else:
+            logger.error("Fencing token {} is invalid or expired, aborting live run".format(fencing_token))
+            with sqla_session() as session:  # type: ignore
+                logger.info("Releasing lock for devices from syncto job: {}".format(job_id))
+                Joblock.release_lock(session, job_id=job_id)
             raise FencingError("Fencing token {} is invalid or expired".format(fencing_token))
 
     try:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -1089,7 +1089,7 @@ def sync_devices(
                 "cnaas_nms.devicehandler.sync_devices:sync_devices",
                 when=0,
                 scheduled_by=scheduled_by,
-                kwargs={"hostnames": hostnames, "dry_run": False, "force": force},
+                kwargs={"hostnames": hostnames, "dry_run": False, "force": force, "fencing_token": str(job_id)},
             )
             logger.info(f"Auto-push scheduled live-run of commit as job id {next_job_id}")
         else:

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -909,7 +909,7 @@ def sync_devices(
     scheduled_by: str = "",
     resync: bool = False,
     confirm_mode_override: Optional[int] = None,
-    fencing_token: Optional[str] = None,
+    fencing_token: Optional[int] = None,
 ) -> NornirJobResult:
     """Synchronize devices to their respective templates. If no arguments
     are specified then synchronize all devices that are currently out
@@ -1060,7 +1060,7 @@ def sync_devices(
 
     # Save fencing token after successful dry run
     if dry_run and job_id:
-        create_syncto_fencing_token(job_id)
+        create_syncto_fencing_token(job_id, device_list)
 
     if len(device_list) == 0:
         total_change_score = 0

--- a/src/cnaas_nms/devicehandler/sync_history.py
+++ b/src/cnaas_nms/devicehandler/sync_history.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
 from cnaas_nms.db.session import redis_session
-from cnaas_nms.devicehandler.fencing import delete_all_fencing_tokens
+from cnaas_nms.devicehandler.fencing import delete_fencing_token
 from cnaas_nms.tools.event import add_event
 from cnaas_nms.tools.log import get_logger
 
@@ -50,8 +50,8 @@ class SyncHistory:
 def add_sync_event(
     hostname: str, cause: str, by: Optional[str] = None, job_id: Optional[int] = None, timestamp: Optional[float] = None
 ):
-    # Invalidate all fencing tokens since device state may have changed
-    delete_all_fencing_tokens()
+    # Invalidate fencing tokens that include this hostname
+    delete_fencing_token(hostname)
     try:
         if not by:
             by = "unknown"

--- a/src/cnaas_nms/devicehandler/sync_history.py
+++ b/src/cnaas_nms/devicehandler/sync_history.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from redis.exceptions import RedisError
 
 from cnaas_nms.db.session import redis_session
+from cnaas_nms.devicehandler.fencing import delete_all_fencing_tokens
 from cnaas_nms.tools.event import add_event
 from cnaas_nms.tools.log import get_logger
 
@@ -49,6 +50,8 @@ class SyncHistory:
 def add_sync_event(
     hostname: str, cause: str, by: Optional[str] = None, job_id: Optional[int] = None, timestamp: Optional[float] = None
 ):
+    # Invalidate all fencing tokens since device state may have changed
+    delete_all_fencing_tokens()
     try:
         if not by:
             by = "unknown"

--- a/src/cnaas_nms/devicehandler/tests/test_fencing.py
+++ b/src/cnaas_nms/devicehandler/tests/test_fencing.py
@@ -1,0 +1,159 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cnaas_nms.devicehandler.fencing import (
+    REDIS_FENCING_TOKENS_KEY,
+    FencingError,
+    create_syncto_fencing_token,
+    delete_all_fencing_tokens,
+    get_fencing_token,
+)
+
+
+@pytest.fixture
+def mock_redis():
+    """Provide a mock Redis client via the redis_session context manager."""
+    mock_client = MagicMock()
+    with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
+        mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_session.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_client
+
+
+class TestCreateSynctoFencingToken:
+    def test_creates_token_in_redis_set(self, mock_redis):
+        create_syncto_fencing_token(42)
+
+        mock_redis.sadd.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
+
+    def test_sets_ttl_on_key(self, mock_redis):
+        create_syncto_fencing_token(42)
+
+        mock_redis.expire.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, 7200)
+
+    def test_converts_job_id_to_string(self, mock_redis):
+        create_syncto_fencing_token(12345)
+
+        mock_redis.sadd.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "12345")
+
+    def test_raises_on_redis_error(self):
+        from redis.exceptions import RedisError
+
+        with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
+            mock_client = MagicMock()
+            mock_client.sadd.side_effect = RedisError("connection failed")
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            with pytest.raises(RedisError):
+                create_syncto_fencing_token(42)
+
+
+class TestGetFencingToken:
+    def test_returns_true_when_token_exists(self, mock_redis):
+        mock_redis.sismember.return_value = True
+
+        result = get_fencing_token("42")
+
+        assert result is True
+        mock_redis.sismember.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
+
+    def test_returns_false_when_token_missing(self, mock_redis):
+        mock_redis.sismember.return_value = False
+
+        result = get_fencing_token("99")
+
+        assert result is False
+
+    def test_converts_input_to_string(self, mock_redis):
+        mock_redis.sismember.return_value = True
+
+        get_fencing_token("123")
+
+        mock_redis.sismember.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "123")
+
+    def test_raises_on_redis_error(self):
+        from redis.exceptions import RedisError
+
+        with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
+            mock_client = MagicMock()
+            mock_client.sismember.side_effect = RedisError("connection failed")
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            with pytest.raises(RedisError):
+                get_fencing_token("42")
+
+
+class TestDeleteAllFencingTokens:
+    def test_deletes_the_redis_key(self, mock_redis):
+        mock_redis.delete.return_value = 1
+
+        delete_all_fencing_tokens()
+
+        mock_redis.delete.assert_called_once_with(REDIS_FENCING_TOKENS_KEY)
+
+    def test_does_not_raise_when_key_does_not_exist(self, mock_redis):
+        mock_redis.delete.return_value = 0
+
+        # Should not raise
+        delete_all_fencing_tokens()
+
+        mock_redis.delete.assert_called_once_with(REDIS_FENCING_TOKENS_KEY)
+
+    def test_does_not_raise_on_redis_error(self):
+        """delete_all_fencing_tokens logs but does not re-raise Redis errors."""
+        from redis.exceptions import RedisError
+
+        with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
+            mock_client = MagicMock()
+            mock_client.delete.side_effect = RedisError("connection failed")
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Should not raise - delete_all_fencing_tokens only logs the error
+            delete_all_fencing_tokens()
+
+
+class TestFencingError:
+    def test_is_exception_subclass(self):
+        assert issubclass(FencingError, Exception)
+
+    def test_can_be_raised_and_caught(self):
+        with pytest.raises(FencingError, match="token 42 is invalid"):
+            raise FencingError("token 42 is invalid")
+
+
+class TestFencingTokenWorkflow:
+    """Integration-style tests verifying the complete fencing token workflow."""
+
+    def test_create_then_get_returns_true(self, mock_redis):
+        mock_redis.sismember.return_value = True
+
+        create_syncto_fencing_token(42)
+        result = get_fencing_token("42")
+
+        assert result is True
+
+    def test_create_then_delete_then_get_returns_false(self, mock_redis):
+        mock_redis.sismember.return_value = False
+        mock_redis.delete.return_value = 1
+
+        create_syncto_fencing_token(42)
+        delete_all_fencing_tokens()
+        result = get_fencing_token("42")
+
+        assert result is False
+
+    def test_multiple_tokens_all_deleted(self, mock_redis):
+        """Verifying that delete_all removes tokens for all job_ids."""
+        mock_redis.delete.return_value = 1
+
+        create_syncto_fencing_token(1)
+        create_syncto_fencing_token(2)
+        create_syncto_fencing_token(3)
+        delete_all_fencing_tokens()
+
+        # Single DEL call removes the entire SET (all tokens at once)
+        mock_redis.delete.assert_called_once_with(REDIS_FENCING_TOKENS_KEY)

--- a/src/cnaas_nms/devicehandler/tests/test_fencing.py
+++ b/src/cnaas_nms/devicehandler/tests/test_fencing.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from cnaas_nms.devicehandler.fencing import (
     FencingError,
     create_syncto_fencing_token,
     delete_all_fencing_tokens,
+    delete_fencing_token,
     get_fencing_token,
 )
 
@@ -22,68 +24,137 @@ def mock_redis():
 
 
 class TestCreateSynctoFencingToken:
-    def test_creates_token_in_redis_set(self, mock_redis):
-        create_syncto_fencing_token(42)
+    def test_creates_token_in_redis_hash(self, mock_redis):
+        create_syncto_fencing_token(42, ["host1", "host2"])
 
-        mock_redis.sadd.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
+        mock_redis.hset.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42", json.dumps(["host1", "host2"]))
 
     def test_sets_ttl_on_key(self, mock_redis):
-        create_syncto_fencing_token(42)
+        create_syncto_fencing_token(42, ["host1"])
 
         mock_redis.expire.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, 7200)
 
     def test_converts_job_id_to_string(self, mock_redis):
-        create_syncto_fencing_token(12345)
+        create_syncto_fencing_token(12345, ["host1"])
 
-        mock_redis.sadd.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "12345")
+        mock_redis.hset.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "12345", json.dumps(["host1"]))
+
+    def test_stores_empty_device_list(self, mock_redis):
+        create_syncto_fencing_token(42, [])
+
+        mock_redis.hset.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42", json.dumps([]))
 
     def test_raises_on_redis_error(self):
         from redis.exceptions import RedisError
 
         with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
             mock_client = MagicMock()
-            mock_client.sadd.side_effect = RedisError("connection failed")
+            mock_client.hset.side_effect = RedisError("connection failed")
             mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
             mock_session.return_value.__exit__ = MagicMock(return_value=False)
 
             with pytest.raises(RedisError):
-                create_syncto_fencing_token(42)
+                create_syncto_fencing_token(42, ["host1"])
 
 
 class TestGetFencingToken:
     def test_returns_true_when_token_exists(self, mock_redis):
-        mock_redis.sismember.return_value = True
+        mock_redis.hexists.return_value = True
 
-        result = get_fencing_token("42")
+        result = get_fencing_token(42)
 
         assert result is True
-        mock_redis.sismember.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
+        mock_redis.hexists.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
 
     def test_returns_false_when_token_missing(self, mock_redis):
-        mock_redis.sismember.return_value = False
+        mock_redis.hexists.return_value = False
 
-        result = get_fencing_token("99")
+        result = get_fencing_token(99)
 
         assert result is False
 
-    def test_converts_input_to_string(self, mock_redis):
-        mock_redis.sismember.return_value = True
+    def test_converts_int_to_string_for_redis(self, mock_redis):
+        mock_redis.hexists.return_value = True
 
-        get_fencing_token("123")
+        get_fencing_token(123)
 
-        mock_redis.sismember.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "123")
+        mock_redis.hexists.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "123")
 
     def test_raises_on_redis_error(self):
         from redis.exceptions import RedisError
 
         with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
             mock_client = MagicMock()
-            mock_client.sismember.side_effect = RedisError("connection failed")
+            mock_client.hexists.side_effect = RedisError("connection failed")
             mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
             mock_session.return_value.__exit__ = MagicMock(return_value=False)
 
             with pytest.raises(RedisError):
-                get_fencing_token("42")
+                get_fencing_token(42)
+
+
+class TestDeleteFencingToken:
+    def test_deletes_token_containing_hostname(self, mock_redis):
+        mock_redis.hgetall.return_value = {
+            "42": json.dumps(["host1", "host2"]),
+            "43": json.dumps(["host3"]),
+        }
+
+        delete_fencing_token("host1")
+
+        mock_redis.hdel.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
+
+    def test_deletes_multiple_tokens_containing_hostname(self, mock_redis):
+        mock_redis.hgetall.return_value = {
+            "42": json.dumps(["host1", "host2"]),
+            "43": json.dumps(["host1", "host3"]),
+            "44": json.dumps(["host4"]),
+        }
+
+        delete_fencing_token("host1")
+
+        assert mock_redis.hdel.call_count == 2
+        mock_redis.hdel.assert_any_call(REDIS_FENCING_TOKENS_KEY, "42")
+        mock_redis.hdel.assert_any_call(REDIS_FENCING_TOKENS_KEY, "43")
+
+    def test_does_not_delete_tokens_without_hostname(self, mock_redis):
+        mock_redis.hgetall.return_value = {
+            "42": json.dumps(["host1", "host2"]),
+            "43": json.dumps(["host3"]),
+        }
+
+        delete_fencing_token("host3")
+
+        mock_redis.hdel.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "43")
+
+    def test_does_nothing_when_no_tokens_exist(self, mock_redis):
+        mock_redis.hgetall.return_value = {}
+
+        delete_fencing_token("host1")
+
+        mock_redis.hdel.assert_not_called()
+
+    def test_does_nothing_when_hostname_not_in_any_token(self, mock_redis):
+        mock_redis.hgetall.return_value = {
+            "42": json.dumps(["host1", "host2"]),
+        }
+
+        delete_fencing_token("host99")
+
+        mock_redis.hdel.assert_not_called()
+
+    def test_does_not_raise_on_redis_error(self):
+        """delete_fencing_token logs but does not re-raise Redis errors."""
+        from redis.exceptions import RedisError
+
+        with patch("cnaas_nms.devicehandler.fencing.redis_session") as mock_session:
+            mock_client = MagicMock()
+            mock_client.hgetall.side_effect = RedisError("connection failed")
+            mock_session.return_value.__enter__ = MagicMock(return_value=mock_client)
+            mock_session.return_value.__exit__ = MagicMock(return_value=False)
+
+            # Should not raise - delete_fencing_token only logs the error
+            delete_fencing_token("host1")
 
 
 class TestDeleteAllFencingTokens:
@@ -129,31 +200,41 @@ class TestFencingTokenWorkflow:
     """Integration-style tests verifying the complete fencing token workflow."""
 
     def test_create_then_get_returns_true(self, mock_redis):
-        mock_redis.sismember.return_value = True
+        mock_redis.hexists.return_value = True
 
-        create_syncto_fencing_token(42)
-        result = get_fencing_token("42")
+        create_syncto_fencing_token(42, ["host1"])
+        result = get_fencing_token(42)
 
         assert result is True
 
-    def test_create_then_delete_then_get_returns_false(self, mock_redis):
-        mock_redis.sismember.return_value = False
-        mock_redis.delete.return_value = 1
+    def test_create_then_delete_by_hostname_invalidates_token(self, mock_redis):
+        mock_redis.hexists.return_value = False
+        mock_redis.hgetall.return_value = {"42": json.dumps(["host1", "host2"])}
 
-        create_syncto_fencing_token(42)
-        delete_all_fencing_tokens()
-        result = get_fencing_token("42")
+        create_syncto_fencing_token(42, ["host1", "host2"])
+        delete_fencing_token("host1")
+        result = get_fencing_token(42)
 
         assert result is False
+        mock_redis.hdel.assert_called_once_with(REDIS_FENCING_TOKENS_KEY, "42")
 
-    def test_multiple_tokens_all_deleted(self, mock_redis):
-        """Verifying that delete_all removes tokens for all job_ids."""
+    def test_unrelated_hostname_does_not_invalidate_token(self, mock_redis):
+        mock_redis.hexists.return_value = True
+        mock_redis.hgetall.return_value = {"42": json.dumps(["host1", "host2"])}
+
+        create_syncto_fencing_token(42, ["host1", "host2"])
+        delete_fencing_token("host99")
+        result = get_fencing_token(42)
+
+        assert result is True
+        mock_redis.hdel.assert_not_called()
+
+    def test_delete_all_removes_all_tokens(self, mock_redis):
         mock_redis.delete.return_value = 1
 
-        create_syncto_fencing_token(1)
-        create_syncto_fencing_token(2)
-        create_syncto_fencing_token(3)
+        create_syncto_fencing_token(1, ["host1"])
+        create_syncto_fencing_token(2, ["host2"])
+        create_syncto_fencing_token(3, ["host3"])
         delete_all_fencing_tokens()
 
-        # Single DEL call removes the entire SET (all tokens at once)
         mock_redis.delete.assert_called_once_with(REDIS_FENCING_TOKENS_KEY)


### PR DESCRIPTION
Allow user to specify a "fencing token" to make sure no unintended changes are commited in a live run following a dry run syncto job
fencing_token is a string of the job_id of the dry_run job