### PR TITLE
Use CSafeLoader when possible for faster yaml loading and parsing

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -51,7 +51,7 @@ ENV GIT_BRANCH=$GIT_BRANCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 nginx supervisor ssh-client \
     bind9-host iputils-ping net-tools netcat-openbsd procps psmisc \
-    curl uwsgi-plugin-python3 git openssl libyaml \
+    curl uwsgi-plugin-python3 git openssl libyaml-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /opt/cnaas/templates /opt/cnaas/settings /etc/cnaas-nms /tmp/devicecerts \
     && chown -R www-data:www-data /opt/cnaas /etc/cnaas-nms /tmp/devicecerts

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -51,7 +51,7 @@ ENV GIT_BRANCH=$GIT_BRANCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 nginx supervisor ssh-client \
     bind9-host iputils-ping net-tools netcat-openbsd procps psmisc \
-    curl uwsgi-plugin-python3 git openssl \
+    curl uwsgi-plugin-python3 git openssl libyaml \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /opt/cnaas/templates /opt/cnaas/settings /etc/cnaas-nms /tmp/devicecerts \
     && chown -R www-data:www-data /opt/cnaas /etc/cnaas-nms /tmp/devicecerts

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -5,7 +5,6 @@ from ipaddress import IPv4Address
 from pathlib import Path
 
 import pytest
-import yaml
 from sqlalchemy import or_
 
 from cnaas_nms.api import app
@@ -15,6 +14,7 @@ from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.db.linknet import Linknet
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.stackmember import Stackmember
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.mark.integration
@@ -58,7 +58,7 @@ class DeviceTests(unittest.TestCase):
         self.jwt_auth_token = None
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
             if "jwt_auth_token" in self.testdata:
                 self.jwt_auth_token = self.testdata["jwt_auth_token"]
         self.app = app.app

--- a/src/cnaas_nms/api/tests/test_settings.py
+++ b/src/cnaas_nms/api/tests/test_settings.py
@@ -2,19 +2,19 @@ import os
 from pathlib import Path
 
 import pytest
-import yaml
 from flask.testing import FlaskClient
 
 from cnaas_nms.api import app
 from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
 from cnaas_nms.db.settings import FILE_MODEL_MAP
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.fixture
 def testdata(scope="module") -> dict:
     data_dir = Path(__file__).parent / "data"
     with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-        return yaml.safe_load(f_testdata)
+        return yaml_safe_load(f_testdata)
 
 
 @pytest.fixture

--- a/src/cnaas_nms/app_settings.py
+++ b/src/cnaas_nms/app_settings.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from typing import Any, List, Optional
 
-import yaml
 from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 from cnaas_nms.models.permissions import PermissionsModel
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class AppSettings(BaseSettings):
@@ -92,7 +92,7 @@ def construct_api_settings() -> ApiSettings:
 
     if api_config.is_file():
         with open(api_config, "r") as api_file:
-            config = yaml.safe_load(api_file)
+            config = yaml_safe_load(api_file)
 
         if config.get("firmware_url", False):
             firmware_url = config["firmware_url"]
@@ -147,7 +147,7 @@ def construct_app_settings() -> AppSettings:
 
     if db_config.is_file():
         with open(db_config, "r") as db_file:
-            config = yaml.safe_load(db_file)
+            config = yaml_safe_load(db_file)
         _create_db_config(app_settings, config)
 
     def _create_repo_config(settings: AppSettings, config: dict) -> None:
@@ -158,7 +158,7 @@ def construct_app_settings() -> AppSettings:
 
     if repo_config.is_file():
         with open(repo_config, "r") as repo_file:
-            config = yaml.safe_load(repo_file)
+            config = yaml_safe_load(repo_file)
         _create_repo_config(app_settings, config)
 
     return app_settings
@@ -172,7 +172,7 @@ def construct_auth_settings() -> AuthSettings:
 
     if auth_config.is_file():
         with open(auth_config, "r") as auth_file:
-            config = yaml.safe_load(auth_file)
+            config = yaml_safe_load(auth_file)
         auth_settings.OIDC_ENABLED = config.get("oidc_enabled", AuthSettings().OIDC_ENABLED)
         auth_settings.FRONTEND_CALLBACK_URL = config.get("frontend_callback_url", AuthSettings().FRONTEND_CALLBACK_URL)
         auth_settings.OIDC_CONF_WELL_KNOWN_URL = config.get(
@@ -202,7 +202,7 @@ def construct_auth_settings() -> AuthSettings:
     elif permission_config.is_file():
         """Load the file with role permission"""
         with open(permission_config, "r") as permission_file:
-            permissions_rules = yaml.safe_load(permission_file)
+            permissions_rules = yaml_safe_load(permission_file)
         auth_settings.PERMISSIONS = PermissionsModel(**permissions_rules)
     else:
         raise FileNotFoundError(f"{permission_config} not found")

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import urldefrag
 
 import git.remote
-import yaml
 from git import InvalidGitRepositoryError, Repo
 from git.exc import GitCommandError, NoSuchPathError
 
@@ -38,6 +37,7 @@ from cnaas_nms.scheduler.thread_data import set_thread_data
 from cnaas_nms.tools.event import add_event
 from cnaas_nms.tools.githelpers import parse_git_changed_files
 from cnaas_nms.tools.log import get_logger
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class RepoType(enum.Enum):
@@ -384,7 +384,7 @@ def template_syncstatus(updated_templates: set) -> Set[Tuple[DeviceType, str]]:
             raise RepoStructureException("File mapping.yml not found in template repo {}".format(path))
         try:
             with open(mapfile, "r") as f:
-                mapping = yaml.safe_load(f)
+                mapping = yaml_safe_load(f)
         except Exception as e:
             logger.exception("Could not parse {}/mapping.yml in template repo: {}".format(path, str(e)))
             raise RepoStructureException("Could not parse {}/mapping.yml in template repo: {}".format(path, str(e)))

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -160,7 +160,10 @@ class NMSRedisLRU(RedisLRU):
 
         raw_key = f"{self.key_prefix}:{func.__module__}:{func.__qualname__}:{safe_args!r}:{safe_kwargs!r}"
 
-        return hashlib.md5(raw_key.encode("utf-8")).hexdigest()
+        # We want a fast hash here, don't care about a secure one.
+        # We hash the string so it is not too long for redis to handle.
+        # Shorter keys in redis improves performance and reduces memory usage.
+        return hashlib.md5(raw_key.encode("utf-8")).hexdigest() # noqa: S4790
 
 
 redis_lru_cache = NMSRedisLRU(redis_client, default_ttl=24 * 3600)

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional, Set, Tuple, Union, overload
 
 import jmespath
-import yaml
 from absl import logging as absl_logging
 from aerleon.aclgen import Error as ACLGenError
 from aerleon.api import Generate
@@ -49,6 +48,7 @@ from cnaas_nms.db.settings_fields import (
 from cnaas_nms.db.settings_fields import f_vxlans as f_vxlans_model
 from cnaas_nms.tools.log import CaptureHandler, get_logger
 from cnaas_nms.tools.mergedict import merge_dict_origin
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @overload
@@ -584,7 +584,7 @@ def read_settings_file(filename):
     if not os.path.isfile(filename):
         return {}
     with open(filename, "r") as f:
-        return yaml.safe_load(f)
+        return yaml_safe_load(f)
 
 
 def read_settings(
@@ -708,7 +708,7 @@ def recursive_filter_yamldata(
 ) -> Union[List, dict, None]:
     """Filter data and remove dictionary items if they have a key that specifies
     a list of groups, but none of those groups are included in the groups argument.
-    Should only be called with yaml.safe_load:ed data.
+    Should only be called with yaml_safe_load:ed data.
 
     Args:
         data: yaml safe_load:ed data
@@ -729,14 +729,11 @@ def recursive_filter_yamldata(
         return data
 
 
-def get_downstream_dependencies(hostname: str, settings: dict) -> dict:
+def get_downstream_dependencies(device: Device, settings: dict) -> dict:
+    if device.device_type != DeviceType.DIST:
+        return settings
     with sqla_session() as session:  # type: ignore
-        dev: Optional[Device] = session.query(Device).filter(Device.hostname == hostname).one_or_none()
-        if not dev:
-            return settings
-        if dev.device_type != DeviceType.DIST:
-            return settings
-        neighbor_devices = dev.get_neighbors(session)
+        neighbor_devices = device.get_neighbors(session)
         # Downstream device hostnames
         for neighbor_dev in neighbor_devices:
             if neighbor_dev.device_type != DeviceType.ACCESS:
@@ -768,7 +765,7 @@ def get_settings(
     # 1. Get CNaaS-NMS default settings
     data_dir = Path(__file__).parent / "data"
     with open(os.path.join(data_dir, "default_settings.yml"), "r") as f_default_settings:
-        settings: dict = yaml.safe_load(f_default_settings)
+        settings: dict = yaml_safe_load(f_default_settings)
 
     settings_origin = {}
     for k in settings.keys():
@@ -849,7 +846,7 @@ def get_settings(
             settings_origin,
             groups,
         )
-        settings = get_downstream_dependencies(device.hostname, settings)
+        settings = get_downstream_dependencies(device, settings)
 
         # 5. Get settings repo group specific settings
         primary_group = None
@@ -1000,7 +997,7 @@ def get_group_settings() -> Tuple[f_groups, dict]:
 
     data_dir = Path(__file__).parent / "data"
     with open(os.path.join(data_dir, "default_groups.yml"), "r") as f_default_settings:
-        default_settings: dict = yaml.safe_load(f_default_settings)
+        default_settings: dict = yaml_safe_load(f_default_settings)
 
     settings, settings_origin = read_settings(
         local_repo_path, ["global", "groups.yml"], "global", settings, settings_origin

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib
 import json
 import logging
@@ -110,6 +111,42 @@ redis_client = StrictRedis(
     socket_keepalive=True,
 )
 
+_DEVICE_FILTER_FIELDS = frozenset(f_group_device_filter.model_fields)
+
+
+def _make_hashable(obj: Any) -> Any:
+    """Recursively convert objects into hashable objects."""
+    if type(obj) in (int, str, float, bool, type(None)):
+        return obj
+
+    elif isinstance(obj, dict):
+        return tuple((k, _make_hashable(obj[k])) for k in sorted(obj))
+
+    elif isinstance(obj, (list, tuple)):
+        return tuple(_make_hashable(v) for v in obj)
+
+    elif isinstance(obj, set):
+        # Sets must be sorted to guarantee stable representations across runs
+        try:
+            return tuple(sorted(_make_hashable(v) for v in obj))
+        except TypeError:
+            # Fallback if set contains mixed, unorderable types
+            return frozenset(_make_hashable(v) for v in obj)
+
+    elif isinstance(obj, Device):
+        # If device use only the fields that are relevant
+        device_dict = obj.as_dict()
+        return tuple((k, _make_hashable(device_dict[k])) for k in sorted(device_dict) if k in _DEVICE_FILTER_FIELDS)
+
+    elif isinstance(obj, (naming.Naming, naming._ItemUnit)):
+        return tuple((k, _make_hashable(obj.__dict__[k])) for k in sorted(obj.__dict__))
+
+    elif hasattr(obj, "as_dict"):
+        obj_dict = obj.as_dict()
+        return tuple((k, _make_hashable(obj_dict[k])) for k in sorted(obj_dict))
+
+    return obj
+
 
 class NMSRedisLRU(RedisLRU):
     def _decorator_key(self, func: types.FunctionType, *args, **kwargs):
@@ -117,37 +154,13 @@ class NMSRedisLRU(RedisLRU):
         Generate a hashable cache key for RedisLRU,
         even when passing dicts, lists, sets, or custom objects.
         """
-
-        def make_hashable(obj):
-            """Recursively convert objects into hashable objects."""
-            if isinstance(obj, dict):
-                # Sort keys to ensure consistent ordering
-                return tuple((k, make_hashable(v)) for k, v in sorted(obj.items()))
-            elif isinstance(obj, (list, tuple)):
-                return tuple(make_hashable(v) for v in obj)
-            elif isinstance(obj, set):
-                return frozenset(make_hashable(v) for v in obj)
-            elif isinstance(obj, Device):
-                # If device use only the fields that are relevant
-                device_filter_fields = f_group_device_filter.model_fields
-                return tuple(
-                    (k, make_hashable(v)) for k, v in sorted(obj.as_dict().items()) if k in device_filter_fields
-                )
-            elif isinstance(obj, naming.Naming) or isinstance(obj, naming._ItemUnit):
-                # Use __dict__ for Naming object
-                return tuple((k, make_hashable(v)) for k, v in sorted(obj.__dict__.items()))
-            elif hasattr(obj, "as_dict"):
-                # Use the dictionary representation for caching
-                return tuple((k, make_hashable(v)) for k, v in sorted(obj.as_dict().items()))
-            else:
-                return obj
-
         # Convert args & kwargs into stable, hashable forms
-        hashed_args = tuple(hash(make_hashable(arg)) for arg in args)
-        hashed_kwargs = {k: hash(make_hashable(v)) for k, v in kwargs.items()}
+        safe_args = tuple(_make_hashable(arg) for arg in args)
+        safe_kwargs = tuple((k, _make_hashable(v)) for k, v in sorted(kwargs.items()))
 
-        # Call the parent class' key generator with transformed arguments
-        return super()._decorator_key(func, *hashed_args, **hashed_kwargs)
+        raw_key = f"{self.key_prefix}:{func.__module__}:{func.__qualname__}:{safe_args!r}:{safe_kwargs!r}"
+
+        return hashlib.md5(raw_key.encode("utf-8")).hexdigest()
 
 
 redis_lru_cache = NMSRedisLRU(redis_client, default_ttl=24 * 3600)

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -163,7 +163,7 @@ class NMSRedisLRU(RedisLRU):
         # We want a fast hash here, don't care about a secure one.
         # We hash the string so it is not too long for redis to handle.
         # Shorter keys in redis improves performance and reduces memory usage.
-        return hashlib.md5(raw_key.encode("utf-8")).hexdigest() # noqa: S4790
+        return hashlib.md5(raw_key.encode("utf-8")).hexdigest()  # noqa: S4790
 
 
 redis_lru_cache = NMSRedisLRU(redis_client, default_ttl=24 * 3600)

--- a/src/cnaas_nms/db/tests/test_device_vars.py
+++ b/src/cnaas_nms/db/tests/test_device_vars.py
@@ -4,16 +4,16 @@ import os
 from pathlib import Path
 
 import pytest
-import yaml
 
 from cnaas_nms.db.device_vars import expand_interface_settings
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.fixture
 def testdata(scope="session"):
     data_dir = Path(__file__).parent / "data"
     with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-        return yaml.safe_load(f_testdata)
+        return yaml_safe_load(f_testdata)
 
 
 def test_expand_interface_settings_norange(testdata):

--- a/src/cnaas_nms/db/tests/test_mgmtdomain.py
+++ b/src/cnaas_nms/db/tests/test_mgmtdomain.py
@@ -6,13 +6,13 @@ from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 from pathlib import Path
 
 import pytest
-import yaml
 
 import cnaas_nms.db.helper
 from cnaas_nms.db.device import Device
 from cnaas_nms.db.mgmtdomain import Mgmtdomain
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.tests.test_device import DeviceTests
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.mark.integration
@@ -26,7 +26,7 @@ class MgmtdomainTests(unittest.TestCase):
     def get_testdata():
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            return yaml.safe_load(f_testdata)
+            return yaml_safe_load(f_testdata)
 
     def setUp(self):
         self.testdata = self.get_testdata()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -3,7 +3,6 @@ import unittest
 from pathlib import Path
 
 import pytest
-import yaml
 from pydantic import ValidationError
 
 import cnaas_nms.db.settings as db_settings_module
@@ -29,6 +28,7 @@ from cnaas_nms.db.settings import (
     verify_dir_structure,
 )
 from cnaas_nms.db.settings_fields import f_access_list, f_group, f_groups
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class SettingsTests(unittest.TestCase):
@@ -40,7 +40,7 @@ class SettingsTests(unittest.TestCase):
     def setUp(self):
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
         self.required_setting_keys = ["ntp_servers", "radius_servers"]
         self.cleandb()
 

--- a/src/cnaas_nms/devicehandler/get.py
+++ b/src/cnaas_nms/devicehandler/get.py
@@ -3,7 +3,6 @@ import os
 import re
 from typing import Dict, List, Optional, Set
 
-import yaml
 from netutils.config import compliance
 from netutils.lib_mapper import NAPALM_LIB_MAPPER
 from nornir.core.filter import F
@@ -18,6 +17,7 @@ from cnaas_nms.db.git import get_template_repo_path
 from cnaas_nms.db.interface import Interface, InterfaceConfigType, InterfaceError
 from cnaas_nms.tools.jinja_filters import get_config_section
 from cnaas_nms.tools.log import get_logger
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 def get_inventory():
@@ -66,7 +66,7 @@ def get_unmanaged_config_sections(hostname: str, platform: str, devtype: DeviceT
     if not os.path.isfile(mapfile):
         raise RepoStructureException("File {} not found in template repo".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         if (
             "unmanaged_config_sections" in mapping[devtype.name]
             and type(mapping[devtype.name]["unmanaged_config_sections"]) is list

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -4,7 +4,6 @@ from ipaddress import IPv4Address, IPv4Interface, ip_interface
 from typing import Any, List, Optional
 
 import napalm.base.exceptions
-import yaml
 from apscheduler.job import Job
 from netmiko.exceptions import ReadTimeout as NMReadTimeout
 from nornir.core.exceptions import NornirSubTaskError
@@ -41,6 +40,7 @@ from cnaas_nms.scheduler.thread_data import set_thread_data
 from cnaas_nms.scheduler.wrapper import job_wrapper
 from cnaas_nms.tools.log import get_logger
 from cnaas_nms.tools.pki import generate_device_cert
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class ConnectionCheckError(Exception):
@@ -69,7 +69,7 @@ def push_base_management(task, device_variables: dict, devtype: DeviceType, job_
     if not os.path.isfile(mapfile):
         raise RepoStructureException("File {} not found in template repo".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         template = mapping[devtype.name]["entrypoint"]
 
     # TODO: install device certificate, using new hostname and reserved IP.

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -3,7 +3,6 @@ import time
 from ipaddress import IPv4Address, IPv4Interface, ip_interface
 from typing import Any, List, Optional, Tuple
 
-import yaml
 from napalm.eos import EOSDriver as NapalmEOSDriver
 from napalm.junos import JunOSDriver as NapalmJunOSDriver
 from nornir.core import Nornir
@@ -31,6 +30,7 @@ from cnaas_nms.scheduler.thread_data import set_thread_data
 from cnaas_nms.scheduler.wrapper import job_wrapper
 from cnaas_nms.tools.jinja_helpers import get_environment_secrets
 from cnaas_nms.tools.log import get_logger
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 AUTOPUSH_MAX_SCORE = 10
 PRIVATE_ASN_START = 4200000000
@@ -411,7 +411,7 @@ def populate_device_vars(
     if not os.path.isfile(mapfile):
         raise RepoStructureException("File {} not found in template repo".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         if (
             devtype.name in mapping
             and "unmanaged_config_sections" in mapping[devtype.name]
@@ -593,7 +593,7 @@ def push_sync_device(
     if not os.path.isfile(mapfile):
         raise RepoStructureException("File {} not found in template repo".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         template = mapping[devtype.name]["entrypoint"]
 
     logger.debug("Generate config for host: {}".format(task.host.name))

--- a/src/cnaas_nms/devicehandler/tests/test_cert.py
+++ b/src/cnaas_nms/devicehandler/tests/test_cert.py
@@ -2,18 +2,18 @@ import os
 import unittest
 from pathlib import Path
 
-import yaml
 from nornir_utils.plugins.functions import print_result
 
 from cnaas_nms.devicehandler.cert import arista_copy_cert
 from cnaas_nms.devicehandler.nornir_helper import cnaas_init
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class CertTests(unittest.TestCase):
     def setUp(self):
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
 
     def copy_cert(self):
         nr = cnaas_init()

--- a/src/cnaas_nms/devicehandler/tests/test_get.py
+++ b/src/cnaas_nms/devicehandler/tests/test_get.py
@@ -4,12 +4,12 @@ import unittest
 from pathlib import Path
 
 import pytest
-import yaml
 
 import cnaas_nms.devicehandler.get
 import cnaas_nms.devicehandler.update
 from cnaas_nms.db.device import Device, DeviceState, DeviceType
 from cnaas_nms.db.session import sqla_session
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.mark.integration
@@ -22,7 +22,7 @@ class GetTests(unittest.TestCase):
     def setUp(self):
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
 
     @classmethod
     def create_test_device(cls, hostname="unittest"):

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -3,7 +3,6 @@ import time
 import unittest
 from pathlib import Path
 
-import yaml
 from nornir.core.inventory import ConnectionOptions
 from nornir_napalm.plugins.tasks import napalm_configure
 from nornir_utils.plugins.functions import print_result
@@ -14,13 +13,14 @@ from cnaas_nms.db.job import Job
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.devicehandler.update import reset_interfacedb
 from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 class InitTests(unittest.TestCase):
     def setUp(self):
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
 
         scheduler = Scheduler()
         scheduler.start()

--- a/src/cnaas_nms/devicehandler/tests/test_syncto.py
+++ b/src/cnaas_nms/devicehandler/tests/test_syncto.py
@@ -4,20 +4,20 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
-import yaml
 
 from cnaas_nms.db.job import Job, JobStatus
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.db.settings import api_settings
 from cnaas_nms.devicehandler.sync_devices import sync_devices
 from cnaas_nms.tools.log import get_logger
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.fixture
 def testdata(scope="module"):
     data_dir = Path(__file__).parent / "data"
     with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-        return yaml.safe_load(f_testdata)
+        return yaml_safe_load(f_testdata)
 
 
 def run_syncto_job(scheduler, testdata: dict, dry_run: bool = True) -> Optional[dict]:

--- a/src/cnaas_nms/devicehandler/tests/test_update.py
+++ b/src/cnaas_nms/devicehandler/tests/test_update.py
@@ -4,13 +4,13 @@ from pathlib import Path
 from typing import Optional
 
 import pytest
-import yaml
 
 from cnaas_nms.db.device import Device, DeviceType
 from cnaas_nms.db.interface import InterfaceError
 from cnaas_nms.db.session import sqla_session
 from cnaas_nms.devicehandler.init_device import InitVerificationError, pre_init_check_neighbors
 from cnaas_nms.devicehandler.update import update_linknets
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 @pytest.mark.integration
@@ -23,7 +23,7 @@ class UpdateTests(unittest.TestCase):
     def setUp(self):
         data_dir = Path(__file__).parent / "data"
         with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
-            self.testdata = yaml.safe_load(f_testdata)
+            self.testdata = yaml_safe_load(f_testdata)
 
     # maybe ar tge type of dict
     def get_linknets(self, session, neighbors_data: Optional[dict] = None, hostname: str = "eosaccess"):

--- a/src/cnaas_nms/plugins/pluginmanager.py
+++ b/src/cnaas_nms/plugins/pluginmanager.py
@@ -1,11 +1,11 @@
 import importlib
 
 import pluggy
-import yaml
 
 from cnaas_nms.app_settings import api_settings
 from cnaas_nms.plugins.pluginspec import CnaasPluginSpec
 from cnaas_nms.tools.log import get_logger
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 logger = get_logger()
 
@@ -28,7 +28,7 @@ class PluginManagerHandler(object, metaclass=SingletonType):
     def get_plugindata(cls):
         if api_settings.PLUGIN_FILE.is_file():
             with open(api_settings.PLUGIN_FILE, "r") as plugins_file:
-                data = yaml.safe_load(plugins_file)
+                data = yaml_safe_load(plugins_file)
                 if "plugins" in data and isinstance(data["plugins"], list):
                     return data
                 else:

--- a/src/cnaas_nms/tools/dhcp_hook.py
+++ b/src/cnaas_nms/tools/dhcp_hook.py
@@ -7,7 +7,8 @@ from typing import Optional
 
 import netaddr
 import requests
-import yaml
+
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 logger = logging.getLogger("dhcp-hook")
 if not logger.handlers:
@@ -21,7 +22,7 @@ logger.setLevel(logging.DEBUG)
 
 def get_apidata(configfile="/etc/cnaas-nms/apiclient.yml"):
     with open(configfile, "r") as apiclient_file:
-        return yaml.safe_load(apiclient_file)
+        return yaml_safe_load(apiclient_file)
 
 
 def get_jwt_token():

--- a/src/cnaas_nms/tools/generate_esi.py
+++ b/src/cnaas_nms/tools/generate_esi.py
@@ -9,8 +9,9 @@ from jinja_helpers import get_environment_secrets
 try:
     import jinja2
     import requests
-    import yaml
     from jinja2.meta import find_undeclared_variables
+
+    from cnaas_nms.tools.yaml import yaml_safe_load
 except ModuleNotFoundError as e:
     print("Please install python modules requests, jinja2 and (ruamel.)yaml: {}".format(e))
     print("Optionally install netutils for more filters")
@@ -30,7 +31,7 @@ def get_entrypoint(platform, device_type):
     if not os.path.isfile(mapfile):
         raise Exception("File {} not found".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         template_file = mapping[device_type]["entrypoint"]
     return template_file
 

--- a/src/cnaas_nms/tools/initdb.py
+++ b/src/cnaas_nms/tools/initdb.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # flake8: noqa
 
-import yaml
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 with open("/etc/cnaas-nms/db_config.yml", "r") as db_file:
-    db_data = yaml.safe_load(db_file)
+    db_data = yaml_safe_load(db_file)
 
 print(db_data)
 conn_str = f"postgresql://{db_data['username']}:{db_data['password']}@{db_data['hostname']}:{db_data['port']}"

--- a/src/cnaas_nms/tools/template_dry_run.py
+++ b/src/cnaas_nms/tools/template_dry_run.py
@@ -9,8 +9,9 @@ from jinja_helpers import get_environment_secrets
 try:
     import jinja2
     import requests
-    import yaml
     from jinja2.meta import find_undeclared_variables
+
+    from cnaas_nms.tools.yaml import yaml_safe_load
 except ModuleNotFoundError as e:
     print("Please install python modules requests, jinja2 and (ruamel.)yaml: {}".format(e))
     print("Optionally install netutils for more filters")
@@ -30,7 +31,7 @@ def get_entrypoint(platform, device_type):
     if not os.path.isfile(mapfile):
         raise Exception("File {} not found".format(mapfile))
     with open(mapfile, "r") as f:
-        mapping = yaml.safe_load(f)
+        mapping = yaml_safe_load(f)
         template_file = mapping[device_type]["entrypoint"]
     return template_file
 

--- a/src/cnaas_nms/tools/yaml.py
+++ b/src/cnaas_nms/tools/yaml.py
@@ -1,0 +1,10 @@
+import yaml
+
+if yaml.__with_libyaml__:
+    SafeLoader = yaml.CSafeLoader
+else:
+    SafeLoader = yaml.SafeLoader
+
+
+def yaml_safe_load(stream):
+    return yaml.load(stream, Loader=SafeLoader)

--- a/src/cnaas_nms/tools/yaml.py
+++ b/src/cnaas_nms/tools/yaml.py
@@ -1,10 +1,10 @@
 import yaml
 
-if yaml.__with_libyaml__:
-    SafeLoader = yaml.CSafeLoader
+if yaml.__with_libyaml__:  # type: ignore[attr-defined]
+    SafeLoader = yaml.CSafeLoader  # type: ignore[attr-defined]
 else:
     SafeLoader = yaml.SafeLoader
 
 
 def yaml_safe_load(stream):
-    return yaml.load(stream, Loader=SafeLoader)
+    return yaml.load(stream, Loader=SafeLoader)  # type: ignore[attr-defined]

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -6,9 +6,9 @@ from contextlib import closing
 from pathlib import Path
 
 import pytest
-import yaml
 
 from cnaas_nms.scheduler.scheduler import Scheduler
+from cnaas_nms.tools.yaml import yaml_safe_load
 
 
 def pytest_configure(config):
@@ -199,4 +199,4 @@ def jwt_auth_token(testdata):
 def testdata(scope="session"):
     data_dir = Path(__file__).parent / "cnaas_nms" / "api" / "tests" / "data"
     with open(data_dir / "testdata.yml", "r") as f_testdata:
-        return yaml.safe_load(f_testdata)
+        return yaml_safe_load(f_testdata)


### PR DESCRIPTION
I was playing around with pytest-profiling and made a synthetic test in which 10000 unique devices run get_settings after each other.

During the test get_settings stood for 81.5 seconds of runtime
Function calls and their runtime within get_settings
- read_settings 29,3s (30,87%)
- get_downstream_dependencies 14,6s (15,34%)
- safe_load 9,86s (10,38%)

Changing to the C-implementation of safe_load and refactoring get_downstream_dependencies the new results are:

get_settings became 56,5 seconds of runtime.
- read_settings 28,7s (41,01%)
- get_downstream_dependencies 0,0234s (0,03%)
- yaml_safe_load 1,39s (1,98%)

A small change but I thought it was smart to use the C-implementation of safe_load either way as it seems to be free performance and the get_downstream_dependencies function had a simple refactor that removed an unnecessary sql query.

_Edit_
I was doing more testing and saw that the redis cache was not hitting as much as I thought it should. Found some flaws with the _decorator_key function in NMSRedisLRU and refactored it with help from an LLM. I again tested a synthetic scenario of 10000 devices and the test took about 1 minute before to generate all settings and with this additional fix it dropped down to 12 seconds.

I also tested in a real-world scenario with 225 devices.
A dry-run over all devices took 3 minutes and 30 seconds with the current master branch.
With this branch with all fixes enabled took 3 minutes so about a 16% increase in real-world performance. 
A smaller sample size of 69 devices took 65 seconds down to 51 seconds.
So in total maybe 10-30% performance increase. Hard to say because of all the variation between runs but I thought it was fun to test it this way as well.