### PR TITLE
Add back jinja2 env cache with fix to template_file in nornir_helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "napalm==5.1",
   "netmiko==4.5",
   "nornir==3.5",
-  "nornir-jinja2==0.2",
+  "nornir-jinja2==1.0.0",
   "nornir-napalm==0.5",
   "nornir-netmiko==1.0.1",
   "nornir-utils==0.2",

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -105,7 +105,6 @@ def push_base_management(task, device_variables: dict, devtype: DeviceType, job_
         name="Generate initial device config",
         template=template,
         jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
-        path=f"{local_repo_path}/{task.host.platform}",
         **device_variables,
     )
 
@@ -1057,7 +1056,6 @@ def set_hostname_task(task, new_hostname: str):
         name="Generate hostname config",
         template="hostname.j2",
         jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
-        path=f"{local_repo_path}/{task.host.platform}",
         **template_vars,
     )
     task.host["config"] = r.result

--- a/src/cnaas_nms/devicehandler/interface_state.py
+++ b/src/cnaas_nms/devicehandler/interface_state.py
@@ -61,7 +61,6 @@ def bounce_task(task, interfaces: List[str]):
         name="Generate port bounce down config",
         template="bounce-down.j2",
         jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
-        path=f"{local_repo_path}/{task.host.platform}",
         **template_vars,
     )
     task.host["config"] = r.result
@@ -76,7 +75,6 @@ def bounce_task(task, interfaces: List[str]):
         name="Generate port bounce up config",
         template="bounce-up.j2",
         jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
-        path=f"{local_repo_path}/{task.host.platform}",
         **template_vars,
     )
     task.host["config"] = r.result

--- a/src/cnaas_nms/devicehandler/nornir_helper.py
+++ b/src/cnaas_nms/devicehandler/nornir_helper.py
@@ -37,7 +37,6 @@ def get_jinja_env(path):
         lstrip_blocks=True,
         keep_trailing_newline=True,
         loader=FileSystemLoader(path),
-        cache_size=0,
     )
     jinja_env.globals.update(jinja_functions.FUNCTIONS)
     jinja_env.filters.update(jinja_filters.FILTERS)

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -603,7 +603,6 @@ def push_sync_device(
         name="Generate device config",
         template=template,
         jinja_env=get_jinja_env(f"{local_repo_path}/{task.host.platform}"),
-        path=f"{local_repo_path}/{task.host.platform}",
         **template_vars,
     )
 


### PR DESCRIPTION
In my quest in optimizing stuff I found that the jinja env cache had been disabled.

I found the culprit and a simple fix for the original issue with overridden loaders.
More info about the original issue here: https://github.com/SUNET/cnaas-nms/commit/f781b815fdec9157a6f9e6849f6e8d9552a8b1b0

While waiting for the upstream fix I thought we can use a patch.

The performance increase is very noticable.
Real life scenario with 225 switches dry_run dropped from 3 minutes and 30 seconds to about 1 minute and 30 seconds.

So this fix together with pr: #536 there is alot of performance available essentially for free.

I also did the same smaller sample size testing with 69 devices and from 65 seconds with both this and my other pr enabled the job took 16 seconds.