### PR TITLE
Add hostname collision check in DeviceInitApi.arg_check

### DIFF
--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -706,6 +706,7 @@ class DeviceInitCheckApi(Resource):
 
                     if replace_dev.get_mlag_peer(session):
                         return empty_result(status="error", data="Replacing a MLAG switch is not supported"), 400
+
             try:
                 dev: Device = cnaas_nms.devicehandler.init_device.pre_init_checks(session, device_id)
                 linknets_all = dev.get_linknets_as_dict(session)

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -527,9 +527,20 @@ class DeviceInitApi(Resource):
         # Set default delay for init_jobs
         init_delay_seconds = 1
 
-        # If device init is already in progress, reschedule a new step2 (connectivity check)
-        # instead of trying to restart initialization
         with sqla_session() as session:  # type: ignore
+            # Check for duplicate hostname only when not replacing device
+            if not job_kwargs.get("replace_hostname") and (
+                used_dev := session.query(Device)
+                .filter(Device.hostname == job_kwargs.get("new_hostname", ""))
+                .one_or_none()
+            ):
+                return empty_result(
+                    status="error",
+                    data=f"Hostname {job_kwargs['new_hostname']} is already used for device with id: {used_dev.id}",
+                ), 400
+
+            # If device init is already in progress, reschedule a new step2 (connectivity check)
+            # instead of trying to restart initialization
             dev: Optional[Device] = session.query(Device).filter(Device.id == device_id).one_or_none()
             if (
                 dev
@@ -645,17 +656,6 @@ class DeviceInitApi(Resource):
 
         if "replace_hostname" in json_data and json_data["replace_hostname"] is not None:
             parsed_args["replace_hostname"] = json_data["replace_hostname"]
-        else:
-            # Check for hostname collision only when not replacing device
-            with sqla_session() as session:  # type: ignore
-                used_dev: Optional[Device] = (
-                    session.query(Device).filter(Device.hostname == parsed_args["new_hostname"]).one_or_none()
-                )
-
-                if used_dev:
-                    raise ValueError(
-                        f"Hostname {parsed_args['new_hostname']} is already used for device with id: {used_dev.id}"
-                    )
 
         return parsed_args
 
@@ -683,6 +683,17 @@ class DeviceInitCheckApi(Resource):
             return empty_result(status="error", data="Error parsing arguments: {}".format(e)), 400
 
         with sqla_session() as session:  # type: ignore
+            # Check for duplicate hostname only when not replacing device
+            if not parsed_args.get("replace_hostname") and (
+                used_dev := session.query(Device)
+                .filter(Device.hostname == parsed_args.get("new_hostname", ""))
+                .one_or_none()
+            ):
+                return empty_result(
+                    status="error",
+                    data=f"Hostname {parsed_args['new_hostname']} is already used for device with id: {used_dev.id}",
+                ), 400
+
             # Check for replace device mlag/stack
             if parsed_args.get("replace_hostname", False):
                 replace_dev: Optional[Device] = (

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -638,13 +638,24 @@ class DeviceInitApi(Resource):
                 parsed_args["neighbors"] = json_data["neighbors"]
             else:
                 raise ValueError(
-                    "Neighbors must be specified as either a list of hostnames,an empty list, or not specified at all"
+                    "Neighbors must be specified as either a list of hostnames, an empty list, or not specified at all"
                 )
         else:
             parsed_args["neighbors"] = None
 
         if "replace_hostname" in json_data and json_data["replace_hostname"] is not None:
             parsed_args["replace_hostname"] = json_data["replace_hostname"]
+        else:
+            # Check for hostname collision only when not replacing device
+            with sqla_session() as session:  # type: ignore
+                used_dev: Optional[Device] = (
+                    session.query(Device).filter(Device.hostname == parsed_args["new_hostname"]).one_or_none()
+                )
+
+                if used_dev:
+                    raise ValueError(
+                        f"Hostname {parsed_args['new_hostname']} is already used for device with id: {used_dev.id}"
+                    )
 
         return parsed_args
 

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -515,7 +515,7 @@ class DeviceTests(unittest.TestCase):
             device = Device(
                 hostname="mac-000000000000",
                 platform="eos",
-                dhcp_ip=IPv4Address("10.0.1.22"),
+                dhcp_ip=IPv4Address("10.0.1.22"),  # noqa: S1313
                 state=DeviceState.DISCOVERED,
                 device_type=DeviceType.UNKNOWN,
             )

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -47,6 +47,7 @@ class DeviceTests(unittest.TestCase):
                 "access-old-name",
                 "access-new-name",
                 "discovered_device",
+                "mac-000000000000",
             ]:
                 device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
                 if device:
@@ -504,6 +505,35 @@ class DeviceTests(unittest.TestCase):
         json_data = json.loads(result.data.decode())
         #        self.assertEqual(json_data['data']['compatible'], False)
         self.assertEqual(json_data["status"], "error")
+
+    def test_init_access_hostname_collision(self):
+        """
+        Test that the api returns an error when trying to
+        init a device with the same hostname as another switch
+        """
+        with sqla_session() as session:  # type: ignore
+            device = Device(
+                hostname="mac-000000000000",
+                platform="eos",
+                dhcp_ip=IPv4Address("10.0.1.22"),
+                state=DeviceState.DISCOVERED,
+                device_type=DeviceType.UNKNOWN,
+            )
+            session.add(device)
+            session.commit()
+            session.refresh(device)
+            device_id = device.id
+
+        # Check for both device_initcheck and device_init that the error shows up.
+        for endpoint in ["device_initcheck", "device_init"]:
+            device_data = {"hostname": "eosaccess", "device_type": "ACCESS"}
+            result = self.client.post(f"/api/v1.0/{endpoint}/{device_id}", json=device_data)
+
+            json_data = result.json
+            self.assertIsNotNone(json_data)
+
+            self.assertEqual(result.status_code, 400)
+            self.assertIn("Hostname eosaccess is already used for device with id:", result.json.get("message"))
 
     def test_get_stackmembers_invalid_device(self):
         result = self.client.get(f"/api/v1.0/device/{'nonexisting'}/stackmember")


### PR DESCRIPTION
Fixes: #417.

Adds an additional check that the hostname is not actually used by another switch.