### PR TITLE
Fix orphaned uplink interfaces during device replacement

### DIFF
--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -672,6 +672,19 @@ class DeviceInitCheckApi(Resource):
             return empty_result(status="error", data="Error parsing arguments: {}".format(e)), 400
 
         with sqla_session() as session:  # type: ignore
+            # Check for replace device mlag
+            if parsed_args["replace_hostname"]:
+                replace_dev: Optional[Device] = (
+                    session.query(Device).filter(Device.hostname == parsed_args.get("new_hostname")).one_or_none()
+                )
+
+                if replace_dev:
+                    if replace_dev.stack_members:
+                        return empty_result(status="error", data="Replacing a stacked switch is not supported"), 400
+
+                    if replace_dev.get_mlag_peer(session):
+                        return empty_result(status="error", data="Replacing a MLAG switch is not supported"), 400
+
             try:
                 dev: Device = cnaas_nms.devicehandler.init_device.pre_init_checks(session, device_id)
                 linknets_all = dev.get_linknets_as_dict(session)

--- a/src/cnaas_nms/api/device.py
+++ b/src/cnaas_nms/api/device.py
@@ -672,10 +672,10 @@ class DeviceInitCheckApi(Resource):
             return empty_result(status="error", data="Error parsing arguments: {}".format(e)), 400
 
         with sqla_session() as session:  # type: ignore
-            # Check for replace device mlag
-            if parsed_args["replace_hostname"]:
+            # Check for replace device mlag/stack
+            if parsed_args.get("replace_hostname", False):
                 replace_dev: Optional[Device] = (
-                    session.query(Device).filter(Device.hostname == parsed_args.get("new_hostname")).one_or_none()
+                    session.query(Device).filter(Device.hostname == parsed_args["new_hostname"]).one_or_none()
                 )
 
                 if replace_dev:
@@ -684,7 +684,6 @@ class DeviceInitCheckApi(Resource):
 
                     if replace_dev.get_mlag_peer(session):
                         return empty_result(status="error", data="Replacing a MLAG switch is not supported"), 400
-
             try:
                 dev: Device = cnaas_nms.devicehandler.init_device.pre_init_checks(session, device_id)
                 linknets_all = dev.get_linknets_as_dict(session)

--- a/src/cnaas_nms/devicehandler/get.py
+++ b/src/cnaas_nms/devicehandler/get.py
@@ -196,7 +196,7 @@ def get_uplinks(
     return uplinks
 
 
-def get_local_ifnames(local_devid: int, peer_devid: int, linknets: List[dict]) -> List[str]:
+def get_local_ifnames(local_devid: int, peer_devid: int, linknets: Optional[List[dict]] = None) -> List[str]:
     ifnames: List[str] = []
     if not linknets:
         return ifnames
@@ -208,7 +208,9 @@ def get_local_ifnames(local_devid: int, peer_devid: int, linknets: List[dict]) -
     return ifnames
 
 
-def get_mlag_ifs(session, dev: Device, mlag_peer_hostname: str, linknets: List[dict] = []) -> Dict[str, int]:
+def get_mlag_ifs(
+    session, dev: Device, mlag_peer_hostname: str, linknets: Optional[List[dict]] = None
+) -> Dict[str, int]:
     """Returns dict with mapping of interface -> neighbor id
     Return id instead of hostname since mlag peer will change hostname during init"""
     logger = get_logger()

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -448,6 +448,7 @@ def init_access_device_step1(
         Nornir result object
 
     Raises:
+        DeviceError
         DeviceStateException
         ValueError
         sqlalchemy.exc.IntegrityError
@@ -476,11 +477,11 @@ def init_access_device_step1(
                 raise DeviceStateError(f"Device {new_hostname} not in UNMANAGED state")
 
             if replace_dev.stack_members:
-                raise Exception("Replacing a stacked switch is not supported")
+                raise DeviceError("Replacing a stacked switch is not supported")
 
             # When changing platform check if the replace device is in a MLAG or not
             if dev.platform != replace_dev.platform and replace_dev.get_mlag_peer(session):
-                raise Exception("Replacing a MLAG switch with a different platform is not supported")
+                raise DeviceError("Replacing a MLAG switch with a different platform is not supported")
 
         linknets_all = dev.get_linknets_as_dict(session)
         mlag_peer_dev: Optional[Device] = None

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -476,12 +476,13 @@ def init_access_device_step1(
             if replace_dev.state != DeviceState.UNMANAGED:
                 raise DeviceStateError(f"Device {new_hostname} not in UNMANAGED state")
 
+            # Not supported replacing a stacked switch
             if replace_dev.stack_members:
                 raise DeviceError("Replacing a stacked switch is not supported")
 
-            # When changing platform check if the replace device is in a MLAG or not
-            if dev.platform != replace_dev.platform and replace_dev.get_mlag_peer(session):
-                raise DeviceError("Replacing a MLAG switch with a different platform is not supported")
+            # Not supported replacing a MLAG switch
+            if replace_dev.get_mlag_peer(session):
+                raise DeviceError("Replacing a MLAG switch is not supported")
 
         linknets_all = dev.get_linknets_as_dict(session)
         mlag_peer_dev: Optional[Device] = None

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -439,7 +439,8 @@ def init_access_device_step1(
         mlag_peer_id: Device ID of MLAG peer device (optional)
         mlag_peer_new_hostname: Hostname to configure on peer device (optional)
         uplink_hostnames_arg: List of hostnames of uplink peer devices (optional)
-                              Used when initializing MLAG peer device
+                              Used when initializing MLAG peer device'
+        replace_hostname: Hostname of the switch that will be replaced
         job_id: job_id provided by scheduler when adding job
         scheduled_by: Username from JWT.
 
@@ -473,6 +474,13 @@ def init_access_device_step1(
                 raise DeviceStateError(f"Device {new_hostname} not found")
             if replace_dev.state != DeviceState.UNMANAGED:
                 raise DeviceStateError(f"Device {new_hostname} not in UNMANAGED state")
+
+            if replace_dev.stack_members:
+                raise Exception("Replacing a stacked switch is not supported")
+
+            # When changing platform check if the replace device is in a MLAG or not
+            if dev.platform != replace_dev.platform and replace_dev.get_mlag_peer(session):
+                raise Exception("Replacing a MLAG switch with a different platform is not supported")
 
         linknets_all = dev.get_linknets_as_dict(session)
         mlag_peer_dev: Optional[Device] = None
@@ -597,7 +605,9 @@ def init_access_device_step1(
                     linknet["device_a_id"] = dev.id
                 if linknet["device_b_id"] == ztp_device_id:
                     linknet["device_b_id"] = dev.id
-            update_interfacedb_worker(session, dev, replace=True, delete_all=False, linknets=linknets)
+            update_interfacedb_worker(
+                session, dev, replace=True, delete_all=False, linknets=linknets, replacing_device=True
+            )
 
         try:
             update_linknets(

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -440,7 +440,7 @@ def init_access_device_step1(
         mlag_peer_new_hostname: Hostname to configure on peer device (optional)
         uplink_hostnames_arg: List of hostnames of uplink peer devices (optional)
                               Used when initializing MLAG peer device
-        replace_hostname: Hostname of the switch that will be replaced
+        replace_hostname: Boolean when true will replace the provided hostname
         job_id: job_id provided by scheduler when adding job
         scheduled_by: Username from JWT.
 

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -439,7 +439,7 @@ def init_access_device_step1(
         mlag_peer_id: Device ID of MLAG peer device (optional)
         mlag_peer_new_hostname: Hostname to configure on peer device (optional)
         uplink_hostnames_arg: List of hostnames of uplink peer devices (optional)
-                              Used when initializing MLAG peer device'
+                              Used when initializing MLAG peer device
         replace_hostname: Hostname of the switch that will be replaced
         job_id: job_id provided by scheduler when adding job
         scheduled_by: Username from JWT.

--- a/src/cnaas_nms/devicehandler/init_device.py
+++ b/src/cnaas_nms/devicehandler/init_device.py
@@ -569,6 +569,7 @@ def init_access_device_step1(
             new_serial = dev.serial
             new_model = dev.model
             new_dhcp_ip = dev.dhcp_ip
+            new_platform = dev.platform
             ztp_hostname = dev.hostname
             ztp_device_id = dev.id
             logger.info(
@@ -587,6 +588,7 @@ def init_access_device_step1(
             dev.model = new_model
             dev.hostname = ztp_hostname
             dev.dhcp_ip = new_dhcp_ip
+            dev.platform = new_platform
             dev.state = DeviceState.DISCOVERED
             mgmt_ip = dev.management_ip
             secondary_mgmt_ip = dev.secondary_management_ip

--- a/src/cnaas_nms/devicehandler/tests/data/testdata.yml
+++ b/src/cnaas_nms/devicehandler/tests/data/testdata.yml
@@ -60,22 +60,22 @@ mlag_dev_a: mlagpeer1
 mlag_dev_b: mlagpeer2
 mlag_dev_nonpeer: nonpeer
 linknets_mlag_peers:
-- description: null
-  device_a_ip: null
-  device_a_port: Ethernet25
-  device_b_ip: null
-  device_b_port: Ethernet51
-  ipv4_network: null
-  redundant_link: true
-  site_id: null
-- description: null
-  device_a_ip: null
-  device_a_port: Ethernet26
-  device_b_ip: null
-  device_b_port: Ethernet52
-  ipv4_network: null
-  redundant_link: true
-  site_id: null
+  - description: null
+    device_a_ip: null
+    device_a_port: Ethernet25
+    device_b_ip: null
+    device_b_port: Ethernet51
+    ipv4_network: null
+    redundant_link: true
+    site_id: null
+  - description: null
+    device_a_ip: null
+    device_a_port: Ethernet26
+    device_b_ip: null
+    device_b_port: Ethernet52
+    ipv4_network: null
+    redundant_link: true
+    site_id: null
 linknets_mlag_nonpeers:
   - description: null
     device_a_ip: null
@@ -89,3 +89,4 @@ syncto_device_hostnames:
   - "eosdist1"
 syncto_settings_override:
   cli_append_str: "interface Management1\ndescription test"
+jwt_auth_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1NzEwNTk2MTgsIm5iZiI6MTU3MTA1OTYxOCwianRpIjoiNTQ2MDk2YTUtZTNmOS00NzFlLWE2NTctZWFlYTZkNzA4NmVhIiwic3ViIjoiYWRtaW4iLCJmcmVzaCI6ZmFsc2UsInR5cGUiOiJhY2Nlc3MifQ.Sfffg9oZg_Kmoq7Oe8IoTcbuagpP6nuUXOQzqJpgDfqDq_GM_4zGzt7XxByD4G0q8g4gZGHQnV14TpDer2hJXw"

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -256,7 +256,6 @@ class InitDeviceTests(unittest.TestCase):
                 state=DeviceState.UNMANAGED,  # UNMANAGED
                 device_type=DeviceType.ACCESS,
             )
-
             mlag_a2 = Device(
                 hostname="mlag_a2",
                 platform="eos",
@@ -367,7 +366,6 @@ class InitDeviceTests(unittest.TestCase):
                 state=DeviceState.MANAGED,
                 device_type=DeviceType.ACCESS,
             )
-
             dev = Device(
                 hostname="replaced_switch_with_orphaned_uplink",
                 platform="eos",

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -319,7 +319,7 @@ class InitDeviceTests(unittest.TestCase):
         self.assertEqual(response.json.get("message"), "Replacing a MLAG switch is not supported")
 
         with self.assertRaises(DeviceError) as context:
-            init_func(device_id=mlag_replacement_id, new_hostname="mlag-a1", replace_hostname="mlag-a1")
+            init_func(device_id=mlag_replacement_id, new_hostname="mlag-a1", replace_hostname=True)
 
         self.assertEqual("Replacing a MLAG switch is not supported", str(context.exception))
 

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -12,7 +12,7 @@ from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 
 import cnaas_nms.devicehandler.init_device
-from cnaas_nms.db.device import Device, DeviceState, DeviceType
+from cnaas_nms.db.device import Device, DeviceError, DeviceState, DeviceType
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.db.job import Job
 from cnaas_nms.db.linknet import Linknet
@@ -238,7 +238,7 @@ class InitDeviceTests(unittest.TestCase):
         self,
         mock_pre_init,
     ):
-        """Test that when trying to replacing a mlag switch with another platform it raises an exception"""
+        """Test that when trying to replacing a mlag switch with another platform it raises an DeviceError"""
 
         def mocked_pre_init(session, device_id: int) -> Device:
             dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()
@@ -297,7 +297,7 @@ class InitDeviceTests(unittest.TestCase):
 
             session.commit()
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(DeviceError) as context:
             init_func(device_id=mlag_replacement_id, new_hostname="mlag_a1", replace_hostname="mlag_a1")
 
         self.assertEqual("Replacing a MLAG switch with a different platform is not supported", str(context.exception))
@@ -344,7 +344,7 @@ class InitDeviceTests(unittest.TestCase):
             session.add(Stackmember(device_id=stack_a1.id, hardware_id="00:11:22:33:44:55", member_no=1, priority=10))
             session.commit()
 
-        with self.assertRaises(Exception) as context:
+        with self.assertRaises(DeviceError) as context:
             init_func(device_id=stack_replacement_id, new_hostname="stack_a1", replace_hostname="stack_a1")
 
         self.assertEqual("Replacing a stacked switch is not supported", str(context.exception))

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -238,7 +238,7 @@ class InitDeviceTests(unittest.TestCase):
         self,
         mock_pre_init,
     ):
-        """Test that when trying to replacing a mlag switch with another platform it raises an exception"""
+        """Test that when trying to replace a mlag switch with another platform it raises an exception"""
 
         def mocked_pre_init(session, device_id: int) -> Device:
             dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()
@@ -307,7 +307,7 @@ class InitDeviceTests(unittest.TestCase):
         self,
         mock_pre_init,
     ):
-        """Test that when trying to replacing a stacked switch it raises an exception"""
+        """Test that when trying to replace a stacked switch it raises an exception"""
 
         def mocked_pre_init(session, device_id: int) -> Device:
             dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -12,6 +12,8 @@ from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 
 import cnaas_nms.devicehandler.init_device
+from cnaas_nms.api import app
+from cnaas_nms.api.tests.app_wrapper import TestAppWrapper
 from cnaas_nms.db.device import Device, DeviceError, DeviceState, DeviceType
 from cnaas_nms.db.interface import Interface, InterfaceConfigType
 from cnaas_nms.db.job import Job
@@ -105,16 +107,16 @@ class InitDeviceTests(unittest.TestCase):
     def cleandb(self):
         with sqla_session() as session:  # type: ignore
             for hostname in [
-                "uplink_a1",
-                "discovered_a1",
-                "discovered_a2",
-                "mlag_a1",
-                "mlag_a2",
-                "mlag_replacement",
-                "stack_a1",
-                "stack_replacement",
-                "uplink_a2",
-                "replaced_switch_with_orphaned_uplink",
+                "uplink-a1",
+                "discovered-a1",
+                "discovered-a2",
+                "mlag-a1",
+                "mlag-a2",
+                "mlag-replacement",
+                "stack-a1",
+                "stack-replacement",
+                "uplink-a2",
+                "replaced-switch-with-orphaned-uplink",
             ]:
                 device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
                 if device:
@@ -133,6 +135,16 @@ class InitDeviceTests(unittest.TestCase):
 
     def setUp(self):
         self.cleandb()
+
+        self.jwt_auth_token = None
+        data_dir = Path(__file__).parent / "data"
+        with open(os.path.join(data_dir, "testdata.yml"), "r") as f_testdata:
+            self.testdata = yaml_safe_load(f_testdata)
+            if "jwt_auth_token" in self.testdata:
+                self.jwt_auth_token = self.testdata["jwt_auth_token"]
+        self.app = app.app
+        self.app.wsgi_app = TestAppWrapper(self.app.wsgi_app, self.jwt_auth_token)
+        self.client = self.app.test_client()
 
     def tearDown(self):
         self.cleandb()
@@ -171,7 +183,7 @@ class InitDeviceTests(unittest.TestCase):
 
         mock_update_interfacedb_worker.return_value = None
 
-        mock_pre_init_check_neighbors.return_value = ["uplink_a1"]
+        mock_pre_init_check_neighbors.return_value = ["uplink-a1"]
 
         mock_check_neighbor_sync.return_value = MagicMock()
 
@@ -181,7 +193,7 @@ class InitDeviceTests(unittest.TestCase):
         with sqla_session() as session:  # type: ignore
             uplink_dev = Device(
                 management_ip="10.0.6.100",  # noqa: S1313
-                hostname="uplink_a1",
+                hostname="uplink-a1",
                 platform="eos",
                 state=DeviceState.MANAGED,
                 device_type=DeviceType.ACCESS,
@@ -190,7 +202,7 @@ class InitDeviceTests(unittest.TestCase):
             # Add 2 Discovered Device
             dev1 = Device(
                 management_ip=None,
-                hostname="discovered_a1",
+                hostname="discovered-a1",
                 platform="eos",
                 state=DeviceState.DISCOVERED,
                 device_type=DeviceType.UNKNOWN,
@@ -198,7 +210,7 @@ class InitDeviceTests(unittest.TestCase):
 
             dev2 = Device(
                 management_ip=None,
-                hostname="discovered_a2",
+                hostname="discovered-a2",
                 platform="eos",
                 state=DeviceState.DISCOVERED,
                 device_type=DeviceType.UNKNOWN,
@@ -234,11 +246,11 @@ class InitDeviceTests(unittest.TestCase):
             self.assertIn("psycopg2.errors.UniqueViolation", str(context.exception))
 
     @patch("cnaas_nms.devicehandler.init_device.pre_init_checks")
-    def test_init_access_mlag_wrong_platform(
+    def test_init_access_mlag_error(
         self,
         mock_pre_init,
     ):
-        """Test that when trying to replace a mlag switch with another platform it raises an exception"""
+        """Test that when trying to replace a mlag switch it raises an exception"""
 
         def mocked_pre_init(session, device_id: int) -> Device:
             dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()
@@ -251,20 +263,20 @@ class InitDeviceTests(unittest.TestCase):
         # Prepare test data.
         with sqla_session() as session:  # type: ignore
             mlag_a1 = Device(
-                hostname="mlag_a1",
+                hostname="mlag-a1",
                 platform="eos",
                 state=DeviceState.UNMANAGED,  # UNMANAGED
                 device_type=DeviceType.ACCESS,
             )
             mlag_a2 = Device(
-                hostname="mlag_a2",
+                hostname="mlag-a2",
                 platform="eos",
                 state=DeviceState.MANAGED,
                 device_type=DeviceType.ACCESS,
             )
             mlag_replacement = Device(
-                hostname="mlag_replacement",
-                platform="ios",  # wrong platform
+                hostname="mlag-replacement",
+                platform="eos",
                 state=DeviceState.DISCOVERED,
                 device_type=DeviceType.UNKNOWN,
             )
@@ -297,10 +309,19 @@ class InitDeviceTests(unittest.TestCase):
 
             session.commit()
 
-        with self.assertRaises(DeviceError) as context:
-            init_func(device_id=mlag_replacement_id, new_hostname="mlag_a1", replace_hostname="mlag_a1")
+        # Test initcheck api
+        response = self.client.post(
+            f"/api/v1.0/device_initcheck/{mlag_replacement_id}",
+            json={"hostname": "mlag-a1", "device_type": "ACCESS", "replace_hostname": True},
+        )
+        self.assertEqual(response.status_code, 400)
 
-        self.assertEqual("Replacing a MLAG switch with a different platform is not supported", str(context.exception))
+        self.assertEqual(response.json.get("message"), "Replacing a MLAG switch is not supported")
+
+        with self.assertRaises(DeviceError) as context:
+            init_func(device_id=mlag_replacement_id, new_hostname="mlag-a1", replace_hostname="mlag-a1")
+
+        self.assertEqual("Replacing a MLAG switch is not supported", str(context.exception))
 
     @patch("cnaas_nms.devicehandler.init_device.pre_init_checks")
     def test_init_access_stack_error(
@@ -320,14 +341,14 @@ class InitDeviceTests(unittest.TestCase):
         # Prepare test data.
         with sqla_session() as session:  # type: ignore
             stack_a1 = Device(
-                hostname="stack_a1",
+                hostname="stack-a1",
                 platform="ios",
                 state=DeviceState.UNMANAGED,  # UNMANAGED
                 device_type=DeviceType.ACCESS,
             )
             stack_replacement = Device(
                 management_ip=None,
-                hostname="stack_replacement",
+                hostname="stack-replacement",
                 platform="ios",
                 state=DeviceState.DISCOVERED,
                 device_type=DeviceType.UNKNOWN,
@@ -344,8 +365,17 @@ class InitDeviceTests(unittest.TestCase):
             session.add(Stackmember(device_id=stack_a1.id, hardware_id="00:11:22:33:44:55", member_no=1, priority=10))
             session.commit()
 
+        # Test initcheck api
+        response = self.client.post(
+            f"/api/v1.0/device_initcheck/{stack_replacement_id}",
+            json={"hostname": "stack-a1", "device_type": "ACCESS", "replace_hostname": True},
+        )
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.json.get("message"), "Replacing a stacked switch is not supported")
+
         with self.assertRaises(DeviceError) as context:
-            init_func(device_id=stack_replacement_id, new_hostname="stack_a1", replace_hostname="stack_a1")
+            init_func(device_id=stack_replacement_id, new_hostname="stack-a1", replace_hostname="stack-a1")
 
         self.assertEqual("Replacing a stacked switch is not supported", str(context.exception))
 
@@ -361,13 +391,13 @@ class InitDeviceTests(unittest.TestCase):
         # Prepare test data.
         with sqla_session() as session:  # type: ignore
             uplink_dev = Device(
-                hostname="uplink_a2",
+                hostname="uplink-a2",
                 platform="eos",
                 state=DeviceState.MANAGED,
                 device_type=DeviceType.ACCESS,
             )
             dev = Device(
-                hostname="replaced_switch_with_orphaned_uplink",
+                hostname="replaced-switch-with-orphaned-uplink",
                 platform="eos",
                 state=DeviceState.MANAGED,
                 device_type=DeviceType.ACCESS,

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -18,7 +18,8 @@ from cnaas_nms.db.job import Job
 from cnaas_nms.db.linknet import Linknet
 from cnaas_nms.db.reservedip import ReservedIP
 from cnaas_nms.db.session import sqla_session
-from cnaas_nms.devicehandler.update import reset_interfacedb
+from cnaas_nms.db.stackmember import Stackmember
+from cnaas_nms.devicehandler.update import reset_interfacedb, update_interfacedb_worker
 from cnaas_nms.scheduler.scheduler import Scheduler
 from cnaas_nms.tools.yaml import yaml_safe_load
 
@@ -107,6 +108,13 @@ class InitDeviceTests(unittest.TestCase):
                 "uplink_a1",
                 "discovered_a1",
                 "discovered_a2",
+                "mlag_a1",
+                "mlag_a2",
+                "mlag_replacement",
+                "stack_a1",
+                "stack_replacement",
+                "uplink_a2",
+                "replaced_switch_with_orphaned_uplink",
             ]:
                 device = session.query(Device).filter(Device.hostname == hostname).one_or_none()
                 if device:
@@ -114,6 +122,7 @@ class InitDeviceTests(unittest.TestCase):
                         or_(Linknet.device_a_id == device.id, Linknet.device_b_id == device.id)
                     ).delete()
                     session.query(Interface).filter(Interface.device_id == device.id).delete()
+                    session.query(Stackmember).filter(Stackmember.device_id == device.id).delete()
                     session.delete(device)
 
             res_ip = session.query(ReservedIP).filter(ReservedIP.ip == "10.0.6.101").one_or_none()  # noqa: S1313
@@ -223,6 +232,191 @@ class InitDeviceTests(unittest.TestCase):
                 init_func(device_id=dev2.id, new_hostname="managed_a1")
 
             self.assertIn("psycopg2.errors.UniqueViolation", str(context.exception))
+
+    @patch("cnaas_nms.devicehandler.init_device.pre_init_checks")
+    def test_init_access_mlag_wrong_platform(
+        self,
+        mock_pre_init,
+    ):
+        """Test that when trying to replacing a mlag switch with another platform it raises an exception"""
+
+        def mocked_pre_init(session, device_id: int) -> Device:
+            dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()
+            return dev
+
+        mock_pre_init.side_effect = mocked_pre_init
+
+        init_func = cnaas_nms.devicehandler.init_device.init_access_device_step1.__wrapped__
+
+        # Prepare test data.
+        with sqla_session() as session:  # type: ignore
+            mlag_a1 = Device(
+                hostname="mlag_a1",
+                platform="eos",
+                state=DeviceState.UNMANAGED,  # UNMANAGED
+                device_type=DeviceType.ACCESS,
+            )
+
+            mlag_a2 = Device(
+                hostname="mlag_a2",
+                platform="eos",
+                state=DeviceState.MANAGED,
+                device_type=DeviceType.ACCESS,
+            )
+            mlag_replacement = Device(
+                hostname="mlag_replacement",
+                platform="ios",  # wrong platform
+                state=DeviceState.DISCOVERED,
+                device_type=DeviceType.UNKNOWN,
+            )
+            session.add(mlag_a1)
+            session.add(mlag_a2)
+            session.add(mlag_replacement)
+            session.commit()
+            session.refresh(mlag_a1)
+            session.refresh(mlag_a2)
+            session.refresh(mlag_replacement)
+
+            mlag_replacement_id = mlag_replacement.id
+
+            # Add MLAG ports
+            # Interfaces
+            interface_a1 = Interface(device_id=mlag_a1.id, name="Ethernet1", configtype=InterfaceConfigType.MLAG_PEER)
+            interface_a2 = Interface(device_id=mlag_a2.id, name="Ethernet1", configtype=InterfaceConfigType.MLAG_PEER)
+            session.add(interface_a1)
+            session.add(interface_a2)
+
+            # Linknet
+            session.add(
+                Linknet(
+                    device_a=mlag_a1,
+                    device_a_port=interface_a1.name,
+                    device_b=mlag_a2,
+                    device_b_port=interface_a2.name,
+                )
+            )
+
+            session.commit()
+
+        with self.assertRaises(Exception) as context:
+            init_func(device_id=mlag_replacement_id, new_hostname="mlag_a1", replace_hostname="mlag_a1")
+
+        self.assertEqual("Replacing a MLAG switch with a different platform is not supported", str(context.exception))
+
+    @patch("cnaas_nms.devicehandler.init_device.pre_init_checks")
+    def test_init_access_stack_error(
+        self,
+        mock_pre_init,
+    ):
+        """Test that when trying to replacing a stacked switch it raises an exception"""
+
+        def mocked_pre_init(session, device_id: int) -> Device:
+            dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()
+            return dev
+
+        mock_pre_init.side_effect = mocked_pre_init
+
+        init_func = cnaas_nms.devicehandler.init_device.init_access_device_step1.__wrapped__
+
+        # Prepare test data.
+        with sqla_session() as session:  # type: ignore
+            stack_a1 = Device(
+                hostname="stack_a1",
+                platform="ios",
+                state=DeviceState.UNMANAGED,  # UNMANAGED
+                device_type=DeviceType.ACCESS,
+            )
+            stack_replacement = Device(
+                management_ip=None,
+                hostname="stack_replacement",
+                platform="ios",
+                state=DeviceState.DISCOVERED,
+                device_type=DeviceType.UNKNOWN,
+            )
+            session.add(stack_a1)
+            session.add(stack_replacement)
+            session.commit()
+            session.refresh(stack_a1)
+            session.refresh(stack_replacement)
+
+            stack_replacement_id = stack_replacement.id
+
+            # Add stack member
+            session.add(Stackmember(device_id=stack_a1.id, hardware_id="00:11:22:33:44:55", member_no=1, priority=10))
+            session.commit()
+
+        with self.assertRaises(Exception) as context:
+            init_func(device_id=stack_replacement_id, new_hostname="stack_a1", replace_hostname="stack_a1")
+
+        self.assertEqual("Replacing a stacked switch is not supported", str(context.exception))
+
+    @patch("cnaas_nms.devicehandler.update.get_interfaces_names")
+    def test_init_access_uplink_removed(self, mock_get_interfaces_names):
+        """
+        Test that when replacing a switch with another switch with other uplink ports the original uplink ports are removed
+        """
+
+        # Override nornir get_interfaces
+        mock_get_interfaces_names.return_value = ["Ethernet25"]
+
+        # Prepare test data.
+        with sqla_session() as session:  # type: ignore
+            uplink_dev = Device(
+                hostname="uplink_a2",
+                platform="eos",
+                state=DeviceState.MANAGED,
+                device_type=DeviceType.ACCESS,
+            )
+
+            dev = Device(
+                hostname="replaced_switch_with_orphaned_uplink",
+                platform="eos",
+                state=DeviceState.MANAGED,
+                device_type=DeviceType.ACCESS,
+            )
+
+            session.add(uplink_dev)
+            session.add(dev)
+            session.commit()
+            session.refresh(uplink_dev)
+            session.refresh(dev)
+
+            # Add Downlink ports to uplink_dev
+            downlink_interface = Interface(
+                device_id=uplink_dev.id, name="Ethernet1", configtype=InterfaceConfigType.ACCESS_DOWNLINK
+            )
+            session.add(downlink_interface)
+
+            # Add orphaned uplink port
+            # Interfaces
+            interface = Interface(
+                device_id=dev.id,
+                name="TenGigabitEthernet1/1/1",  # Orphaned port
+                configtype=InterfaceConfigType.ACCESS_UPLINK,
+            )
+            session.add(interface)
+            session.commit()
+
+            # New uplink port will be part of this linknets
+            linknets = [
+                {
+                    "device_a_id": dev.id,
+                    "device_a_port": "Ethernet25",
+                    "device_b_id": uplink_dev.id,
+                    "device_b_port": "Ethernet1",
+                }
+            ]
+
+            update_interfacedb_worker(
+                session, dev, replace=True, delete_all=False, linknets=linknets, replacing_device=True
+            )
+
+            interfaces = list(session.query(Interface).filter(Interface.device_id == dev.id))
+
+            self.assertEqual(1, len(interfaces))
+
+            self.assertEqual("Ethernet25", interfaces[0].name)
+            self.assertEqual(InterfaceConfigType.ACCESS_UPLINK, interfaces[0].configtype)
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -375,7 +375,7 @@ class InitDeviceTests(unittest.TestCase):
         self.assertEqual(response.json.get("message"), "Replacing a stacked switch is not supported")
 
         with self.assertRaises(DeviceError) as context:
-            init_func(device_id=stack_replacement_id, new_hostname="stack-a1", replace_hostname="stack-a1")
+            init_func(device_id=stack_replacement_id, new_hostname="stack-a1", replace_hostname=True)
 
         self.assertEqual("Replacing a stacked switch is not supported", str(context.exception))
 

--- a/src/cnaas_nms/devicehandler/tests/test_init.py
+++ b/src/cnaas_nms/devicehandler/tests/test_init.py
@@ -238,7 +238,7 @@ class InitDeviceTests(unittest.TestCase):
         self,
         mock_pre_init,
     ):
-        """Test that when trying to replacing a mlag switch with another platform it raises an DeviceError"""
+        """Test that when trying to replacing a mlag switch with another platform it raises an exception"""
 
         def mocked_pre_init(session, device_id: int) -> Device:
             dev: Device = session.query(Device).filter(Device.id == device_id).one_or_none()

--- a/src/cnaas_nms/devicehandler/update.py
+++ b/src/cnaas_nms/devicehandler/update.py
@@ -33,7 +33,7 @@ def update_interfacedb_worker(
     replace: bool,
     delete_all: bool,
     mlag_peer_hostname: Optional[str] = None,
-    linknets: List[dict] = [],
+    linknets: Optional[List[dict]] = None,
     replacing_device: bool = False,
 ) -> List[dict]:
     """Perform actual work of updating database for update_interfacedb.

--- a/src/cnaas_nms/devicehandler/update.py
+++ b/src/cnaas_nms/devicehandler/update.py
@@ -34,6 +34,7 @@ def update_interfacedb_worker(
     delete_all: bool,
     mlag_peer_hostname: Optional[str] = None,
     linknets: List[dict] = [],
+    replacing_device: bool = False,
 ) -> List[dict]:
     """Perform actual work of updating database for update_interfacedb.
     If replace is set to true, configtype and data will get overwritten.
@@ -107,7 +108,11 @@ def update_interfacedb_worker(
 
     # Remove interfaces that no longer exist on device
     for unmatched_intf in unmatched_iflist:
-        protected_interfaces = [InterfaceConfigType.ACCESS_UPLINK, InterfaceConfigType.MLAG_PEER]
+        # When replacing a device only preserve MLAG_PEER ports.
+        if replacing_device:
+            protected_interfaces = [InterfaceConfigType.MLAG_PEER]
+        else:
+            protected_interfaces = [InterfaceConfigType.ACCESS_UPLINK, InterfaceConfigType.MLAG_PEER]
         if unmatched_intf.configtype in protected_interfaces:
             logger.warn(
                 "Interface of protected type disappeared from {} ignoring: {}".format(dev.hostname, unmatched_intf.name)

--- a/src/cnaas_nms/devicehandler/update.py
+++ b/src/cnaas_nms/devicehandler/update.py
@@ -108,9 +108,9 @@ def update_interfacedb_worker(
 
     # Remove interfaces that no longer exist on device
     for unmatched_intf in unmatched_iflist:
-        # When replacing a device only preserve MLAG_PEER ports.
+        # When replacing a device do not protect any ports.
         if replacing_device:
-            protected_interfaces = [InterfaceConfigType.MLAG_PEER]
+            protected_interfaces = []
         else:
             protected_interfaces = [InterfaceConfigType.ACCESS_UPLINK, InterfaceConfigType.MLAG_PEER]
         if unmatched_intf.configtype in protected_interfaces:


### PR DESCRIPTION
Fixes: #542 

Also found a bug that the platform was not copied over so you could not replace a device over different platforms.

Also added additional checks for cases in which a user tries to replace a mlag switch with another platform or trying to replace a stacked switch.

_Edit 2026-06-20_
I tried my branch locally and was successfully able to replace a example device I manually placed in the DB.
The orphaned uplink interface and linknet was correctly deleted and new linknets was created.

Left to do is to actually test replacing a mlag switch.

I used this SQL data together with the integration tests clab.

```sql
insert into "public"."device"
    ("device_type", "hostname", "id", "management_ip", "platform", "state")
values
    ('ACCESS', 'eosaccess', 8, '10.0.6.6', 'ios', 'UNMANAGED');

insert into "public"."linknet"
    ("device_a_id", "device_a_port", "device_b_id", "device_b_port")
values
    (1, 'Ethernet2', 8, 'TenGigabitEthernet1/1/1');

insert into "public"."interface"
    ("device_id","name", "configtype")
values
    (8, 'TenGigabitEthernet1/1/1', 'ACCESS_UPLINK'),
    (8, 'GigabitEthernet0', 'ACCESS_AUTO');
```