### PR TITLE
Add a feature to check commits_ahead and commits_behind for api repository

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Clone test data
         run: |
-          git clone --depth 1 --no-single-branch https://github.com/SUNET/cnaas-integrationtest-templates.git .test-data/templates
+          git clone --depth 2 --no-single-branch https://github.com/SUNET/cnaas-integrationtest-templates.git .test-data/templates
           git clone --depth 1 https://github.com/SUNET/cnaas-integrationtest-settings.git .test-data/settings
 
       - name: Start test databases

--- a/src/cnaas_nms/api/repository.py
+++ b/src/cnaas_nms/api/repository.py
@@ -2,7 +2,7 @@ from flask import request
 from flask_restx import Namespace, Resource, fields
 
 from cnaas_nms.api.generic import empty_result
-from cnaas_nms.db.git import RepoType, get_repo_status, refresh_repo
+from cnaas_nms.db.git import RepoType, commits_out_of_sync, get_repo_status, refresh_repo
 from cnaas_nms.db.joblock import JoblockError
 from cnaas_nms.db.settings import SettingsSyntaxError, VerifyPathException
 from cnaas_nms.tools.security import get_identity, login_required
@@ -17,16 +17,50 @@ repository_model = api.model(
     },
 )
 
+repository_return_model = api.model(
+    "RepositoryReturn",
+    {
+        "status": fields.String(enum=["success", "error"], description="Status of the response"),
+        "data": fields.String(description="Commit information"),
+        "commits_ahead": fields.Integer(
+            description="How many commits ahead of origin",
+            required=False,
+            default=None,
+        ),
+        "commits_behind": fields.Integer(
+            description="How many commits behind of origin",
+            required=False,
+            default=None,
+        ),
+    },
+)
+
 
 class RepositoryApi(Resource):
+    @api.doc(
+        params={
+            "repo": {
+                "description": "Repository type",
+                "type": "string",
+                "enum": [r.name.lower() for r in RepoType],
+            }
+        }
+    )
+    @api.marshal_with(repository_return_model)
     @login_required
-    def get(self, repo):
+    def get(self, repo: str):
         """Get repository information"""
         try:
             repo_type = RepoType[str(repo).upper()]
         except Exception:  # noqa: S110
             return empty_result("error", "Invalid repository type"), 400
-        return empty_result("success", get_repo_status(repo_type))
+        result = empty_result("success", get_repo_status(repo_type))
+
+        ahead, behind = commits_out_of_sync(repo_type)
+        result["commits_ahead"] = ahead
+        result["commits_behind"] = behind
+
+        return result
 
     @login_required
     @api.expect(repository_model)

--- a/src/cnaas_nms/api/repository.py
+++ b/src/cnaas_nms/api/repository.py
@@ -62,6 +62,15 @@ class RepositoryApi(Resource):
 
         return result
 
+    @api.doc(
+        params={
+            "repo": {
+                "description": "Repository type",
+                "type": "string",
+                "enum": [r.name.lower() for r in RepoType],
+            }
+        }
+    )
     @login_required
     @api.expect(repository_model)
     def put(self, repo):

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -157,6 +157,9 @@ def test_repository_get(client):
     assert result.json["status"] == "success"
     # Exactly one result
     assert result.json["data"] == "Repository is not yet cloned from remote"
+    # commits_head and commits_behind is None
+    assert result.json["commits_ahead"] is None
+    assert result.json["commits_behind"] is None
 
     # Refresh repo
     data = {"action": "refresh"}
@@ -170,6 +173,9 @@ def test_repository_get(client):
     assert result.json["status"] == "success"
     # Exactly one result
     assert re.match(r"[Cc]ommit", result.json["data"])
+    # commits_ahead and commits_behind is 0
+    assert result.json["commits_ahead"] == 0
+    assert result.json["commits_behind"] == 0
 
 
 def test_settings_hostname(client):

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -70,6 +70,43 @@ def get_repo_status(repo_type: RepoType = RepoType.TEMPLATES) -> str:
         return "Repository is not yet cloned from remote"
 
 
+def commits_out_of_sync(repo_type: RepoType = RepoType.TEMPLATES) -> tuple[Optional[int], Optional[int]]:
+    """
+    Returns a tuple of (ahead commits, behind commits)
+    """
+    if repo_type == RepoType.TEMPLATES:
+        local_repo_path = app_settings.TEMPLATES_LOCAL
+    elif repo_type == RepoType.SETTINGS:
+        local_repo_path = app_settings.SETTINGS_LOCAL
+    else:
+        raise ValueError("Invalid repository")
+
+    try:
+        local_repo = Repo(local_repo_path)
+
+        # Make sure we have up-to-date remote refs
+        local_repo.remote().fetch()
+
+        branch_name = local_repo.active_branch.name
+
+        local_branch = local_repo.heads[branch_name]
+        remote_branch = local_repo.remote().refs[branch_name]
+
+        local_commit = local_branch.commit.hexsha
+        remote_commit = remote_branch.commit.hexsha
+
+        # Commits local has that remote doesn't (ahead)
+        ahead = list(local_repo.iter_commits(f"{remote_commit}..{local_commit}"))
+
+        # Commits remote has that local doesn't (behind)
+        behind = list(local_repo.iter_commits(f"{local_commit}..{remote_commit}"))
+
+        return len(ahead), len(behind)
+
+    except (InvalidGitRepositoryError, NoSuchPathError):  # noqa: S110
+        return None, None
+
+
 def refresh_repo(repo_type: RepoType = RepoType.TEMPLATES, scheduled_by: str = "") -> str:
     """Refresh the repository for repo_type
 

--- a/src/cnaas_nms/db/git.py
+++ b/src/cnaas_nms/db/git.py
@@ -103,7 +103,9 @@ def commits_out_of_sync(repo_type: RepoType = RepoType.TEMPLATES) -> tuple[Optio
 
         return len(ahead), len(behind)
 
-    except (InvalidGitRepositoryError, NoSuchPathError):  # noqa: S110
+    except Exception as e:
+        logger = get_logger()
+        logger.error("Could not fetch out of sync commits, error: {}".format(str(e)))
         return None, None
 
 

--- a/src/cnaas_nms/db/tests/test_git.py
+++ b/src/cnaas_nms/db/tests/test_git.py
@@ -2,11 +2,14 @@ import unittest
 from typing import Set, Tuple
 
 import pytest
+from git import Repo
 
+from cnaas_nms.app_settings import app_settings
 from cnaas_nms.db.device import DeviceType
 from cnaas_nms.db.git import (
     RepoType,
     _is_device_type_update_required,
+    commits_out_of_sync,
     repo_checkout_working,
     repo_save_working_commit,
     template_syncstatus,
@@ -58,6 +61,24 @@ class GitTests(unittest.TestCase):
         repo_save_working_commit(RepoType.TEMPLATES, "bd5e1f70f52037e8e2a451b2968a9ca8160a7cba")
         self.assertTrue(repo_checkout_working(RepoType.SETTINGS, dry_run=True), "Working commit not saved in redis")
         self.assertTrue(repo_checkout_working(RepoType.TEMPLATES, dry_run=True), "Working commit not saved in redis")
+
+    def test_commits_out_of_sync(self):
+        """Test commits_out_of_sync"""
+        # Check if the repo is behind or ahead before test is run
+        pre_ahead, pre_behind = commits_out_of_sync(RepoType.TEMPLATES)
+
+        if not pre_ahead or not pre_behind:
+            pre_ahead = 0
+            pre_behind = 0
+
+        # Force template repo back one commit
+        repo = Repo(app_settings.TEMPLATES_LOCAL)
+        repo.git.reset("--hard", "HEAD~1")
+
+        ahead, behind = commits_out_of_sync(RepoType.TEMPLATES)
+
+        self.assertEqual(ahead, pre_ahead + 0)
+        self.assertEqual(behind, pre_behind + 1)
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/db/tests/test_git.py
+++ b/src/cnaas_nms/db/tests/test_git.py
@@ -1,5 +1,6 @@
 import unittest
 from typing import Set, Tuple
+from unittest.mock import MagicMock, patch
 
 import pytest
 from git import Repo
@@ -64,21 +65,33 @@ class GitTests(unittest.TestCase):
 
     def test_commits_out_of_sync(self):
         """Test commits_out_of_sync"""
-        # Check if the repo is behind or ahead before test is run
-        pre_ahead, pre_behind = commits_out_of_sync(RepoType.TEMPLATES)
-
-        if not pre_ahead or not pre_behind:
-            pre_ahead = 0
-            pre_behind = 0
-
         # Force template repo back one commit
         repo = Repo(app_settings.TEMPLATES_LOCAL)
-        repo.git.reset("--hard", "HEAD~1")
+        # Make sure the repo is up to date
+        repo.remote().pull()
+        repo.git.reset("--hard", "HEAD~1")  # Force back one step
 
         ahead, behind = commits_out_of_sync(RepoType.TEMPLATES)
 
-        self.assertEqual(ahead, pre_ahead + 0)
-        self.assertEqual(behind, pre_behind + 1)
+        self.assertEqual(ahead, 0)
+        self.assertEqual(behind, 1)
+
+    @patch("cnaas_nms.db.git.Repo")
+    def test_commits_out_of_sync_error(self, mock_repo):
+        """Test commits_out_of_sync error"""
+        mock_repo_instance = MagicMock()
+
+        mock_repo_instance.active_branch.name.return_value = "master"
+
+        # Some error happened in this call
+        mock_repo_instance.remote.return_value.refs.__getitem__.side_effect = IndexError("this is a IndexError")
+
+        mock_repo.return_value = mock_repo_instance
+
+        ahead, behind = commits_out_of_sync(RepoType.TEMPLATES)
+
+        self.assertIsNone(ahead)
+        self.assertIsNone(behind)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added more information to /repository endpoint to also display how many commits ahead or behind a repository is to give insight to users if they are actually out of sync.

Updated Swagger endpoint
<img width="1438" height="695" alt="bild" src="https://github.com/user-attachments/assets/aa233a1b-2f69-45bf-a3ec-66dc245c8334" />

Example when one commit behind
```json
{
  "status": "success",
  "data": "Commit e5ae93e4e2c4617c73f3b9e23e789dea7a9e8218 main by Johan Marcusson at 2023-01-23 17:10:57+01:00\n",
  "commits_ahead": 0,
  "commits_behind": 1
}
```