### PR TITLE
Make dhcp_hook independent again

### DIFF
--- a/src/cnaas_nms/tools/dhcp_hook.py
+++ b/src/cnaas_nms/tools/dhcp_hook.py
@@ -21,7 +21,7 @@ logger.setLevel(logging.DEBUG)
 
 def get_apidata(configfile="/etc/cnaas-nms/apiclient.yml"):
     with open(configfile, "r") as apiclient_file:
-        return yaml.safe_load(apiclient_file)
+        return yaml.safe_load(apiclient_file)  # type: ignore[attr-defined]
 
 
 def get_jwt_token():

--- a/src/cnaas_nms/tools/dhcp_hook.py
+++ b/src/cnaas_nms/tools/dhcp_hook.py
@@ -7,8 +7,7 @@ from typing import Optional
 
 import netaddr
 import requests
-
-from cnaas_nms.tools.yaml import yaml_safe_load
+import yaml
 
 logger = logging.getLogger("dhcp-hook")
 if not logger.handlers:
@@ -22,7 +21,7 @@ logger.setLevel(logging.DEBUG)
 
 def get_apidata(configfile="/etc/cnaas-nms/apiclient.yml"):
     with open(configfile, "r") as apiclient_file:
-        return yaml_safe_load(apiclient_file)
+        return yaml.safe_load(apiclient_file)
 
 
 def get_jwt_token():


### PR DESCRIPTION
Fixes this error in the develop branch

```bash
File "/opt/cnaas/venv/cnaas-nms/src/cnaas_nms/tools/dhcp_hook.py", line 11, in <module>
    from cnaas_nms.tools.yaml import yaml_safe_load
ModuleNotFoundError: No module named 'cnaas_nms.tools.yaml'
```