### PR TITLE
Translate vlan names to ids in interface api

### DIFF
--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -165,7 +165,7 @@ class InterfaceApi(Resource):
                                     intfdata["untagged_vlan"] = vlan_id
                                 else:
                                     errors.append(
-                                        "Specified VLAN name/id {} is not present in {}".format(
+                                        "Specified VLAN {} is not present in {}".format(
                                             if_dict["data"]["untagged_vlan"], hostname
                                         )
                                     )
@@ -178,7 +178,7 @@ class InterfaceApi(Resource):
                                     intfdata["tagged_vlan_list"] = vlan_id_list
                                 else:
                                     errors.append(
-                                        "Some VLAN names/ids {} are not present in {}".format(
+                                        "Some VLANs {} are not present in {}".format(
                                             ", ".join(if_dict["data"]["tagged_vlan_list"]), hostname
                                         )
                                     )

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -148,8 +148,9 @@ class InterfaceApi(Resource):
                         if not device_settings:
                             device_settings, _ = get_settings(dev, dev.device_type)
                         if "vxlan" in if_dict["data"]:
-                            if if_dict["data"]["vxlan"] in device_settings["vxlans"]:
-                                intfdata["vxlan"] = if_dict["data"]["vxlan"]
+                            vlan_id = resolve_vlanid(if_dict["data"]["vxlan"], device_settings["vxlans"])
+                            if vlan_id:
+                                intfdata["vxlan"] = vlan_id
                             else:
                                 errors.append(
                                     "Specified VXLAN {} is not present in {}".format(if_dict["data"]["vxlan"], hostname)

--- a/src/cnaas_nms/api/interface.py
+++ b/src/cnaas_nms/api/interface.py
@@ -161,10 +161,10 @@ class InterfaceApi(Resource):
                             else:
                                 vlan_id = resolve_vlanid(if_dict["data"]["untagged_vlan"], device_settings["vxlans"])
                                 if vlan_id:
-                                    intfdata["untagged_vlan"] = if_dict["data"]["untagged_vlan"]
+                                    intfdata["untagged_vlan"] = vlan_id
                                 else:
                                     errors.append(
-                                        "Specified VLAN name {} is not present in {}".format(
+                                        "Specified VLAN name/id {} is not present in {}".format(
                                             if_dict["data"]["untagged_vlan"], hostname
                                         )
                                     )
@@ -174,10 +174,10 @@ class InterfaceApi(Resource):
                                     if_dict["data"]["tagged_vlan_list"], device_settings["vxlans"]
                                 )
                                 if len(vlan_id_list) == len(if_dict["data"]["tagged_vlan_list"]):
-                                    intfdata["tagged_vlan_list"] = if_dict["data"]["tagged_vlan_list"]
+                                    intfdata["tagged_vlan_list"] = vlan_id_list
                                 else:
                                     errors.append(
-                                        "Some VLAN names {} are not present in {}".format(
+                                        "Some VLAN names/ids {} are not present in {}".format(
                                             ", ".join(if_dict["data"]["tagged_vlan_list"]), hostname
                                         )
                                     )

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -233,6 +233,27 @@ def test_update_interface_configtype(client, testdata):
     assert ifname in result.json["data"]["updated"]
 
 
+def test_update_interface_data_vxlan(client, testdata):
+    # Test vxlan
+    ifname = testdata["interface_update"]
+    data = {"interfaces": {ifname: {"data": {"vxlan": testdata["untagged_vlan"]}}}}
+    result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
+    assert result.status_code == 200
+    assert result.json["status"] == "success"
+
+    # Test vxlan as an id instead of a name
+    data["interfaces"][ifname]["data"]["vxlan"] = 500
+    result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
+    assert result.status_code == 200
+    assert result.json["status"] == "success"
+
+    # Test invalid
+    data["interfaces"][ifname]["data"]["vxlan"] = "thisshouldnetexist"
+    result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
+    assert result.status_code == 400
+    assert result.json["status"] == "error"
+
+
 def test_update_interface_data_untagged(client, testdata):
     # Test untagged_vlan
     ifname = testdata["interface_update"]

--- a/src/cnaas_nms/api/tests/test_api.py
+++ b/src/cnaas_nms/api/tests/test_api.py
@@ -240,6 +240,13 @@ def test_update_interface_data_untagged(client, testdata):
     result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
     assert result.status_code == 200
     assert result.json["status"] == "success"
+
+    # Test untagged_vlan as an id instead of a name
+    data["interfaces"][ifname]["data"]["untagged_vlan"] = 500
+    result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
+    assert result.status_code == 200
+    assert result.json["status"] == "success"
+
     #        self.assertEqual(ifname in result.json['data']['updated'], True)
     # Test invalid
     data["interfaces"][ifname]["data"]["untagged_vlan"] = "thisshouldnetexist"
@@ -255,6 +262,13 @@ def test_update_interface_data_tagged(client, testdata):
     result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
     assert result.status_code == 200
     assert result.json["status"] == "success"
+
+    # Test tagged_vlan_list as a list of ids instead of names
+    data["interfaces"][ifname]["data"]["tagged_vlan_list"] = [500]
+    result = client.put("/api/v1.0/device/{}/interfaces".format(testdata["interface_device"]), json=data)
+    assert result.status_code == 200
+    assert result.json["status"] == "success"
+
     #        self.assertEqual(ifname in result.json['data']['updated'], True)
     # Test invalid
     data["interfaces"][ifname]["data"]["tagged_vlan_list"] = ["thisshouldnetexist"]

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -534,7 +534,8 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], u
     for hostname, settings in devices_dict.items():
         if "vxlans" not in settings:
             continue
-        for vxlan_name, vxlan_data in settings["vxlans"].items():
+        vxlans = settings["vxlans"]
+        for vxlan_name, vxlan_data in vxlans.items():
             # VXLAN VNI checks
             if "vni" not in vxlan_data or not isinstance(vxlan_data["vni"], int):
                 logger.error("VXLAN {} is missing vni".format(vxlan_name))
@@ -583,6 +584,14 @@ def check_vlan_collisions(devices_dict: Dict[str, dict], mgmt_vlans: Set[int], u
             if "vlan_name" not in vxlan_data or not isinstance(vxlan_data["vlan_name"], str):
                 logger.error("VXLAN {} is missing vlan_name".format(vxlan_name))
                 continue
+
+            # Vxlan name cannot be the same as another vxlan key.
+            other_vxlan_keys = set(vxlans.keys()) - {vxlan_name}
+            if vxlan_data.get("vlan_name") in other_vxlan_keys:
+                raise VlanConflictError(
+                    f"Vxlan '{vxlan_name}' name '{vxlan_data['vlan_name']}' cannot be the same as another vxlan key."
+                )
+
             if (
                 hostname in device_vlan_names
                 and vxlan_data["vlan_name"] in device_vlan_names[hostname]

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -256,6 +256,28 @@ class SettingsTests(unittest.TestCase):
         }
         self.assertIsNone(check_vlan_collisions(devices_dict, mgmt_vlans))
 
+    def test_vxlan_name_key_collision(self):
+        """Test that vxlan name cannot be the same as another vxlan key"""
+        settings = {
+            "vxlans": {
+                "vxlan1": {
+                    "vni": 100100,
+                    "vlan_id": 100,
+                    "vlan_name": "vxlan1",  # Ok to have the same name as the key within the same vxlan
+                },
+                "vxlan2": {
+                    "vni": 100200,
+                    "vlan_id": 200,
+                    "vlan_name": "vxlan1",  # Exact name as another vxlan key
+                },
+            }
+        }
+        # Validate
+        f_root(**settings)  # type: ignore
+
+        with self.assertRaises(VlanConflictError):
+            check_vlan_collisions({"eosaccess": settings}, mgmt_vlans=set())
+
     def test_routing_policy(self):
         test_device_name = "policytest"
         test_vrfs = [

--- a/src/cnaas_nms/devicehandler/sync_devices.py
+++ b/src/cnaas_nms/devicehandler/sync_devices.py
@@ -72,7 +72,7 @@ def resolve_vlanid(vlan_name: str, vxlans: dict) -> Optional[int]:
         return None
     for vxlan_name, vxlan_data in vxlans.items():
         try:
-            if vxlan_data["vlan_name"] == vlan_name:
+            if vxlan_data["vlan_name"] == vlan_name or vxlan_name == vlan_name:
                 return int(vxlan_data["vlan_id"])
         except (KeyError, ValueError) as e:
             logger.error("Could not resolve VLAN ID for VLAN name {}: {}".format(vlan_name, str(e)))


### PR DESCRIPTION
Fixes: #549 

All other parts of the code can already handle both name and id from the api.
I think it makes sense to only save the id and never the name.

Have to double-check that the frontend also accepts ids instead of names but I think it does.

To update all devices a small script could be written that iterates over all devices, gets all interfaces and posts the exact same data again, the interface export api would work perfectly for that.
That way the API will translate the vlan names to ids and save them.