### PR TITLE
Allow device filtering with in operator.

### DIFF
--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -146,8 +146,12 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
             # otherwise we just check the single value
             if isinstance(filter_value, list):
                 check_value = filter_value
+                # Make sure we match on UPPER strings for ENUM
+                filter_value = [v.upper() for v in filter_value]
             else:
                 check_value = [filter_value]
+                # Make sure we match on UPPER strings for ENUM
+                filter_value = filter_value.upper()
 
             # Check that all values are valid enum names
             for val in check_value:

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -154,7 +154,7 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
             value = "%" + value + "%"
         elif operator == "in":
             f_class_op = getattr(f_class_field, "in_")
-            value = value.split(",")
+            value = value.split(",")  # type: ignore[assignment]
         else:
             f_class_op = getattr(f_class_field, "__eq__")
 

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -135,8 +135,13 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
         if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.Enum):
             value = value.upper()
             allowed_names = set(item.name for item in f_class.__table__._columns[attribute].type.enum_class)
-            if value not in allowed_names:
-                raise ValueError("{} is not a valid value for {}".format(value, attribute))
+
+            # If the operator is "in", we need to check each value in the comma-separated list
+            # If it does not contain ","" it will be a single value, so we can just check that as well
+            for val in value.split(","):
+                if val not in allowed_names:
+                    raise ValueError("{} is not a valid value for {}".format(val, attribute))
+
         f_class_field = getattr(f_class, attribute)
         if operator == "contains":
             if allowed_names:
@@ -147,6 +152,9 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
                 raise ValueError("Cannot use 'contains' operator for datetime types")
             f_class_op = getattr(f_class_field, "ilike")
             value = "%" + value + "%"
+        elif operator == "in":
+            f_class_op = getattr(f_class_field, "in_")
+            value = value.split(",")
         else:
             f_class_op = getattr(f_class_field, "__eq__")
 

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -163,6 +163,7 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
             if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.DateTime):
                 raise ValueError("Cannot use 'contains' operator for datetime types")
             f_class_op = getattr(f_class_field, "ilike")
+            assert isinstance(filter_value, str)
             filter_value = "%" + filter_value + "%"
         elif operator == "in":
             f_class_op = getattr(f_class_field, "in_")

--- a/src/cnaas_nms/api/generic.py
+++ b/src/cnaas_nms/api/generic.py
@@ -128,18 +128,30 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
         if operator:
             operator = operator.lstrip("[").rstrip("]")
 
+        # Handle list of values for "in" operator, removes empty values
+        filter_value: str | list[str]
+        if operator == "in":
+            filter_value = [v.strip() for v in value.strip().split(",") if v.strip()]
+        else:
+            filter_value = value.strip()
+
         if attribute not in f_class.__table__._columns.keys():
             raise ValueError("{} is not a valid attribute to filter on".format(attribute))
         # Special handling from Enum type, check valid enum names
         allowed_names = None
         if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.Enum):
-            value = value.upper()
             allowed_names = set(item.name for item in f_class.__table__._columns[attribute].type.enum_class)
 
-            # If the operator is "in", we need to check each value in the comma-separated list
-            # If it does not contain ","" it will be a single value, so we can just check that as well
-            for val in value.split(","):
-                if val not in allowed_names:
+            # If the filter value is a list, we need to check all values in the list
+            # otherwise we just check the single value
+            if isinstance(filter_value, list):
+                check_value = filter_value
+            else:
+                check_value = [filter_value]
+
+            # Check that all values are valid enum names
+            for val in check_value:
+                if val.upper() not in allowed_names:
                     raise ValueError("{} is not a valid value for {}".format(val, attribute))
 
         f_class_field = getattr(f_class, attribute)
@@ -151,14 +163,13 @@ def build_filter(f_class, query: sqlalchemy.orm.query.Query):
             if isinstance(f_class.__table__._columns[attribute].type, sqlalchemy.DateTime):
                 raise ValueError("Cannot use 'contains' operator for datetime types")
             f_class_op = getattr(f_class_field, "ilike")
-            value = "%" + value + "%"
+            filter_value = "%" + filter_value + "%"
         elif operator == "in":
             f_class_op = getattr(f_class_field, "in_")
-            value = value.split(",")  # type: ignore[assignment]
         else:
             f_class_op = getattr(f_class_field, "__eq__")
 
-        query = query.filter(f_class_op(value))
+        query = query.filter(f_class_op(filter_value))
 
     if f_class_order_by_field and order:
         query = query.order_by(order(f_class_order_by_field))

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -173,6 +173,12 @@ class DeviceTests(unittest.TestCase):
         json_data = json.loads(result.data.decode())
         self.assertTrue(self.hostname in [device["hostname"] for device in json_data["data"]["devices"]])
 
+    def test_get_devices_with_filter(self):
+        result = self.client.get("/api/v1.0/devices", query_string={"filter[device_type][in]": "DIST,CORE"})
+        self.assertEqual(result.status_code, 200)
+        json_data = result.json
+        self.assertEqual(len(json_data["data"]["devices"]), 3)
+
     def test_modify_device(self):
         modify_data = {"description": "changed_description"}
         result = self.client.put(f"/api/v1.0/device/{self.device_id}", json=modify_data)

--- a/src/cnaas_nms/api/tests/test_device.py
+++ b/src/cnaas_nms/api/tests/test_device.py
@@ -174,7 +174,7 @@ class DeviceTests(unittest.TestCase):
         self.assertTrue(self.hostname in [device["hostname"] for device in json_data["data"]["devices"]])
 
     def test_get_devices_with_filter(self):
-        result = self.client.get("/api/v1.0/devices", query_string={"filter[device_type][in]": "DIST,CORE"})
+        result = self.client.get("/api/v1.0/devices", query_string={"filter[device_type][in]": "dist,core"})
         self.assertEqual(result.status_code, 200)
         json_data = result.json
         self.assertEqual(len(json_data["data"]["devices"]), 3)


### PR DESCRIPTION
Allows /devices api endpoint to accept a list to filter with.
Usage: `?filter[hostname][in]=eosdist1,eosdist2` will return those two devices.