### PR TITLE
Updates to access list generation

### DIFF
--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -12,6 +12,7 @@ New features:
  - Fencing token added to syncto jobs to make sure no unintended changes are commited in a live run (#535)
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
+ - Added skip_terms_with_empty_network_definitions to access_lists that will filter out terms with empty network definitions if set to true (#571)
 
 Changes:
 

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -12,7 +12,7 @@ New features:
  - Fencing token added to syncto jobs to make sure no unintended changes are commited in a live run (#535)
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
- - Added skip_terms_with_empty_network_definitions to access_lists that will filter out terms with empty network definitions if set to true (#571)
+ - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
 
 Changes:
 

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -172,6 +172,8 @@ access_lists.yml
     Use a site like: `<https://play.jmespath.org/>`_ to test your jmespath string.
     The result of the jmespath search must be a list of addresses or networks, otherwise an error will be raised during access list generation.
 
+    Two helper functions exist that can normalize null values to empty lists or objects. Use them with :code:`arr` or :code:`obj`.
+
     Here are some example jmespath strings:
 
     All IPv4 and IPv6 addresses from VXLANs in the STUDENT VRF:
@@ -205,13 +207,13 @@ access_lists.yml
     :code:`interfaces[?vrf == 'MGMT'].[ipv4_address, ipv6_address][]`
 
     All BGP IPv4 and IPv6 neighbors in the STUDENT VRF:
-    :code:`extroute_bgp.vrfs[?name=='STUDENT'].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
+    :code:`arr(extroute_bgp.vrfs)[?name=='STUDENT'].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
 
     All BGP IPv4 neighbors:
-    :code:`extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4`
+    :code:`arr(extroute_bgp.vrfs)[].neighbor_v4[].peer_ipv4`
 
     All BGP IPv4 and IPv6 neighbors
-    :code:`extroute_bgp.vrfs[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
+    :code:`arr(extroute_bgp.vrfs)[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]`
 
 - service_definitions: Dictionary of {<name>, [entries]}:
 
@@ -229,7 +231,7 @@ access_lists.yml
 
 
 * access_lists: Dictionary of {<name>, access_lists}:
-
+  * skip_terms_with_empty_network_definitions: If enabled, remove an entire ACL term when any referenced network definition is empty.
   * comment: A comment that describes the access list.
   * inet_families: List of ipv4, ipv6 of which inet families the access list should be generated to, defaults to ipv4 only.
   * header_map: A dictionary of {<platform>, <header>} allowing for customization of the aerleon header.
@@ -276,8 +278,8 @@ Access list examples
       - address: 192.168.0.0/16
     "BGP_PEERS":
       # This will contain all BGP neighbors for a device.
-      - path: extroute_bgp.vrfs[].neighbor_v4[].peer_ipv4
-      - path: extroute_bgp.vrfs[].neighbor_v6[].peer_ipv6
+      - path: arr(extroute_bgp.vrfs)[].neighbor_v4[].peer_ipv4
+      - path: arr(extroute_bgp.vrfs)[].neighbor_v6[].peer_ipv6
     "STUDENT_GWS":
       # This will only have host ips of the actual gateway.
       - path: vxlans.* | [?vrf=='STUDENT'].[ipv4_gw, ipv4_secondaries, ipv6_gw][][]

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -257,6 +257,8 @@ access_lists.yml
 .. note::
    NMS will substitute napalm platforms to aerleon platforms so for example ios and eos can be used in access list syntax and will be automatically translated to the correct aerleon platform.
 
+   Devices will generate ACLs found in system_access_lists and ACLs fetched dynamically from interfaces and for dist-switches vxlans.
+
 Access list examples
 ^^^^^^^^^^^^^^^^^^^^
 .. code-block:: yaml

--- a/docs/reporef/index.rst
+++ b/docs/reporef/index.rst
@@ -230,8 +230,9 @@ access_lists.yml
   * name: Name of another service object to include in this service definition
 
 
-* access_lists: Dictionary of {<name>, access_lists}:
-  * skip_terms_with_empty_network_definitions: If enabled, remove an entire ACL term when any referenced network definition is empty.
+- access_lists: Dictionary of {<name>, access_lists}:
+
+  * skip_empty_network_definitions: If enabled, removes empty network definitions from acl terms and renders the access-list without them. If no network definitions remain, the term will be removed entirely.
   * comment: A comment that describes the access list.
   * inet_families: List of ipv4, ipv6 of which inet families the access list should be generated to, defaults to ipv4 only.
   * header_map: A dictionary of {<platform>, <header>} allowing for customization of the aerleon header.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "absl-py==2.3.1",
-  "aerleon==1.16.0",
+  "aerleon==1.17.0",
   "alembic==1.15.2",
   "apscheduler==3.11",
   "async-timeout>=4.0.2",

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1229,6 +1229,8 @@ def get_generated_access_lists(
             - If the platform cannot be determined.
             - If Aerleon encounters an error during generation.
     """
+    logger = get_logger()
+
     # Prefer platform argument, otherwise get from device.
     if platform is None:
         if dev is not None:
@@ -1284,11 +1286,48 @@ def get_generated_access_lists(
         )
 
         inside_policies = []
-        acl_terms = _get_aerleon_translated_terms(access_list.terms, device_model)
+
+        # Check if source/destination is empty and remove them with a debug log
+        # As aerleon does not like terms with empty network definitions.
+        filtered_acl_terms = []
+        for acl_term in _get_aerleon_translated_terms(access_list.terms, device_model):
+            # Include terms should always be included
+            if acl_term.get("include"):
+                filtered_acl_terms.append(acl_term)
+                continue
+            # When skip_terms_with_empty_network_definitions is False
+            # Add all terms to filtered_acl_terms, even if they have empty network definitions.
+            if not access_list.skip_terms_with_empty_network_definitions:
+                filtered_acl_terms.append(acl_term)
+                continue
+
+            # Check if terms have empty network definitions and skip them with a debug log
+            for field in ["source", "source-address", "destination", "destination-address"]:
+                if networks := acl_term.get(field):
+                    net_count = 0
+                    if not isinstance(networks, list):
+                        networks = [networks]
+                    for network in networks:
+                        try:
+                            net_count += len(defs._GetNet(network))
+                        except naming.UndefinedAddressError:
+                            # Do nothing for this error, as aerleon will handle it later
+                            pass
+                    if net_count == 0:
+                        logger.debug(
+                            "Access list '{}' term '{}' has empty network definition for '{}': removing this term as skip_terms_with_empty_network_definitions is True".format(
+                                access_list_name, acl_term.get("name"), field
+                            )
+                        )
+                        break
+            else:
+                # If all above checks pass, add the term to filtered_acl_terms
+                filtered_acl_terms.append(acl_term)
+
 
         # Add all access_lists to includes
         # Only needs to be done once as terms are inet-agnostic
-        included_list: PolicyFilterTermsOnly = {"terms": acl_terms}
+        included_list: PolicyFilterTermsOnly = {"terms": filtered_acl_terms}
         includes.update({access_list_name: included_list})
 
         for inet_family in access_list.inet_families:
@@ -1298,7 +1337,7 @@ def get_generated_access_lists(
             )
             inside_policy_dict: PolicyFilter = {
                 "header": {"targets": {aerleon_platform: acl_header}, "comment": access_list.comment},
-                "terms": acl_terms,
+                "terms": filtered_acl_terms,
             }
             inside_policies.append(inside_policy_dict)
 

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1072,7 +1072,9 @@ def _resolve_jmespath_networks(network: dict, settings: dict, network_name: str)
     addresses = jmespath.search(network["path"], settings)
 
     if not isinstance(addresses, list):
-        raise AccessListGenerationError(f"Expected a list from jmespath search, got {type(addresses).__name__}.")
+        raise AccessListGenerationError(
+            f"Expected a list from jmespath search, got {type(addresses).__name__} in network definition {network_name}."
+        )
 
     resolved_networks = []
     for address in addresses:
@@ -1323,7 +1325,6 @@ def get_generated_access_lists(
             else:
                 # If all above checks pass, add the term to filtered_acl_terms
                 filtered_acl_terms.append(acl_term)
-
 
         # Add all access_lists to includes
         # Only needs to be done once as terms are inet-agnostic

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -16,6 +16,7 @@ from aerleon.api import Generate
 from aerleon.lib import naming
 from aerleon.lib.policy_builder import PolicyDict, PolicyFilter, PolicyFilterTermsOnly, TermsList
 from aerleon.lib.yaml import PolicyTypeError
+from jmespath import functions
 from netutils.lib_mapper import AERLEON_LIB_MAPPER, AERLEON_LIB_MAPPER_REVERSE, NAPALM_LIB_MAPPER
 from pydantic import BaseModel, ValidationError
 from redis import StrictRedis
@@ -1067,9 +1068,22 @@ def get_group_settings_asdict() -> Dict[str, Dict[str, Any]]:
     return group_dict
 
 
+class JMESPathFunctions(functions.Functions):
+    """Normalize functions for JMESPath to force data to object or array types."""
+
+    @functions.signature({"types": ["object", "array", "string", "number", "boolean", "null"]})
+    def _func_obj(self, x):
+        return x if isinstance(x, dict) else {}
+
+    @functions.signature({"types": ["object", "array", "string", "number", "boolean", "null"]})
+    def _func_arr(self, x):
+        return x if isinstance(x, list) else []
+
+
 def _resolve_jmespath_networks(network: dict, settings: dict, network_name: str) -> list[dict]:
     """Resolves and validates a JMESPath network reference into a list of address dictionaries."""
-    addresses = jmespath.search(network["path"], settings)
+    options = jmespath.Options(custom_functions=JMESPathFunctions())
+    addresses = jmespath.search(network["path"], settings, options=options)
 
     if not isinstance(addresses, list):
         raise AccessListGenerationError(
@@ -1313,8 +1327,9 @@ def get_generated_access_lists(
                         try:
                             net_count += len(defs._GetNet(network))
                         except naming.UndefinedAddressError:
-                            # Do nothing for this error, as aerleon will handle it later
-                            pass
+                            raise AccessListGenerationError(
+                                f"Undefined network '{network}' in access list '{access_list_name}' term '{acl_term.get('name')}'"
+                            )
                     if net_count == 0:
                         logger.debug(
                             "Access list '{}' term '{}' has empty network definition for '{}': removing this term as skip_terms_with_empty_network_definitions is True".format(

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1311,34 +1311,48 @@ def get_generated_access_lists(
             if acl_term.get("include"):
                 filtered_acl_terms.append(acl_term)
                 continue
-            # When skip_terms_with_empty_network_definitions is False
-            # Add all terms to filtered_acl_terms, even if they have empty network definitions.
-            if not access_list.skip_terms_with_empty_network_definitions:
+
+            # When skip_empty_network_definitions is False skip
+            if not access_list.skip_empty_network_definitions:
                 filtered_acl_terms.append(acl_term)
                 continue
 
-            # Check if terms have empty network definitions and skip them with a debug log
+            # Check if terms have empty network definitions and remove the empty networks with a debug log
             for field in ["source", "source-address", "destination", "destination-address"]:
+                field_nets = []
                 if networks := acl_term.get(field):
-                    net_count = 0
                     if not isinstance(networks, list):
                         networks = [networks]
                     for network in networks:
                         try:
-                            net_count += len(defs._GetNet(network))
+                            if not defs._GetNet(network):
+                                logger.debug(
+                                    "Access list '{}' term '{}' has empty network definition for '{}': removing this network as skip_empty_network_definitions is True".format(
+                                        access_list_name, acl_term.get("name"), field
+                                    )
+                                )
+                                continue
+                            field_nets.append(network)
                         except naming.UndefinedAddressError:
                             raise AccessListGenerationError(
                                 f"Undefined network '{network}' in access list '{access_list_name}' term '{acl_term.get('name')}'"
                             )
-                    if net_count == 0:
-                        logger.debug(
-                            "Access list '{}' term '{}' has empty network definition for '{}': removing this term as skip_terms_with_empty_network_definitions is True".format(
-                                access_list_name, acl_term.get("name"), field
-                            )
+                # Must check networks as if it is empty the term references ANY
+                if networks and field_nets:
+                    # Override the acl_term with the filtered networks
+                    acl_term[field] = field_nets  # type: ignore[literal-required]
+                elif networks and not field_nets:
+                    logger.debug(
+                        "Access list '{}' term '{}' has no network definitions for '{}': removing entire term skip_empty_network_definitions is True".format(
+                            access_list_name, acl_term.get("name"), field
                         )
-                        break
+                    )
+                    break
+                else:
+                    # Do nothing if the field is not defined
+                    pass
             else:
-                # If all above checks pass, add the term to filtered_acl_terms
+                # When all networks are either empty or valid, keep the term
                 filtered_acl_terms.append(acl_term)
 
         # Add all access_lists to includes

--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -14,7 +14,12 @@ from absl import logging as absl_logging
 from aerleon.aclgen import Error as ACLGenError
 from aerleon.api import Generate
 from aerleon.lib import naming
-from aerleon.lib.policy_builder import PolicyDict, PolicyFilter, PolicyFilterTermsOnly, TermsList
+from aerleon.lib.policy_builder import (
+    PolicyDict,
+    PolicyFilter,
+    PolicyFilterTermsOnly,
+    TermsList,
+)
 from aerleon.lib.yaml import PolicyTypeError
 from jmespath import functions
 from netutils.lib_mapper import AERLEON_LIB_MAPPER, AERLEON_LIB_MAPPER_REVERSE, NAPALM_LIB_MAPPER
@@ -1216,6 +1221,81 @@ def _get_all_access_lists(data: List[Dict[str, str]]) -> Iterator[str]:
                 yield acl
 
 
+def _process_access_list_terms(
+    access_list: f_access_list, access_list_name: str, defs: naming.Naming, device_model: str | None = None
+) -> TermsList:
+    """
+    Processes an access list terms
+    Translates the terms to the aerleon format.
+    And removes empty network definitions if skip_empty_network_definitions is True.
+
+    Args:
+        access_list: The access list object.
+        access_list_name: The name of the access list.
+        defs: The naming definitions.
+        device_model: The device model, if applicable.
+
+    Returns:
+        A list of filtered access list terms.
+    """
+    logger = get_logger()
+
+    acl_terms = _get_aerleon_translated_terms(access_list.terms, device_model)
+
+    # When skip_empty_network_definitions is False skip
+    if not access_list.skip_empty_network_definitions:
+        return acl_terms
+
+    # Check if source/destination is empty and remove them with a debug log
+    # As aerleon does not like terms with empty network definitions.
+    filtered_acl_terms = []
+    for acl_term in acl_terms:
+        # Include terms should always be included
+        if acl_term.get("include"):
+            filtered_acl_terms.append(acl_term)
+            continue
+
+        # Check if terms have empty network definitions and remove the empty networks with a debug log
+        for field in ["source", "source-address", "destination", "destination-address"]:
+            field_nets = []
+            if networks := acl_term.get(field):
+                if not isinstance(networks, list):
+                    networks = [networks]
+                for network in networks:
+                    try:
+                        if not defs._GetNet(network):
+                            logger.debug(
+                                "Access list '{}' term '{}' has empty network definition for '{}': removing this network as skip_empty_network_definitions is True".format(
+                                    access_list_name, acl_term.get("name"), field
+                                )
+                            )
+                            continue
+                        field_nets.append(network)
+                    except naming.UndefinedAddressError:
+                        raise AccessListGenerationError(
+                            f"Undefined network '{network}' in access list '{access_list_name}' term '{acl_term.get('name')}'"
+                        )
+            # Must check networks as if it is empty the term references ANY
+            if networks and field_nets:
+                # Override the acl_term with the filtered networks
+                acl_term[field] = field_nets  # type: ignore[literal-required]
+            elif networks and not field_nets:
+                logger.debug(
+                    "Access list '{}' term '{}' has no network definitions for '{}': removing entire term skip_empty_network_definitions is True".format(
+                        access_list_name, acl_term.get("name"), field
+                    )
+                )
+                break
+            else:
+                # Do nothing if the field is not defined
+                pass
+        else:
+            # When all networks are either empty or valid, keep the term
+            filtered_acl_terms.append(acl_term)
+
+    return filtered_acl_terms
+
+
 def get_generated_access_lists(
     dev: Optional[Device] = None, platform: Optional[str] = None, settings: Optional[dict] = None
 ) -> Dict[str, str]:
@@ -1303,61 +1383,12 @@ def get_generated_access_lists(
 
         inside_policies = []
 
-        # Check if source/destination is empty and remove them with a debug log
-        # As aerleon does not like terms with empty network definitions.
-        filtered_acl_terms = []
-        for acl_term in _get_aerleon_translated_terms(access_list.terms, device_model):
-            # Include terms should always be included
-            if acl_term.get("include"):
-                filtered_acl_terms.append(acl_term)
-                continue
-
-            # When skip_empty_network_definitions is False skip
-            if not access_list.skip_empty_network_definitions:
-                filtered_acl_terms.append(acl_term)
-                continue
-
-            # Check if terms have empty network definitions and remove the empty networks with a debug log
-            for field in ["source", "source-address", "destination", "destination-address"]:
-                field_nets = []
-                if networks := acl_term.get(field):
-                    if not isinstance(networks, list):
-                        networks = [networks]
-                    for network in networks:
-                        try:
-                            if not defs._GetNet(network):
-                                logger.debug(
-                                    "Access list '{}' term '{}' has empty network definition for '{}': removing this network as skip_empty_network_definitions is True".format(
-                                        access_list_name, acl_term.get("name"), field
-                                    )
-                                )
-                                continue
-                            field_nets.append(network)
-                        except naming.UndefinedAddressError:
-                            raise AccessListGenerationError(
-                                f"Undefined network '{network}' in access list '{access_list_name}' term '{acl_term.get('name')}'"
-                            )
-                # Must check networks as if it is empty the term references ANY
-                if networks and field_nets:
-                    # Override the acl_term with the filtered networks
-                    acl_term[field] = field_nets  # type: ignore[literal-required]
-                elif networks and not field_nets:
-                    logger.debug(
-                        "Access list '{}' term '{}' has no network definitions for '{}': removing entire term skip_empty_network_definitions is True".format(
-                            access_list_name, acl_term.get("name"), field
-                        )
-                    )
-                    break
-                else:
-                    # Do nothing if the field is not defined
-                    pass
-            else:
-                # When all networks are either empty or valid, keep the term
-                filtered_acl_terms.append(acl_term)
+        # Process acl terms
+        acl_terms = _process_access_list_terms(access_list, access_list_name, defs, device_model)
 
         # Add all access_lists to includes
         # Only needs to be done once as terms are inet-agnostic
-        included_list: PolicyFilterTermsOnly = {"terms": filtered_acl_terms}
+        included_list: PolicyFilterTermsOnly = {"terms": acl_terms}
         includes.update({access_list_name: included_list})
 
         for inet_family in access_list.inet_families:
@@ -1367,7 +1398,7 @@ def get_generated_access_lists(
             )
             inside_policy_dict: PolicyFilter = {
                 "header": {"targets": {aerleon_platform: acl_header}, "comment": access_list.comment},
-                "terms": filtered_acl_terms,
+                "terms": acl_terms,
             }
             inside_policies.append(inside_policy_dict)
 

--- a/src/cnaas_nms/db/settings_fields/access_lists.py
+++ b/src/cnaas_nms/db/settings_fields/access_lists.py
@@ -1,13 +1,13 @@
 import datetime  # noqa: F401
 import re
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Dict, List, Literal, Optional
+from typing import Annotated, Dict, List, Literal, Optional
 
 import jmespath
 from aerleon.lib.policy_builder import TermsList
 from jmespath.exceptions import ParseError
 from netutils.lib_mapper import AERLEON_LIB_MAPPER, NAPALM_LIB_MAPPER
-from pydantic import BaseModel, TypeAdapter, field_validator
+from pydantic import BaseModel, Field, TypeAdapter, field_validator
 
 from cnaas_nms.db.settings_fields.shared import access_list_name
 
@@ -56,6 +56,19 @@ TermsListAdapter.rebuild()
 
 
 class f_access_list(BaseModel):
+    skip_terms_with_empty_network_definitions: Annotated[
+        bool,
+        Field(
+            default=False,
+            description=(
+                "If enabled, remove an entire ACL term when any referenced network "
+                "definition is empty (e.g., source, source-address, destination, "
+                "or destination-address). Use this to avoid downstream rendering/"
+                "compilation failures caused by empty address sets. A debug log "
+                "should be emitted for each removed term."
+            ),
+        ),
+    ]
     comment: str = ""
     inet_families: List[Literal["ipv4", "ipv6"]] = ["ipv4"]
     header_map: Dict[str, str] = {}

--- a/src/cnaas_nms/db/settings_fields/access_lists.py
+++ b/src/cnaas_nms/db/settings_fields/access_lists.py
@@ -56,16 +56,13 @@ TermsListAdapter.rebuild()
 
 
 class f_access_list(BaseModel):
-    skip_terms_with_empty_network_definitions: Annotated[
+    skip_empty_network_definitions: Annotated[
         bool,
         Field(
             default=False,
             description=(
-                "If enabled, remove an entire ACL term when any referenced network "
-                "definition is empty (e.g., source, source-address, destination, "
-                "or destination-address). Use this to avoid downstream rendering/"
-                "compilation failures caused by empty address sets. A debug log "
-                "should be emitted for each removed term."
+                "If enabled, removes empty network definitions from acl terms and renders the access-list without them. "
+                "If no network definitions remain, the term will be removed entirely."
             ),
         ),
     ]

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -836,6 +836,90 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("SOME_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
 
+    def test_access_list_jmespath_functions(self):
+        """Test acl omits terms with empty network references using JMESPath with helper functions"""
+        settings = {
+            "extroute_bgp": None,
+            "network_definitions": {
+                "EMPTY": [
+                    {"path": "arr(extroute_bgp.vrfs)[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]"}
+                ]  # This will be empty,
+            },
+            "system_access_lists": ["SOME_ACL"],
+            "access_lists": {
+                "SOME_ACL": {
+                    "skip_terms_with_empty_network_definitions": True,
+                    "terms": [
+                        {"name": "permit-empty", "destination-address": "EMPTY", "action": "accept"},
+                        {"name": "permit-any", "action": "accept"},
+                    ],
+                },
+            },
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
+        acls = get_generated_access_lists(dist_device, settings=settings)
+        self.assertIn("SOME_ACL", acls.keys())
+        self.assertEqual(len(acls), 1)
+
+    def test_access_list_jmespath_functions_bgp(self):
+        """Test acl network references using JMESPath"""
+        settings = {
+            "extroute_bgp": {
+                "vrfs": [
+                    {
+                        "name": "MGMT",
+                        "local_as": 64551,
+                        "neighbor_v4": [
+                            {
+                                "peer_ipv4": "192.168.0.0",  # noqa: S1313
+                                "peer_as": 65656,
+                                "route_map_in": "ANY",
+                                "route_map_out": "ANY",
+                                "description": "",
+                                "bfd": None,
+                                "graceful_restart": None,
+                                "next_hop_self": None,
+                                "update_source": None,
+                                "ebgp_multihop": None,
+                                "maximum_routes": None,
+                                "auth_type": None,
+                                "auth_string": None,
+                                "remove_private_as": None,
+                                "cli_append_str": "",
+                            }
+                        ],
+                    }
+                ]
+            },
+            "network_definitions": {
+                "BGP_NEIGHBORS": [
+                    {"path": "arr(extroute_bgp.vrfs)[].neighbor_v4[].peer_ipv4"},
+                    {"path": "arr(extroute_bgp.vrfs)[].neighbor_v6[].peer_ipv6"}
+                ]
+            },
+            "system_access_lists": ["SOME_ACL_BGP"],
+            "access_lists": {
+                "SOME_ACL_BGP": {
+                    "terms": [
+                        {"name": "permit-bgp", "destination-address": "BGP_NEIGHBORS", "action": "accept"},
+                        {"name": "permit-any", "action": "accept"},
+                    ],
+                },
+            },
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
+        acls = get_generated_access_lists(dist_device, settings=settings)
+        self.assertIn("SOME_ACL_BGP", acls.keys())
+        self.assertEqual(len(acls), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -814,7 +814,7 @@ class SettingsTests(unittest.TestCase):
         settings = {
             "snmp_servers": [],
             "network_definitions": {
-                "EMPTY": [{"path": "snmp_servers[].host"}]  # This will be empty,
+                "EMPTY": [{"path": "snmp_servers[].host"}]  # This will be empty
             },
             "system_access_lists": ["SOME_ACL"],
             "access_lists": {
@@ -841,17 +841,17 @@ class SettingsTests(unittest.TestCase):
         settings = {
             "extroute_bgp": None,
             "network_definitions": {
-                "EMPTY": [
+                "BGP-EMPTY": [
                     {"path": "arr(extroute_bgp.vrfs)[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]"}
-                ]  # This will be empty,
+                ]  # This will be empty and not error
             },
-            "system_access_lists": ["SOME_ACL"],
+            "system_access_lists": ["JMESPATH_FUNCTIONS"],
             "access_lists": {
-                "SOME_ACL": {
+                "JMESPATH_FUNCTIONS": {
                     "skip_terms_with_empty_network_definitions": True,
                     "terms": [
-                        {"name": "permit-empty", "destination-address": "EMPTY", "action": "accept"},
-                        {"name": "permit-any", "action": "accept"},
+                        {"name": "permit-bgp-empty", "destination-address": "BGP-EMPTY", "action": "accept"},
+                        {"name": "permit-any", "action": "accept"},  # Will be the only term
                     ],
                 },
             },
@@ -862,8 +862,7 @@ class SettingsTests(unittest.TestCase):
 
         dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
         acls = get_generated_access_lists(dist_device, settings=settings)
-        self.assertIn("SOME_ACL", acls.keys())
-        self.assertEqual(len(acls), 1)
+        self.assertIn("JMESPATH_FUNCTIONS", acls.keys())
 
     def test_access_list_jmespath_functions_bgp(self):
         """Test acl network references using JMESPath"""
@@ -918,7 +917,6 @@ class SettingsTests(unittest.TestCase):
         dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
         acls = get_generated_access_lists(dist_device, settings=settings)
         self.assertIn("SOME_ACL_BGP", acls.keys())
-        self.assertEqual(len(acls), 1)
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -898,7 +898,7 @@ class SettingsTests(unittest.TestCase):
             "network_definitions": {
                 "BGP_NEIGHBORS": [
                     {"path": "arr(extroute_bgp.vrfs)[].neighbor_v4[].peer_ipv4"},
-                    {"path": "arr(extroute_bgp.vrfs)[].neighbor_v6[].peer_ipv6"}
+                    {"path": "arr(extroute_bgp.vrfs)[].neighbor_v6[].peer_ipv6"},
                 ]
             },
             "system_access_lists": ["SOME_ACL_BGP"],

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -809,6 +809,33 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("host 192.168.0.1", acls["SOME_ACL"])  # noqa: S1313
         self.assertIn("2001:db8::1", acls["SOME_ACL"])  # noqa: S1313
 
+    def test_access_list_empty_network_term_is_skipped(self):
+        """Test acl omits terms with empty network references"""
+        settings = {
+            "snmp_servers": [],
+            "network_definitions": {
+                "EMPTY": [{"path": "snmp_servers[].host"}]  # This will be empty,
+            },
+            "system_access_lists": ["SOME_ACL"],
+            "access_lists": {
+                "SOME_ACL": {
+                    "skip_terms_with_empty_network_definitions": True,
+                    "terms": [
+                        {"name": "permit-empty", "destination-address": "EMPTY", "action": "accept"},
+                        {"name": "permit-any", "action": "accept"},
+                    ]
+                },
+            },
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
+        acls = get_generated_access_lists(dist_device, settings=settings)
+        self.assertIn("SOME_ACL", acls.keys())
+        self.assertEqual(len(acls), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -823,7 +823,7 @@ class SettingsTests(unittest.TestCase):
                     "terms": [
                         {"name": "permit-empty", "destination-address": "EMPTY", "action": "accept"},
                         {"name": "permit-any", "action": "accept"},
-                    ]
+                    ],
                 },
             },
         }

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -819,7 +819,7 @@ class SettingsTests(unittest.TestCase):
             "system_access_lists": ["SOME_ACL"],
             "access_lists": {
                 "SOME_ACL": {
-                    "skip_terms_with_empty_network_definitions": True,
+                    "skip_empty_network_definitions": True,
                     "terms": [
                         {"name": "permit-empty", "destination-address": "EMPTY", "action": "accept"},
                         {"name": "permit-any", "action": "accept"},
@@ -848,7 +848,7 @@ class SettingsTests(unittest.TestCase):
             "system_access_lists": ["JMESPATH_FUNCTIONS"],
             "access_lists": {
                 "JMESPATH_FUNCTIONS": {
-                    "skip_terms_with_empty_network_definitions": True,
+                    "skip_empty_network_definitions": True,
                     "terms": [
                         {"name": "permit-bgp-empty", "destination-address": "BGP-EMPTY", "action": "accept"},
                         {"name": "permit-any", "action": "accept"},  # Will be the only term
@@ -863,6 +863,43 @@ class SettingsTests(unittest.TestCase):
         dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
         acls = get_generated_access_lists(dist_device, settings=settings)
         self.assertIn("JMESPATH_FUNCTIONS", acls.keys())
+        # Will not have the term with empty network references
+        self.assertNotIn("permit-bgp-empty", acls["JMESPATH_FUNCTIONS"])
+
+    def test_access_list_jmespath_other(self):
+        """Test acl omits terms with empty network references using JMESPath with helper functions"""
+        settings = {
+            "extroute_bgp": None,
+            "network_definitions": {
+                "SOME_SUBNET": [{"address": "192.168.0.0/24"}],  # noqa: S1313
+                "BGP-EMPTY": [
+                    {"path": "arr(extroute_bgp.vrfs)[].[neighbor_v4[].peer_ipv4, neighbor_v6[].peer_ipv6][][]"}
+                ],  # This will be empty
+            },
+            "system_access_lists": ["JMESPATH_FUNCTIONS_OTHER"],
+            "access_lists": {
+                "JMESPATH_FUNCTIONS_OTHER": {
+                    "skip_empty_network_definitions": True,
+                    "terms": [
+                        {
+                            "name": "permit-bgp-empty",
+                            "destination-address": ["SOME_SUBNET", "BGP-EMPTY"],
+                            "action": "accept",
+                        },
+                        {"name": "permit-any", "action": "accept"},  # Will be the only term
+                    ],
+                },
+            },
+        }
+
+        # Validate settings
+        f_root(**settings)
+
+        dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
+        acls = get_generated_access_lists(dist_device, settings=settings)
+        self.assertIn("JMESPATH_FUNCTIONS_OTHER", acls.keys())
+        # Removes the empty network definition but keeps the entire term
+        self.assertIn("permit-bgp-empty", acls["JMESPATH_FUNCTIONS_OTHER"])
 
     def test_access_list_jmespath_functions_bgp(self):
         """Test acl network references using JMESPath"""
@@ -898,13 +935,17 @@ class SettingsTests(unittest.TestCase):
                 "BGP_NEIGHBORS": [
                     {"path": "arr(extroute_bgp.vrfs)[].neighbor_v4[].peer_ipv4"},
                     {"path": "arr(extroute_bgp.vrfs)[].neighbor_v6[].peer_ipv6"},
-                ]
+                ],
             },
             "system_access_lists": ["SOME_ACL_BGP"],
             "access_lists": {
                 "SOME_ACL_BGP": {
                     "terms": [
-                        {"name": "permit-bgp", "destination-address": "BGP_NEIGHBORS", "action": "accept"},
+                        {
+                            "name": "permit-bgp",
+                            "destination-address": "BGP_NEIGHBORS",
+                            "action": "accept",
+                        },
                         {"name": "permit-any", "action": "accept"},
                     ],
                 },
@@ -917,6 +958,7 @@ class SettingsTests(unittest.TestCase):
         dist_device = Device(hostname="test-dist1", platform="eos", device_type=DeviceType.DIST)
         acls = get_generated_access_lists(dist_device, settings=settings)
         self.assertIn("SOME_ACL_BGP", acls.keys())
+        self.assertIn("permit-bgp", acls["SOME_ACL_BGP"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When generating dynamic acls with jmespath references sometimes stuff can be empty.
This PR adds some helper functions that can be used to fix those edge-cases.


Adds access-list option: skip_empty_network_definitions that will remove empty network definitions if set to true. Aerleon will fail when trying to render access lists with terms with empty network definitions.

Adds jmespath custom functions `arr` and `obj` that can normalize null values to an empty array or object.
For example when extroute_bgp = null jmespath fails to render out an empty array and the helper arr function can be used to bypass that issue.
For example different dist switches might have bgp neighbors or not.