### PR TITLE
Fix excessive acl logging

### DIFF
--- a/src/cnaas_nms/db/settings.py
+++ b/src/cnaas_nms/db/settings.py
@@ -1305,6 +1305,25 @@ def _process_access_list_terms(
     return filtered_acl_terms
 
 
+def get_included_access_lists(setting_acls: Dict[str, dict], generate_access_lists: Set[str]) -> Set[str]:
+    """
+    Recursively identifies all access lists that are included by generate_access_lists.
+    """
+    included_access_lists: Set[str] = set()
+    for acl_name, acl_data in setting_acls.items():
+        # Only check access lists that are in the generate_access_lists list
+        if acl_name not in generate_access_lists:
+            continue
+        for term in acl_data.get("terms", []):
+            include_acl: str
+            # Only check include acls
+            if not (include_acl := term.get("include")):
+                continue
+            included_access_lists.add(include_acl)
+            included_access_lists.update(get_included_access_lists(setting_acls, {include_acl}))
+    return included_access_lists
+
+
 def get_generated_access_lists(
     dev: Optional[Device] = None, platform: Optional[str] = None, settings: Optional[dict] = None
 ) -> Dict[str, str]:
@@ -1378,9 +1397,16 @@ def get_generated_access_lists(
     includes = {}  # A dict with acl_name: policy_dict if another access_list includes another acl.
     setting_acls: Dict[str, dict] = settings.get("access_lists", {})
 
+    # Locate all reference included access lists
+    included_access_lists: Set[str] = get_included_access_lists(setting_acls, generate_access_lists)
+
     defs = _build_aerleon_definitions(settings)
 
     for access_list_name, access_list_dict in setting_acls.items():
+        # Skip access lists that are neither in the generate_access_lists nor included_access_lists
+        if access_list_name not in generate_access_lists and access_list_name not in included_access_lists:
+            continue
+
         # Construct f_access_list object without validation
         access_list: f_access_list = f_access_list.model_construct(**access_list_dict)
 

--- a/src/cnaas_nms/db/settings_fields/access_lists.py
+++ b/src/cnaas_nms/db/settings_fields/access_lists.py
@@ -153,6 +153,43 @@ class f_access_lists(BaseModel):
 
     @field_validator("access_lists", mode="after")
     @classmethod
+    def validate_access_lists_recursion(
+        cls, access_lists: Dict[access_list_name, f_access_list]
+    ) -> Dict[access_list_name, f_access_list]:
+        """Validates that included access-lists do not cause infinite recursion"""
+        safe_nodes = set()
+
+        def find_cycle(acl_name: str, visited_stack: List[str]) -> Optional[List[str]]:
+            if acl_name in visited_stack:
+                cycle_start = visited_stack.index(acl_name)
+                return visited_stack[cycle_start:] + [acl_name]
+
+            if acl_name in safe_nodes:
+                return None
+
+            acl_obj = access_lists.get(acl_name)
+            if not acl_obj:
+                return None
+
+            visited_stack.append(acl_name)
+            for term in acl_obj.terms:
+                include_acl = term.get("include")
+                if include_acl and isinstance(include_acl, str):
+                    if cycle := find_cycle(include_acl, visited_stack):
+                        return cycle
+            visited_stack.pop()
+            safe_nodes.add(acl_name)
+            return None
+
+        for acl_name in access_lists:
+            if cycle := find_cycle(acl_name, []):
+                cycle_path = " -> ".join(cycle)
+                raise ValueError(f"Infinite recursion detected in access-list includes: {cycle_path}")
+
+        return access_lists
+
+    @field_validator("access_lists", mode="after")
+    @classmethod
     def validate_access_lists_included_terms(
         cls, access_lists: Dict[access_list_name, f_access_list]
     ) -> Dict[access_list_name, f_access_list]:

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -501,6 +501,8 @@ class SettingsTests(unittest.TestCase):
         acls = get_generated_access_lists(platform="eos", settings=settings)
         self.assertIn("TEST_ACL", acls.keys())
         self.assertEqual(len(acls), 1)
+        self.assertIn("remark some-acl", acls["TEST_ACL"])
+        self.assertIn("permit ip any any", acls["TEST_ACL"])
 
     def test_access_list_include_non_unique(self):
         """Test include acl where the included terms are not unique together with the parent term names"""

--- a/src/cnaas_nms/db/tests/test_settings.py
+++ b/src/cnaas_nms/db/tests/test_settings.py
@@ -504,6 +504,20 @@ class SettingsTests(unittest.TestCase):
         self.assertIn("remark some-acl", acls["TEST_ACL"])
         self.assertIn("permit ip any any", acls["TEST_ACL"])
 
+    def test_access_list_circular_include(self):
+        """Test include acl when acls are circularly included"""
+        settings = {
+            "access_lists": {
+                "INCLUDE-ACL1": {"terms": [{"include": "INCLUDE-ACL2"}]},
+                "INCLUDE-ACL2": {"terms": [{"name": "some-acl", "action": "accept"}, {"include": "INCLUDE-ACL1"}]},
+                "TEST_ACL": {"terms": [{"include": "INCLUDE-ACL1"}]},
+            },
+            "system_access_lists": ["TEST_ACL"],
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            f_root(**settings)
+        self.assertIn("Infinite recursion detected in access-list includes", str(ctx.exception))
+
     def test_access_list_include_non_unique(self):
         """Test include acl where the included terms are not unique together with the parent term names"""
         settings = {


### PR DESCRIPTION
This PR adds a small fix that makes get_generated_acls only process the acls it needs.
Previously it added all access-lists in a big include dictionary and had to process those terms as well.
Now we filter out them before processing.

I saw excessive acl logging before that was bogging down the job output.