### PR TITLE
Add /api/health api endpoint

### DIFF
--- a/docs/apiref/health.rst
+++ b/docs/apiref/health.rst
@@ -1,0 +1,23 @@
+Health
+======
+
+Version
+-------
+
+To get the current health status:
+
+::
+
+   curl https://hostname/api/health
+
+Example output:
+
+::
+
+   {
+       "status": "success",
+       "checks": {
+           "postgres": "healthy",
+           "redis": "healthy"
+       }
+   }

--- a/docs/apiref/index.rst
+++ b/docs/apiref/index.rst
@@ -5,6 +5,7 @@ API Reference
    :maxdepth: 1
 
    Home <self>
+   health
    devices
    groups
    jobs

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -13,7 +13,7 @@ New features:
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
  - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
- - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#576)
+ - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#578)
 
 Changes:
 

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -13,6 +13,7 @@ New features:
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
  - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
+ - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#576)
 
 Changes:
 

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -180,6 +180,7 @@ api.add_namespace(plugins_api)
 api.add_namespace(system_api)
 api.add_namespace(rbac_api)
 
+
 # SocketIO on connect
 @socketio.on("connect")
 def socketio_on_connect():

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -29,6 +29,7 @@ from cnaas_nms.api.device import (
 )
 from cnaas_nms.api.firmware import api as firmware_api
 from cnaas_nms.api.groups import api as groups_api
+from cnaas_nms.api.health import health_bp
 from cnaas_nms.api.interface import api as interfaces_api
 from cnaas_nms.api.jobs import job_api, joblock_api, jobs_api
 from cnaas_nms.api.json import CNaaSJSONEncoder
@@ -147,6 +148,11 @@ api = CnaasApi(
     app, prefix="/api/{}".format(__api_version__), authorizations=authorizations, security="apikey", doc="/api/doc/"
 )
 
+# Register health blueprint
+# No swagger docs for this endpoint
+# Lives outside the flask_restx API at /api/health
+app.register_blueprint(health_bp)
+
 api.add_namespace(auth_api)
 api.add_namespace(device_api)
 api.add_namespace(devices_api)
@@ -173,7 +179,6 @@ api.add_namespace(settings_api)
 api.add_namespace(plugins_api)
 api.add_namespace(system_api)
 api.add_namespace(rbac_api)
-
 
 # SocketIO on connect
 @socketio.on("connect")

--- a/src/cnaas_nms/api/health.py
+++ b/src/cnaas_nms/api/health.py
@@ -1,0 +1,60 @@
+from typing import Literal
+
+from flask import Blueprint, jsonify
+from sqlalchemy import text
+
+from cnaas_nms.db.session import redis_session, sqla_session
+from cnaas_nms.tools.log import get_logger
+
+logger = get_logger()
+
+health_bp = Blueprint("health", __name__, url_prefix="/api")
+
+
+@health_bp.get("/health")
+def get_health():
+    postgres_status: Literal["healthy", "unhealthy"]
+    redis_status: Literal["healthy", "unhealthy"]
+
+    # Fetch postgresql health status
+    try:
+        with sqla_session() as session:  # type: ignore
+            session.execute(text("SELECT 1"))
+            postgres_status = "healthy"
+    except Exception as e:
+        logger.error("Postgres health check failed", exc_info=e)
+        postgres_status = "unhealthy"
+
+    # Fetch redis health status
+    try:
+        with redis_session() as redis:  # type: ignore
+            redis.ping()
+            redis_status = "healthy"
+    except Exception as e:
+        logger.error("Redis health check failed", exc_info=e)
+        redis_status = "unhealthy"
+
+    if postgres_status == "healthy" and redis_status == "healthy":
+        return jsonify(
+            {
+                "status": "success",
+                "data": {
+                    "checks": {
+                        "postgres": postgres_status,
+                        "redis": redis_status,
+                    }
+                },
+            }
+        ), 200
+
+    return jsonify(
+        {
+            "status": "error",
+            "data": {
+                "checks": {
+                    "postgres": postgres_status,
+                    "redis": redis_status,
+                }
+            },
+        }
+    ), 503

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+
+def test_health(client):
+    result = client.get("/api/health")
+
+    # 200 OK
+    assert result.status_code == 200
+
+
+def test_health_postgres_down(client):
+    # Simulate PostgreSQL being down
+    # Mock sqla_session()
+    with patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")):
+        result = client.get("/api/health")
+
+    # 503 Service Unavailable
+    assert result.status_code == 503
+
+
+def test_health_redis_down(client):
+    # Simulate Redis being down
+    # Mock redis_session()
+    with patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")):
+        result = client.get("/api/health")
+
+    # 503 Service Unavailable
+    assert result.status_code == 503
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -28,5 +28,6 @@ def test_health_redis_down(client):
     # 503 Service Unavailable
     assert result.status_code == 503
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -1,6 +1,10 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
+
+pytestmark = pytest.mark.integration
+
 
 def test_health(client):
     result = client.get("/api/health")


### PR DESCRIPTION
Resolves: #573 

Adds an /api/health endpoint that can be used to track the health of the NMS api by checking PostgreSQL and Redis connection.

Example output:
```json
{
    "status": "success",
    "checks": {
        "postgres": "healthy",
        "redis": "healthy"
    }
}
```

Returns a 200 when everything is good and a 503 when something is 'unhealthy'