### PR TITLE
Feature.api health probes

### DIFF
--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -95,4 +95,6 @@ RUN chmod 444 /etc/cnaas-nms/api.yml /etc/cnaas-nms/db_config.yml /etc/cnaas-nms
 
 USER www-data
 EXPOSE 1443
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -kfsS https://localhost:1443/api/health/live || exit 1
 ENTRYPOINT ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/docs/apiref/health.rst
+++ b/docs/apiref/health.rst
@@ -1,0 +1,23 @@
+Health
+======
+
+Version
+-------
+
+To get the current health status:
+
+::
+
+   curl https://hostname/api/health
+
+Example output:
+
+::
+
+   {
+       "status": "success",
+       "checks": {
+           "postgres": "healthy",
+           "redis": "healthy"
+       }
+   }

--- a/docs/apiref/health.rst
+++ b/docs/apiref/health.rst
@@ -1,23 +1,83 @@
 Health
 ======
 
-Version
--------
+Three endpoints report the health of the API, following the
+`MicroProfile Health 4.0 <https://download.eclipse.org/microprofile/microprofile-health-4.0/microprofile-health-spec-4.0.html>`_
+response format. They require no authentication and are not part of the
+versioned API, so a monitor can read them without a token.
 
-To get the current health status:
+Every response carries a ``status`` of ``UP`` or ``DOWN``, and a ``checks``
+list holding the individual results. ``UP`` is answered with 200 and ``DOWN``
+with 503, so a probe can act on the status code alone.
+
+Liveness
+--------
+
+To check that the API is running:
 
 ::
 
-   curl https://hostname/api/health
+   curl https://hostname/api/health/live
+
+This performs no I/O and stays ``UP`` while a dependency is unreachable, so it
+is the endpoint to use for a Kubernetes liveness probe or a container health
+check. Restarting the API cannot repair a database outage.
 
 Example output:
 
 ::
 
    {
-       "status": "success",
-       "checks": {
-           "postgres": "healthy",
-           "redis": "healthy"
-       }
+       "status": "UP",
+       "checks": []
+   }
+
+Readiness
+---------
+
+To check that the API can reach the dependencies it needs to answer requests:
+
+::
+
+   curl https://hostname/api/health/ready
+
+PostgreSQL holds the device inventory and job state, and Redis holds the token
+cache, event stream and job queue, so the API can serve nothing useful without
+either. Use this endpoint for a Kubernetes readiness probe, which takes the pod
+out of the Service endpoints while it answers ``DOWN``, and for monitoring.
+
+A result is cached for a few seconds, so probing frequently costs no more than
+probing rarely.
+
+Example output:
+
+::
+
+   {
+       "status": "UP",
+       "checks": [
+           {"name": "postgres", "status": "UP"},
+           {"name": "redis", "status": "UP"}
+       ]
+   }
+
+Health
+------
+
+To get every check in one call:
+
+::
+
+   curl https://hostname/api/health
+
+Example output when a dependency is unreachable, answered with 503:
+
+::
+
+   {
+       "status": "DOWN",
+       "checks": [
+           {"name": "postgres", "status": "UP"},
+           {"name": "redis", "status": "DOWN"}
+       ]
    }

--- a/docs/apiref/index.rst
+++ b/docs/apiref/index.rst
@@ -5,6 +5,7 @@ API Reference
    :maxdepth: 1
 
    Home <self>
+   health
    devices
    groups
    jobs

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -13,7 +13,7 @@ New features:
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
  - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
- - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#576)
+ - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#578)
 
 Changes:
 

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -13,7 +13,7 @@ New features:
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
  - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
- - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#578)
+ - /api/health, /api/health/live and /api/health/ready endpoints that report the health of the API, including checks for PostgreSQL and Redis (#578, #573)
 
 Changes:
 

--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -13,6 +13,7 @@ New features:
  - The repository api now tracks when a repo is out of sync with the origin (#546)
  - Added banner_login and banner_motd settings to base_system (#570)
  - Added skip_empty_network_definitions to access_lists that will remove empty network definitions if set to true (#571)
+ - /api/health endpoint that provides the current health status of the system, including checks for PostgreSQL and Redis (#576)
 
 Changes:
 

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -180,6 +180,7 @@ api.add_namespace(plugins_api)
 api.add_namespace(system_api)
 api.add_namespace(rbac_api)
 
+
 # SocketIO on connect
 @socketio.on("connect")
 def socketio_on_connect():

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -29,6 +29,7 @@ from cnaas_nms.api.device import (
 )
 from cnaas_nms.api.firmware import api as firmware_api
 from cnaas_nms.api.groups import api as groups_api
+from cnaas_nms.api.health import health_bp
 from cnaas_nms.api.interface import api as interfaces_api
 from cnaas_nms.api.jobs import job_api, joblock_api, jobs_api
 from cnaas_nms.api.json import CNaaSJSONEncoder
@@ -147,6 +148,11 @@ api = CnaasApi(
     app, prefix="/api/{}".format(__api_version__), authorizations=authorizations, security="apikey", doc="/api/doc/"
 )
 
+# Register health blueprint
+# No swagger docs for this endpoint
+# Lives outside the flask_restx API at /api/health
+app.register_blueprint(health_bp)
+
 api.add_namespace(auth_api)
 api.add_namespace(device_api)
 api.add_namespace(devices_api)
@@ -173,7 +179,6 @@ api.add_namespace(settings_api)
 api.add_namespace(plugins_api)
 api.add_namespace(system_api)
 api.add_namespace(rbac_api)
-
 
 # SocketIO on connect
 @socketio.on("connect")

--- a/src/cnaas_nms/api/app.py
+++ b/src/cnaas_nms/api/app.py
@@ -148,9 +148,8 @@ api = CnaasApi(
     app, prefix="/api/{}".format(__api_version__), authorizations=authorizations, security="apikey", doc="/api/doc/"
 )
 
-# Register health blueprint
-# No swagger docs for this endpoint
-# Lives outside the flask_restx API at /api/health
+# Health endpoints live outside the flask_restx API and the versioned prefix, so a probe
+# can read them without a token and they stay out of the swagger docs
 app.register_blueprint(health_bp)
 
 api.add_namespace(auth_api)

--- a/src/cnaas_nms/api/health.py
+++ b/src/cnaas_nms/api/health.py
@@ -1,6 +1,7 @@
-from typing import Literal
+import time
+from typing import Dict, List, Literal, Optional, Tuple
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, Response, jsonify
 from sqlalchemy import text
 
 from cnaas_nms.db.session import redis_session, sqla_session
@@ -10,51 +11,69 @@ logger = get_logger()
 
 health_bp = Blueprint("health", __name__, url_prefix="/api")
 
+Status = Literal["UP", "DOWN"]
 
-@health_bp.get("/health")
-def get_health():
-    postgres_status: Literal["healthy", "unhealthy"]
-    redis_status: Literal["healthy", "unhealthy"]
+# A readiness result is reused for this long, so that probing often costs no
+# more than probing rarely.
+READINESS_CACHE_SECONDS = 5.0
 
-    # Fetch postgresql health status
+_readiness_cache: Optional[Tuple[float, List[Dict[str, str]]]] = None
+
+
+def check_postgres() -> Status:
     try:
         with sqla_session() as session:  # type: ignore
             session.execute(text("SELECT 1"))
-            postgres_status = "healthy"
+        return "UP"
     except Exception as e:
-        logger.error("Postgres health check failed", exc_info=e)
-        postgres_status = "unhealthy"
+        logger.warning("Postgres health check failed: {}".format(e))
+        return "DOWN"
 
-    # Fetch redis health status
+
+def check_redis() -> Status:
     try:
         with redis_session() as redis:  # type: ignore
             redis.ping()
-            redis_status = "healthy"
+        return "UP"
     except Exception as e:
-        logger.error("Redis health check failed", exc_info=e)
-        redis_status = "unhealthy"
+        logger.warning("Redis health check failed: {}".format(e))
+        return "DOWN"
 
-    if postgres_status == "healthy" and redis_status == "healthy":
-        return jsonify(
-            {
-                "status": "success",
-                "data": {
-                    "checks": {
-                        "postgres": postgres_status,
-                        "redis": redis_status,
-                    }
-                },
-            }
-        ), 200
 
-    return jsonify(
-        {
-            "status": "error",
-            "data": {
-                "checks": {
-                    "postgres": postgres_status,
-                    "redis": redis_status,
-                }
-            },
-        }
-    ), 503
+def readiness_checks() -> List[Dict[str, str]]:
+    """Check the dependencies the API needs to serve requests, at most once every cache interval."""
+    global _readiness_cache
+
+    cached = _readiness_cache
+    if cached and time.monotonic() - cached[0] < READINESS_CACHE_SECONDS:
+        return cached[1]
+
+    checks: List[Dict[str, str]] = [
+        {"name": "postgres", "status": check_postgres()},
+        {"name": "redis", "status": check_redis()},
+    ]
+    _readiness_cache = (time.monotonic(), checks)
+    return checks
+
+
+def health_response(checks: List[Dict[str, str]]) -> Tuple[Response, int]:
+    status: Status = "UP" if all(check["status"] == "UP" for check in checks) else "DOWN"
+    return jsonify({"status": status, "checks": checks}), 200 if status == "UP" else 503
+
+
+@health_bp.get("/health")
+def get_health():
+    """Aggregate of every check, so a single call shows whether the API is both running and usable."""
+    return health_response(readiness_checks())
+
+
+@health_bp.get("/health/live")
+def get_health_live():
+    """Report that the API process runs. Performs no I/O, so a dependency outage never fails it."""
+    return health_response([])
+
+
+@health_bp.get("/health/ready")
+def get_health_ready():
+    """Report whether the API can reach the dependencies it needs to answer requests."""
+    return health_response(readiness_checks())

--- a/src/cnaas_nms/api/health.py
+++ b/src/cnaas_nms/api/health.py
@@ -1,0 +1,60 @@
+from typing import Literal
+
+from flask import Blueprint, jsonify
+from sqlalchemy import text
+
+from cnaas_nms.db.session import redis_session, sqla_session
+from cnaas_nms.tools.log import get_logger
+
+logger = get_logger()
+
+health_bp = Blueprint("health", __name__, url_prefix="/api")
+
+
+@health_bp.get("/health")
+def get_health():
+    postgres_status: Literal["healthy", "unhealthy"]
+    redis_status: Literal["healthy", "unhealthy"]
+
+    # Fetch postgresql health status
+    try:
+        with sqla_session() as session:  # type: ignore
+            session.execute(text("SELECT 1"))
+            postgres_status = "healthy"
+    except Exception as e:
+        logger.error("Postgres health check failed", exc_info=e)
+        postgres_status = "unhealthy"
+
+    # Fetch redis health status
+    try:
+        with redis_session() as redis:  # type: ignore
+            redis.ping()
+            redis_status = "healthy"
+    except Exception as e:
+        logger.error("Redis health check failed", exc_info=e)
+        redis_status = "unhealthy"
+
+    if postgres_status == "healthy" and redis_status == "healthy":
+        return jsonify(
+            {
+                "status": "success",
+                "data": {
+                    "checks": {
+                        "postgres": postgres_status,
+                        "redis": redis_status,
+                    }
+                },
+            }
+        ), 200
+
+    return jsonify(
+        {
+            "status": "error",
+            "data": {
+                "checks": {
+                    "postgres": postgres_status,
+                    "redis": redis_status,
+                }
+            },
+        }
+    ), 503

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import patch
+
+
+def test_health(client):
+    result = client.get("/api/health")
+
+    # 200 OK
+    assert result.status_code == 200
+
+
+def test_health_postgres_down(client):
+    # Simulate PostgreSQL being down
+    # Mock sqla_session()
+    with patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")):
+        result = client.get("/api/health")
+
+    # 503 Service Unavailable
+    assert result.status_code == 503
+
+
+def test_health_redis_down(client):
+    # Simulate Redis being down
+    # Mock redis_session()
+    with patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")):
+        result = client.get("/api/health")
+
+    # 503 Service Unavailable
+    assert result.status_code == 503
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -28,5 +28,6 @@ def test_health_redis_down(client):
     # 503 Service Unavailable
     assert result.status_code == 503
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -1,6 +1,10 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
+
+pytestmark = pytest.mark.integration
+
 
 def test_health(client):
     result = client.get("/api/health")

--- a/src/cnaas_nms/api/tests/test_health.py
+++ b/src/cnaas_nms/api/tests/test_health.py
@@ -3,34 +3,103 @@ from unittest.mock import patch
 
 import pytest
 
+from cnaas_nms.api import health
+
 pytestmark = pytest.mark.integration
 
 
-def test_health(client):
+@pytest.fixture(autouse=True)
+def uncached_readiness(monkeypatch):
+    """Report the current state of the dependencies, so a cached result cannot answer for the next test."""
+    monkeypatch.setattr(health, "_readiness_cache", None)
+    monkeypatch.setattr(health, "READINESS_CACHE_SECONDS", 0)
+
+
+def checks_by_name(result):
+    return {check["name"]: check["status"] for check in result.json["checks"]}
+
+
+def test_live_reports_up(client):
+    result = client.get("/api/health/live")
+
+    assert result.status_code == 200
+    assert result.json["status"] == "UP"
+
+
+def test_live_reports_up_while_dependencies_are_down(client):
+    with (
+        patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")),
+        patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")),
+    ):
+        result = client.get("/api/health/live")
+
+    # The process is alive and should not be restarted over an outage it cannot fix
+    assert result.status_code == 200
+    assert result.json["status"] == "UP"
+
+
+def test_ready_reports_up(client):
+    result = client.get("/api/health/ready")
+
+    assert result.status_code == 200
+    assert result.json["status"] == "UP"
+    assert checks_by_name(result) == {"postgres": "UP", "redis": "UP"}
+
+
+def test_ready_reports_down_when_postgres_is_down(client):
+    with patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")):
+        result = client.get("/api/health/ready")
+
+    assert result.status_code == 503
+    assert result.json["status"] == "DOWN"
+    assert checks_by_name(result) == {"postgres": "DOWN", "redis": "UP"}
+
+
+def test_ready_reports_down_when_redis_is_down(client):
+    with patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")):
+        result = client.get("/api/health/ready")
+
+    assert result.status_code == 503
+    assert result.json["status"] == "DOWN"
+    assert checks_by_name(result) == {"postgres": "UP", "redis": "DOWN"}
+
+
+def test_ready_recovers_when_postgres_returns(client):
+    with patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")):
+        client.get("/api/health/ready")
+
+    result = client.get("/api/health/ready")
+
+    assert result.status_code == 200
+    assert result.json["status"] == "UP"
+
+
+def test_health_reports_the_dependencies(client):
     result = client.get("/api/health")
 
-    # 200 OK
     assert result.status_code == 200
+    assert result.json["status"] == "UP"
+    assert checks_by_name(result) == {"postgres": "UP", "redis": "UP"}
 
 
-def test_health_postgres_down(client):
-    # Simulate PostgreSQL being down
-    # Mock sqla_session()
-    with patch("cnaas_nms.api.health.sqla_session", side_effect=Exception("Postgres down")):
-        result = client.get("/api/health")
-
-    # 503 Service Unavailable
-    assert result.status_code == 503
-
-
-def test_health_redis_down(client):
-    # Simulate Redis being down
-    # Mock redis_session()
+def test_health_reports_down_when_a_dependency_is_down(client):
     with patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")):
         result = client.get("/api/health")
 
-    # 503 Service Unavailable
     assert result.status_code == 503
+    assert result.json["status"] == "DOWN"
+
+
+def test_ready_reuses_a_result_within_the_cache_interval(client, monkeypatch):
+    monkeypatch.setattr(health, "READINESS_CACHE_SECONDS", 60)
+    client.get("/api/health/ready")
+
+    # A dependency that drops out is not reported until the cached result expires
+    with patch("cnaas_nms.api.health.redis_session", side_effect=Exception("Redis down")):
+        result = client.get("/api/health/ready")
+
+    assert result.status_code == 200
+    assert result.json["status"] == "UP"
 
 
 if __name__ == "__main__":

--- a/src/cnaas_nms/db/session.py
+++ b/src/cnaas_nms/db/session.py
@@ -9,12 +9,18 @@ from cnaas_nms.app_settings import app_settings
 
 _sessionmaker = None
 
+# Bound the wait for an unreachable dependency, so a request fails instead of
+# occupying a worker until the OS gives up on the TCP connection.
+CONNECT_TIMEOUT = 5
+
 
 def _get_session():
     global _sessionmaker
     if _sessionmaker is None:
         conn_str = app_settings.POSTGRES_DSN
-        engine = create_engine(conn_str, pool_size=50, max_overflow=50)
+        engine = create_engine(
+            conn_str, pool_size=50, max_overflow=50, connect_args={"connect_timeout": CONNECT_TIMEOUT}
+        )
         engine.connect()
         _sessionmaker = sessionmaker(bind=engine)
     return _sessionmaker()
@@ -45,6 +51,11 @@ def sqla_execute(**kwargs):
 @contextmanager
 def redis_session(**kwargs):
     with StrictRedis(
-        host=app_settings.REDIS_HOSTNAME, port=app_settings.REDIS_PORT, encoding="utf-8", decode_responses=True
+        host=app_settings.REDIS_HOSTNAME,
+        port=app_settings.REDIS_PORT,
+        encoding="utf-8",
+        decode_responses=True,
+        socket_connect_timeout=CONNECT_TIMEOUT,
+        socket_timeout=CONNECT_TIMEOUT,
     ) as conn:
         yield conn


### PR DESCRIPTION
@Qwiko hope you don't mind me pushing for using this standard as much as possible (it's basically the only health endpoint related standard I found).

Built on your #578 - your five commits are unchanged.

Added /api/health/live (no I/O) and /api/health/ready (dependencies), which are the two probes MicroProfile defines underneath the /health aggregate you already built. One endpoint can't do both jobs: a liveness probe that goes DOWN during a Postgres outage gets the pod restarted, which repairs nothing. /api/health keeps your path and your checks, and answers with everything. It matches /ready exactly for now, since liveness has no checks of its own to contribute.

On /version as the cheap check - we went that way first and backed out: it forks git name-rev on every request.

Also: MicroProfile Health 4.0 body (status + checks), HEALTHCHECK in the API Dockerfile, connect timeouts on Postgres and Redis (neither had one, so if a host stops responding without refusing the connection, requests wait on the OS TCP timeout and tie up API workers), and a 5s readiness cache. 9 tests, no regressions.

Happy to swap to the CNaaS data envelope if you'd rather these match the rest of the API.

Resolves: #573
