### PR TITLE
chore: move stack to Python 3.14

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: uv sync --group docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dev dependencies
         run: uv sync --group dev
@@ -36,7 +36,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install dev dependencies
         run: uv sync --group dev

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: uv sync --group dev
@@ -48,7 +48,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: uv sync --group dev

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     post_create_environment:
       # pip 25.1+ required for --group flag (PEP 735)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://readthedocs.org/projects/cnaas-nms/badge/?version=latest)](https://cnaas-nms.readthedocs.io/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/SUNET/cnaas-nms/branch/master/graph/badge.svg)](https://codecov.io/gh/SUNET/cnaas-nms) [![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/downloads/release/python-3130/)
+[![Documentation Status](https://readthedocs.org/projects/cnaas-nms/badge/?version=latest)](https://cnaas-nms.readthedocs.io/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/SUNET/cnaas-nms/branch/master/graph/badge.svg)](https://codecov.io/gh/SUNET/cnaas-nms) [![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/release/python-3140/)
 
 # CNaaS-NMS
 
@@ -31,7 +31,7 @@ uv sync --group docs      # documentation tools (sphinx)
 
 Docker and docker compose or:
 
-1. Python 3.13
+1. Python 3.14
 2. `uv sync` (and `uv sync --group dev` for development)
 3. SQL database, Redis
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Builder - install dependencies
-FROM python:3.13-slim-trixie AS builder
+FROM python:3.14-slim-trixie AS builder
 COPY --from=ghcr.io/astral-sh/uv:0.12.7 /uv /uvx /bin/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -41,7 +41,7 @@ COPY alembic/ /opt/cnaas/venv/cnaas-nms/alembic/
 COPY alembic.ini /opt/cnaas/venv/cnaas-nms/
 
 # Stage 2: Runtime - minimal production image
-FROM python:3.13-slim-trixie AS runtime
+FROM python:3.14-slim-trixie AS runtime
 
 ARG GIT_COMMIT
 ARG GIT_DATE

--- a/docker/dhcpd/Dockerfile
+++ b/docker/dhcpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-trixie
+FROM python:3.14-slim-trixie
 COPY --from=ghcr.io/astral-sh/uv:0.12.7 /uv /uvx /bin/
 
 # Create virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ license = { text = "BSD-2-Clause" }
 authors = [
   { name = "SUNET" },
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.14"
 classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 dynamic = [ "version" ]
 dependencies = [
@@ -29,9 +29,9 @@ dependencies = [
   "flask-jwt-extended==4.7.1",
   "flask-restx==1.3",
   "flask-socketio==5.6.1",
-  "gevent==25.4.2",
+  "gevent==25.8.2",
   "gitpython==3.1.59",
-  "greenlet==3.2.1",
+  "greenlet==3.5.5",
   "jmespath>=1.1.0",
   "markupsafe==3.0.2",
   "napalm==5.2",
@@ -43,8 +43,8 @@ dependencies = [
   "nornir-utils==0.2",
   "pluggy==1.5",
   "portalocker==3.1.1",
-  "psycopg2-binary==2.9.10",
-  "pydantic==2.11.3",
+  "psycopg2-binary==2.9.13",
+  "pydantic==2.12.5",
   "pydantic-settings==2.9.1",
   "python-jose==3.4",
   "pytz==2025.2",
@@ -52,7 +52,7 @@ dependencies = [
   "redis==5.2.1",
   "redis-lru==0.1",
   "requests==2.33.0",
-  "sqlalchemy==2.0.40",
+  "sqlalchemy==2.0.52",
   "sqlalchemy-utils==0.41.2",
   "werkzeug==3.1.6",
 ]
@@ -153,7 +153,7 @@ where = [ "src" ]
 exclude = [ "tests" ]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py314"
 line-length = 120
 exclude = [
   ".eggs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "ruff==0.14.14",
-  "coverage==7.8",
+  "coverage==7.10",
   "mypy==1.15",
   "mypy-extensions==1.1",
   "nose==1.3.7",
@@ -82,7 +82,7 @@ api-runtime = [
 integration-tools = [
   "pytest==9.0.3",
   "pytest-cov==6.1.1",
-  "coverage==7.8",
+  "coverage==7.10",
 ]
 
 [project.readme]

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,8 @@ filterwarnings =
     ignore::DeprecationWarning:^(?!cnaas_nms(\.|$)).*
     # Keep our own user warnings strict; ignore third-party user warnings (e.g. napalm/pkg_resources, nornir).
     ignore::UserWarning:^(?!cnaas_nms(\.|$)).*
+    # Keep our own syntax warnings strict; ignore third-party ones (pyeapi returns from a finally block).
+    ignore::SyntaxWarning:^(?!cnaas_nms(\.|$)).*
 
 env =
     JWT_SECRET_KEY="kMbSp+O4ZuF/AYOJtmGiMPOOWqvez5mVpml9A8f9Oso="

--- a/src/cnaas_nms/db/settings_fields/groups.py
+++ b/src/cnaas_nms/db/settings_fields/groups.py
@@ -36,7 +36,7 @@ class f_group_device_filter(BaseModel):
         """
         Is a cached property to avoid re-compiling regex patterns
         """
-        fields = set(self.__annotations__.keys())
+        fields = set(type(self).model_fields)
         compiled_patterns = {}
         for field in fields:
             pattern = getattr(self, field, None)

--- a/src/cnaas_nms/run.py
+++ b/src/cnaas_nms/run.py
@@ -24,6 +24,9 @@ print("Code coverage collection for worker in pid {}: {}".format(os.getpid(), is
 
 
 if is_coverage_enabled():
+    # The C tracer is the only coverage core that supports gevent concurrency;
+    # sys.monitoring is the default from Python 3.14 on and rejects it.
+    os.environ["COVERAGE_CORE"] = "ctrace"
     import coverage
 
     cov = coverage.coverage(data_file=".coverage-{}".format(os.getpid()), concurrency="gevent")

--- a/test/integrationtests.py
+++ b/test/integrationtests.py
@@ -68,12 +68,12 @@ class GetTests(unittest.TestCase):
         r = requests.put(
             f"{URL}/api/v1.0/repository/settings", headers=AUTH_HEADER, json={"action": "refresh"}, verify=TLS_VERIFY
         )
-        print("Settings refresh status: {}".format(r.status_code))
+        print("Settings refresh status: {}, body: {}".format(r.status_code, r.text))
         self.assertEqual(r.status_code, 200, "Failed to refresh settings")
         r = requests.put(
             f"{URL}/api/v1.0/repository/templates", headers=AUTH_HEADER, json={"action": "refresh"}, verify=TLS_VERIFY
         )
-        print("Template refresh status: {}".format(r.status_code))
+        print("Template refresh status: {}, body: {}".format(r.status_code, r.text))
         self.assertEqual(r.status_code, 200, "Failed to refresh templates")
 
     def test_01_init_dist(self):

--- a/test/integrationtests.sh
+++ b/test/integrationtests.sh
@@ -50,14 +50,18 @@ if docker volume ls | egrep -q "cnaas-postgres-data$"; then
 	fi
 fi
 
+# The traps also run after popd returns to the test dir, where docker compose
+# finds no configuration file, so log from the compose dir explicitly.
+COMPOSE_DIR="$PWD"
+
 on_exit() {
-	$COMPOSE_COMMAND logs cnaas_dhcpd
-	$COMPOSE_COMMAND logs cnaas_api
+	$COMPOSE_COMMAND --project-directory "$COMPOSE_DIR" logs cnaas_dhcpd
+	$COMPOSE_COMMAND --project-directory "$COMPOSE_DIR" logs cnaas_api
 	echo "Integrationtests exited (on_exit)"
 }
 
 on_err() {
-	$COMPOSE_COMMAND logs -n 100 cnaas_api
+	$COMPOSE_COMMAND --project-directory "$COMPOSE_DIR" logs -n 100 cnaas_api
 }
 
 trap on_exit EXIT


### PR DESCRIPTION
Bump the runtime, images, CI and docs builds from 3.13 to 3.14, with the dependency bumps needed for cp314 wheels.

pyeapi 1.0.4 returns from a finally block, which 3.14 reports as a SyntaxWarning; pytest turns warnings into errors, so ignore it for third-party code the same way DeprecationWarning and UserWarning are.